### PR TITLE
Fix: TypeScript root detection to support Python project markers

### DIFF
--- a/internal/extractors/tsextractor/ts.go
+++ b/internal/extractors/tsextractor/ts.go
@@ -42,14 +42,18 @@ func findTSRoot(repoPath string) (string, bool) {
 		return repoPath, true
 	}
 	maxDepth := 2
-	if isJavaStructured(repoPath) {
+	if isDeepNestedProject(repoPath) {
 		maxDepth = 8
 	}
 	return searchTSRoot(repoPath, 0, maxDepth)
 }
 
-func isJavaStructured(repoPath string) bool {
-	for _, marker := range []string{"pom.xml", "build.gradle", "build.gradle.kts"} {
+func isDeepNestedProject(repoPath string) bool {
+	markers := []string{
+		"pom.xml", "build.gradle", "build.gradle.kts",
+		"pyproject.toml", "setup.py", "setup.cfg", "requirements.txt",
+	}
+	for _, marker := range markers {
 		if _, err := os.Stat(filepath.Join(repoPath, marker)); err == nil {
 			return true
 		}


### PR DESCRIPTION
### Summary
Fix TypeScript extractor's detection of deep/nested projects by extending the heuristics to recognize Python project markers (pyproject.toml, setup.py, setup.cfg, requirements.txt). This ensures the TS root search uses a deeper recursion depth for repos that are multi-language or deeply nested Python projects.

### Changes
- **File:** `internal/extractors/tsextractor/ts.go`
  - Renamed `isJavaStructured()` → `isDeepNestedProject()`
  - Extended marker detection to include Python project files:
    - Java markers: `pom.xml`, `build.gradle`, `build.gradle.kts`
    - **New** Python markers: `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements.txt`
  - When `isDeepNestedProject()` returns true, `maxDepth` is increased from 2 to 8

### Why
Previously the extractor only treated Java projects as "deeply nested" and increased search depth accordingly. That missed Python monorepos or repositories with deeply nested TS/JS code under Python projects, causing the TS extractor to stop searching too early and fail to locate the TypeScript root.
Adding common Python markers makes the extractor more robust in multi-language repositories and monorepos.