### PR TITLE
feat: Add Vue and Nuxt framework detection and extraction support

### DIFF
--- a/internal/extractors/tsextractor/ts.go
+++ b/internal/extractors/tsextractor/ts.go
@@ -117,8 +117,10 @@ func hasTSMarkers(dir string) bool {
 func (e *TSExtractor) Extract(ctx context.Context, repoPath string, files []string) ([]facts.Fact, error) {
 	var allFacts []facts.Fact
 
-	// Detect if this is a Next.js project
+	// Detect frameworks
 	isNextJS := detectNextJS(repoPath)
+	isVue := detectVue(repoPath)
+	isNuxt := detectNuxt(repoPath)
 
 	// Parse tsconfig.json for path alias mappings (e.g., "@/*" → "src/*")
 	aliases := parseTSPathAliases(repoPath)
@@ -144,7 +146,7 @@ func (e *TSExtractor) Extract(ctx context.Context, repoPath string, files []stri
 			continue
 		}
 
-		fileFacts := e.extractFile(src, relFile, isNextJS, aliases)
+		fileFacts := e.extractFile(src, relFile, isNextJS, isVue, isNuxt, aliases)
 		allFacts = append(allFacts, fileFacts...)
 
 		dir := filepath.Dir(relFile)
@@ -174,10 +176,16 @@ type extractCtx struct {
 	dir       string
 	isTSX     bool
 	isNextJS  bool
+	isVue     bool
+	isNuxt    bool
 	importMap map[string]string
 }
 
-func (e *TSExtractor) extractFile(src []byte, relFile string, isNextJS bool, aliases map[string]string) []facts.Fact {
+func (e *TSExtractor) extractFile(src []byte, relFile string, isNextJS, isVue, isNuxt bool, aliases map[string]string) []facts.Fact {
+	if isVueFile(relFile) {
+		return e.extractVueSFC(src, relFile, isNuxt, aliases)
+	}
+
 	var result []facts.Fact
 
 	// Parse openapi-typescript generated files for backend API route dependencies.
@@ -213,6 +221,8 @@ func (e *TSExtractor) extractFile(src []byte, relFile string, isNextJS bool, ali
 		dir:       filepath.Dir(relFile),
 		isTSX:     isTSX,
 		isNextJS:  isNextJS,
+		isVue:     isVue,
+		isNuxt:    isNuxt,
 		importMap: buildImportSymbols(root, src, relFile, aliases),
 	}
 	decls := e.extractDeclarations(root, ctx)
@@ -238,6 +248,21 @@ func (e *TSExtractor) extractFile(src []byte, relFile string, isNextJS bool, ali
 		if routeFact := detectRoute(relFile); routeFact != nil {
 			result = append(result, *routeFact)
 		}
+	}
+
+	// Detect Vue Router configuration files
+	if (isVue || isNuxt) && containsCreateRouterCall(root, src) {
+		result = append(result, facts.Fact{
+			Kind: facts.KindRoute,
+			Name: relFile,
+			File: relFile,
+			Line: 1,
+			Props: map[string]any{
+				"type":      "router_config",
+				"language":  "typescript",
+				"framework": "vue",
+			},
+		})
 	}
 
 	return result
@@ -695,7 +720,7 @@ func detectNextJSAt(dir string) bool {
 
 func isTypeScriptFile(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
-	return ext == ".ts" || ext == ".tsx"
+	return ext == ".ts" || ext == ".tsx" || ext == ".vue"
 }
 
 // hasChildKind reports whether node has a direct child of the given kind.
@@ -807,10 +832,19 @@ func classifySymbol(f *facts.Fact, name string, body *sitter.Node, ctx *extractC
 		f.Props["framework"] = "nextjs"
 		return
 	}
-	// React hook: a useXxx function.
+	// Composable (Vue/Nuxt) or hook (React): a useXxx function.
 	if symbolKind == facts.SymbolFunc && isHookName(name) {
-		f.Props["web_component"] = "hook"
-		f.Props["framework"] = "react"
+		if ctx.isVue || ctx.isNuxt {
+			f.Props["web_component"] = "composable"
+			if ctx.isNuxt {
+				f.Props["framework"] = "nuxt"
+			} else {
+				f.Props["framework"] = "vue"
+			}
+		} else {
+			f.Props["web_component"] = "hook"
+			f.Props["framework"] = "react"
+		}
 		return
 	}
 	// React component: a PascalCase function/class that renders JSX. In .tsx/.jsx

--- a/internal/extractors/tsextractor/vue.go
+++ b/internal/extractors/tsextractor/vue.go
@@ -1,0 +1,320 @@
+package tsextractor
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/enola-labs/enola/internal/facts"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+)
+
+// vueScriptBlock holds the extracted <script> content from a Vue SFC.
+type vueScriptBlock struct {
+	Content   []byte
+	IsSetup   bool
+	Lang      string // "ts", "tsx", "js", or ""
+	StartLine int    // 0-based line number where the script content begins
+}
+
+// extractVueScriptBlocks extracts all <script> blocks from a Vue SFC file.
+// A Vue SFC may contain both a <script> and a <script setup> block.
+func extractVueScriptBlocks(src []byte) []*vueScriptBlock {
+	var blocks []*vueScriptBlock
+	pos := 0
+	for {
+		remaining := src[pos:]
+		idx := indexCaseInsensitive(remaining, []byte("<script"))
+		if idx < 0 {
+			break
+		}
+		tagStart := pos + idx
+
+		tagEnd := bytes.IndexByte(src[tagStart:], '>')
+		if tagEnd < 0 {
+			break
+		}
+		tagEnd += tagStart
+
+		attrs := string(src[tagStart : tagEnd+1])
+
+		closeIdx := indexCaseInsensitive(src[tagEnd+1:], []byte("</script>"))
+		if closeIdx < 0 {
+			break
+		}
+		closeIdx += tagEnd + 1
+
+		content := src[tagEnd+1 : closeIdx]
+		isSetup := strings.Contains(strings.ToLower(attrs), "setup")
+		lang := extractAttr(attrs, "lang")
+		startLine := bytes.Count(src[:tagEnd+1], []byte("\n"))
+
+		blocks = append(blocks, &vueScriptBlock{
+			Content:   content,
+			IsSetup:   isSetup,
+			Lang:      lang,
+			StartLine: startLine,
+		})
+
+		pos = closeIdx + len("</script>")
+	}
+	return blocks
+}
+
+func extractAttr(tag, name string) string {
+	for _, q := range []byte{'"', '\''} {
+		needle := name + "=" + string(q)
+		idx := strings.Index(strings.ToLower(tag), strings.ToLower(needle))
+		if idx < 0 {
+			continue
+		}
+		start := idx + len(needle)
+		end := strings.IndexByte(tag[start:], q)
+		if end < 0 {
+			continue
+		}
+		return tag[start : start+end]
+	}
+	return ""
+}
+
+func indexCaseInsensitive(src, needle []byte) int {
+	return bytes.Index(bytes.ToLower(src), bytes.ToLower(needle))
+}
+
+func detectVue(repoPath string) bool {
+	tsRoot, _ := findTSRoot(repoPath)
+	return detectVueAt(tsRoot) || (tsRoot != repoPath && detectVueAt(repoPath))
+}
+
+func detectVueAt(dir string) bool {
+	return hasPkgDependency(dir, "vue")
+}
+
+func detectNuxt(repoPath string) bool {
+	tsRoot, _ := findTSRoot(repoPath)
+	return detectNuxtAt(tsRoot) || (tsRoot != repoPath && detectNuxtAt(repoPath))
+}
+
+func detectNuxtAt(dir string) bool {
+	for _, name := range []string{"nuxt.config.js", "nuxt.config.ts", "nuxt.config.mjs"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return hasPkgDependency(dir, "nuxt")
+}
+
+func hasPkgDependency(dir, pkg string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var p map[string]any
+	if err := json.Unmarshal(data, &p); err != nil {
+		return false
+	}
+	for _, key := range []string{"dependencies", "devDependencies"} {
+		if deps, ok := p[key].(map[string]any); ok {
+			if _, ok := deps[pkg]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// detectNuxtRoute checks if a .vue file path corresponds to a Nuxt route.
+func detectNuxtRoute(relFile string) *facts.Fact {
+	if !strings.HasSuffix(relFile, ".vue") {
+		return nil
+	}
+
+	parts := strings.Split(filepath.ToSlash(relFile), "/")
+
+	for i, p := range parts {
+		if p == "pages" && i < len(parts)-1 {
+			remaining := parts[i+1:]
+			fileName := remaining[len(remaining)-1]
+			baseName := strings.TrimSuffix(fileName, ".vue")
+
+			routeParts := make([]string, 0, len(remaining))
+			for j, rp := range remaining {
+				if j == len(remaining)-1 {
+					if baseName != "index" {
+						routeParts = append(routeParts, baseName)
+					}
+				} else {
+					routeParts = append(routeParts, rp)
+				}
+			}
+
+			routePath := "/" + strings.Join(routeParts, "/")
+
+			return &facts.Fact{
+				Kind: facts.KindRoute,
+				Name: routePath,
+				File: relFile,
+				Line: 1,
+				Props: map[string]any{
+					"method":    "GET",
+					"type":      "page",
+					"router":    "pages",
+					"language":  "typescript",
+					"framework": "nuxt",
+				},
+			}
+		}
+	}
+
+	return nil
+}
+
+func isVueFile(path string) bool {
+	return strings.ToLower(filepath.Ext(path)) == ".vue"
+}
+
+// containsCreateRouterCall reports whether the AST subtree contains a createRouter() call.
+func containsCreateRouterCall(node *sitter.Node, src []byte) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind() == "call_expression" {
+		fn := node.ChildByFieldName("function")
+		if fn != nil && fn.Kind() == "identifier" && nodeText(fn, src) == "createRouter" {
+			return true
+		}
+	}
+	for i := range node.ChildCount() {
+		if containsCreateRouterCall(node.Child(i), src) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractVueSFC extracts architectural facts from a Vue Single File Component.
+func (e *TSExtractor) extractVueSFC(rawSrc []byte, relFile string, isNuxt bool, aliases map[string]string) []facts.Fact {
+	var result []facts.Fact
+	blocks := extractVueScriptBlocks(rawSrc)
+
+	isSetup := false
+	for _, block := range blocks {
+		if block.IsSetup {
+			isSetup = true
+		}
+		result = append(result, e.extractVueScriptBlock(block, relFile, isNuxt, aliases)...)
+	}
+
+	dir := filepath.Dir(relFile)
+	componentName := fileSymbolName(relFile)
+	factName := dir + "." + componentName
+	fw := "vue"
+	if isNuxt {
+		fw = "nuxt"
+	}
+
+	// If the script block already emitted a symbol with the component name
+	// (e.g. from `export default defineComponent(...)`), enrich it with Vue
+	// classification instead of creating a duplicate.
+	found := false
+	for i := range result {
+		if result[i].Kind == facts.KindSymbol && result[i].Name == factName {
+			result[i].Props["web_component"] = "component"
+			result[i].Props["framework"] = fw
+			if isSetup {
+				result[i].Props["vue_setup"] = true
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		compFact := facts.Fact{
+			Kind: facts.KindSymbol,
+			Name: factName,
+			File: relFile,
+			Line: 1,
+			Props: map[string]any{
+				"symbol_kind":   facts.SymbolFunc,
+				"exported":      true,
+				"language":      "typescript",
+				"web_component": "component",
+				"framework":     fw,
+			},
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: dir}},
+		}
+		if isSetup {
+			compFact.Props["vue_setup"] = true
+		}
+		result = append(result, compFact)
+	}
+
+	if isNuxt {
+		if routeFact := detectNuxtRoute(relFile); routeFact != nil {
+			result = append(result, *routeFact)
+		}
+	}
+
+	return result
+}
+
+// extractVueScriptBlock parses a single <script> block from a Vue SFC and
+// returns the extracted facts with line numbers adjusted to the original file.
+func (e *TSExtractor) extractVueScriptBlock(block *vueScriptBlock, relFile string, isNuxt bool, aliases map[string]string) []facts.Fact {
+	isTSX := block.Lang == "tsx"
+	lang := typescript.LanguageTypescript()
+	if isTSX {
+		lang = typescript.LanguageTSX()
+	}
+
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(sitter.NewLanguage(lang))
+
+	tree := parser.Parse(block.Content, nil)
+	defer tree.Close()
+
+	root := tree.RootNode()
+
+	var result []facts.Fact
+	result = append(result, e.extractImports(root, block.Content, relFile, aliases)...)
+
+	ctx := &extractCtx{
+		src:       block.Content,
+		relFile:   relFile,
+		dir:       filepath.Dir(relFile),
+		isTSX:     isTSX,
+		isVue:     true,
+		isNuxt:    isNuxt,
+		importMap: buildImportSymbols(root, block.Content, relFile, aliases),
+	}
+	decls := e.extractDeclarations(root, ctx)
+
+	if exported := collectExportedLocalNames(root, block.Content); len(exported) > 0 {
+		for i := range decls {
+			if decls[i].Kind != facts.KindSymbol {
+				continue
+			}
+			local := decls[i].Name[strings.LastIndexByte(decls[i].Name, '.')+1:]
+			if exported[local] {
+				decls[i].Props["exported"] = true
+			}
+		}
+	}
+	result = append(result, decls...)
+
+	if block.StartLine > 0 {
+		for i := range result {
+			if result[i].Line > 0 {
+				result[i].Line += block.StartLine
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/extractors/tsextractor/vue_test.go
+++ b/internal/extractors/tsextractor/vue_test.go
@@ -1,0 +1,472 @@
+package tsextractor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func setupVueProject(t *testing.T, files map[string]string, nuxt bool) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgJSON := `{"dependencies": {"vue": "^3.0.0"}}`
+	if nuxt {
+		pkgJSON = `{"dependencies": {"vue": "^3.0.0", "nuxt": "^3.0.0"}}`
+		if err := os.WriteFile(filepath.Join(dir, "nuxt.config.ts"), []byte(`export default defineNuxtConfig({})`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for relPath, content := range files {
+		absPath := filepath.Join(dir, relPath)
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return dir
+}
+
+func extractVue(t *testing.T, files map[string]string, nuxt bool) []facts.Fact {
+	t.Helper()
+	dir := setupVueProject(t, files, nuxt)
+
+	var relFiles []string
+	for f := range files {
+		relFiles = append(relFiles, f)
+	}
+
+	ext := New()
+	result, err := ext.Extract(context.Background(), dir, relFiles)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return result
+}
+
+// --- SFC script block extraction ---
+
+func TestExtractVueScriptBlocks_Setup(t *testing.T) {
+	src := []byte(`<template>
+  <div>{{ msg }}</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+const msg = ref('hello')
+</script>
+`)
+	blocks := extractVueScriptBlocks(src)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if !blocks[0].IsSetup {
+		t.Error("expected IsSetup = true")
+	}
+	if blocks[0].Lang != "ts" {
+		t.Errorf("lang = %q, want ts", blocks[0].Lang)
+	}
+	if blocks[0].StartLine != 4 {
+		t.Errorf("StartLine = %d, want 4", blocks[0].StartLine)
+	}
+}
+
+func TestExtractVueScriptBlocks_NoSetup(t *testing.T) {
+	src := []byte(`<script lang="ts">
+import { defineComponent } from 'vue'
+export default defineComponent({ name: 'MyComp' })
+</script>
+`)
+	blocks := extractVueScriptBlocks(src)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].IsSetup {
+		t.Error("expected IsSetup = false")
+	}
+	if blocks[0].Lang != "ts" {
+		t.Errorf("lang = %q, want ts", blocks[0].Lang)
+	}
+}
+
+func TestExtractVueScriptBlocks_Multiple(t *testing.T) {
+	src := []byte(`<script lang="ts">
+export interface Props { title: string }
+</script>
+
+<script setup lang="ts">
+const props = defineProps<Props>()
+</script>
+`)
+	blocks := extractVueScriptBlocks(src)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	if blocks[0].IsSetup {
+		t.Error("first block should not be setup")
+	}
+	if !blocks[1].IsSetup {
+		t.Error("second block should be setup")
+	}
+}
+
+func TestExtractVueScriptBlocks_NoScript(t *testing.T) {
+	src := []byte(`<template><div>Hello</div></template>`)
+	blocks := extractVueScriptBlocks(src)
+	if len(blocks) != 0 {
+		t.Fatalf("expected 0 blocks, got %d", len(blocks))
+	}
+}
+
+// --- Framework detection ---
+
+func TestDetectVue(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"),
+		[]byte(`{"dependencies":{"vue":"^3.0.0"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !detectVue(dir) {
+		t.Error("expected detectVue = true")
+	}
+}
+
+func TestDetectNuxt_Config(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "nuxt.config.ts"), []byte(`export default {}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !detectNuxt(dir) {
+		t.Error("expected detectNuxt = true")
+	}
+}
+
+func TestDetectNuxt_PkgDep(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"),
+		[]byte(`{"devDependencies":{"nuxt":"^3.0.0"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !detectNuxt(dir) {
+		t.Error("expected detectNuxt = true")
+	}
+}
+
+// --- Nuxt route detection ---
+
+func TestDetectNuxtRoute(t *testing.T) {
+	tests := []struct {
+		name      string
+		file      string
+		wantRoute string
+	}{
+		{"index page", "pages/index.vue", "/"},
+		{"about page", "pages/about.vue", "/about"},
+		{"nested page", "pages/users/index.vue", "/users"},
+		{"dynamic param", "pages/users/[id].vue", "/users/[id]"},
+		{"deep nested", "pages/blog/posts/[slug].vue", "/blog/posts/[slug]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectNuxtRoute(tt.file)
+			if got == nil {
+				t.Fatal("expected route fact, got nil")
+			}
+			if got.Name != tt.wantRoute {
+				t.Errorf("route = %q, want %q", got.Name, tt.wantRoute)
+			}
+			if got.Props["framework"] != "nuxt" {
+				t.Errorf("framework = %v, want nuxt", got.Props["framework"])
+			}
+			if got.Props["router"] != "pages" {
+				t.Errorf("router = %v, want pages", got.Props["router"])
+			}
+		})
+	}
+}
+
+func TestDetectNuxtRoute_NonPage(t *testing.T) {
+	if got := detectNuxtRoute("src/components/Button.vue"); got != nil {
+		t.Error("non-page .vue file should return nil")
+	}
+	if got := detectNuxtRoute("pages/about.ts"); got != nil {
+		t.Error(".ts file should return nil")
+	}
+}
+
+// --- Full extraction: Vue SFC ---
+
+func TestExtract_VueSFC_ScriptSetup(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/components/Counter.vue": `<template>
+  <button @click="increment">{{ count }}</button>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+
+function increment() {
+  count.value++
+}
+</script>
+`,
+	}, false)
+
+	// Component fact
+	comp, ok := findFact(ff, "src/components.Counter")
+	if !ok {
+		t.Fatalf("expected component fact src/components.Counter; got %v", factNames(ff))
+	}
+	if comp.Props["web_component"] != "component" {
+		t.Errorf("web_component = %v, want component", comp.Props["web_component"])
+	}
+	if comp.Props["framework"] != "vue" {
+		t.Errorf("framework = %v, want vue", comp.Props["framework"])
+	}
+	if comp.Props["vue_setup"] != true {
+		t.Errorf("vue_setup = %v, want true", comp.Props["vue_setup"])
+	}
+
+	// Declarations from script block
+	inc, ok := findFact(ff, "src/components.increment")
+	if !ok {
+		t.Fatalf("expected fact src/components.increment; got %v", factNames(ff))
+	}
+	if inc.Props["symbol_kind"] != facts.SymbolFunc {
+		t.Errorf("increment symbol_kind = %v, want function", inc.Props["symbol_kind"])
+	}
+
+	// Import dependency
+	deps := findFactsByKind(ff, facts.KindDependency)
+	hasVueImport := false
+	for _, d := range deps {
+		for _, r := range d.Relations {
+			if r.Target == "vue" {
+				hasVueImport = true
+			}
+		}
+	}
+	if !hasVueImport {
+		t.Error("expected import dependency on 'vue'")
+	}
+}
+
+func TestExtract_VueSFC_DefineComponent(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/components/Modal.vue": `<template>
+  <div class="modal"><slot/></div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'Modal',
+  props: { visible: Boolean },
+})
+</script>
+`,
+	}, false)
+
+	comp, ok := findFact(ff, "src/components.Modal")
+	if !ok {
+		t.Fatalf("expected component fact src/components.Modal; got %v", factNames(ff))
+	}
+	if comp.Props["web_component"] != "component" {
+		t.Errorf("web_component = %v, want component", comp.Props["web_component"])
+	}
+	if comp.Props["framework"] != "vue" {
+		t.Errorf("framework = %v, want vue", comp.Props["framework"])
+	}
+	if comp.Props["vue_setup"] == true {
+		t.Error("vue_setup should not be true for non-setup script")
+	}
+}
+
+func TestExtract_VueSFC_TemplateOnly(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/components/Divider.vue": `<template><hr/></template>`,
+	}, false)
+
+	comp, ok := findFact(ff, "src/components.Divider")
+	if !ok {
+		t.Fatalf("expected component fact src/components.Divider; got %v", factNames(ff))
+	}
+	if comp.Props["web_component"] != "component" {
+		t.Errorf("web_component = %v, want component", comp.Props["web_component"])
+	}
+}
+
+func TestExtract_VueSFC_LineOffset(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/components/App.vue": `<template>
+  <div>hello</div>
+</template>
+
+<script setup lang="ts">
+function greet() { return 'hi' }
+</script>
+`,
+	}, false)
+
+	f, ok := findFact(ff, "src/components.greet")
+	if !ok {
+		t.Fatalf("expected fact src/components.greet; got %v", factNames(ff))
+	}
+	// greet is on line 6 of the .vue file (1-based), script block starts at line 5
+	if f.Line < 5 {
+		t.Errorf("line = %d, expected >= 5 (script block offset should be applied)", f.Line)
+	}
+}
+
+// --- Composable classification ---
+
+func TestExtract_VueComposable(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/composables/useAuth.ts": `export function useAuth() { return null }
+export const useUser = () => null`,
+	}, false)
+
+	for _, name := range []string{"src/composables.useAuth", "src/composables.useUser"} {
+		f, ok := findFact(ff, name)
+		if !ok {
+			t.Fatalf("expected fact %s", name)
+		}
+		if f.Props["web_component"] != "composable" {
+			t.Errorf("%s web_component = %v, want composable", name, f.Props["web_component"])
+		}
+		if f.Props["framework"] != "vue" {
+			t.Errorf("%s framework = %v, want vue", name, f.Props["framework"])
+		}
+	}
+}
+
+func TestExtract_NuxtComposable(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/composables/useFetch.ts": `export function useFetch() { return null }`,
+	}, true)
+
+	f, ok := findFact(ff, "src/composables.useFetch")
+	if !ok {
+		t.Fatalf("expected fact src/composables.useFetch; got %v", factNames(ff))
+	}
+	if f.Props["web_component"] != "composable" {
+		t.Errorf("web_component = %v, want composable", f.Props["web_component"])
+	}
+	if f.Props["framework"] != "nuxt" {
+		t.Errorf("framework = %v, want nuxt", f.Props["framework"])
+	}
+}
+
+// --- Nuxt page extraction ---
+
+func TestExtract_NuxtPage(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"pages/about.vue": `<template><h1>About</h1></template>
+
+<script setup lang="ts">
+const title = 'About'
+</script>
+`,
+	}, true)
+
+	// Component fact
+	comp, ok := findFact(ff, "pages.About")
+	if !ok {
+		t.Fatalf("expected component fact pages.About; got %v", factNames(ff))
+	}
+	if comp.Props["framework"] != "nuxt" {
+		t.Errorf("framework = %v, want nuxt", comp.Props["framework"])
+	}
+
+	// Route fact
+	routes := findFactsByKind(ff, facts.KindRoute)
+	var found bool
+	for _, r := range routes {
+		if r.Name == "/about" && r.Props["framework"] == "nuxt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected nuxt route /about; routes: %v", routes)
+	}
+}
+
+// --- Vue Router config detection ---
+
+func TestExtract_VueRouterConfig(t *testing.T) {
+	ff := extractVue(t, map[string]string{
+		"src/router/index.ts": `import { createRouter, createWebHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [],
+})
+
+export default router`,
+	}, false)
+
+	routes := findFactsByKind(ff, facts.KindRoute)
+	var found bool
+	for _, r := range routes {
+		if r.Props["type"] == "router_config" && r.Props["framework"] == "vue" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected vue router_config route fact; routes: %v", routes)
+	}
+}
+
+// --- isVueFile ---
+
+func TestIsVueFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"src/App.vue", true},
+		{"src/app.VUE", true},
+		{"src/app.ts", false},
+		{"src/app.tsx", false},
+	}
+	for _, tt := range tests {
+		if got := isVueFile(tt.path); got != tt.want {
+			t.Errorf("isVueFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+// --- isTypeScriptFile includes .vue ---
+
+func TestIsTypeScriptFile_Vue(t *testing.T) {
+	if !isTypeScriptFile("src/App.vue") {
+		t.Error("isTypeScriptFile should return true for .vue files")
+	}
+}


### PR DESCRIPTION
# Add Vue and Nuxt Framework Support to TypeScript Extractor

## Overview
This PR extends the TypeScript extractor to recognize and extract architectural facts from **Vue** and **Nuxt** projects, enabling comprehensive analysis of Vue Single File Components (SFCs), composables, and automatic route detection.

## Changes

### New Files

#### `internal/extractors/tsextractor/vue.go`
Comprehensive Vue/Nuxt support module including:
- **SFC Script Block Extraction**: Parses `<script>` and `<script setup>` blocks from `.vue` files with proper line number mapping
- **Framework Detection**: 
  - `detectVue()` - Detects Vue via `package.json` dependencies
  - `detectNuxt()` - Detects Nuxt via config files or `package.json`
- **Route Detection**: `detectNuxtRoute()` automatically maps Nuxt `pages/` directory structure to routes (e.g., `pages/users/[id].vue` → `/users/[id]`)
- **Vue Router Configuration**: `containsCreateRouterCall()` identifies router setup files
- **Utility Functions**: Case-insensitive HTML parsing for robust SFC handling

#### `internal/extractors/tsextractor/vue_test.go`
Comprehensive test suite (472 lines) covering:
- Script block extraction (single, multiple, setup vs non-setup)
- Framework detection (Vue and Nuxt)
- Nuxt route detection with various patterns (index, nested, dynamic parameters)
- Vue SFC component extraction with metadata
- Composable classification (Vue/Nuxt-specific)
- Vue Router configuration detection
- Line offset calculation for source mapping
- Edge cases (template-only components, non-page files)

### Modified Files

#### `internal/extractors/tsextractor/ts.go`
**Framework Context Tracking**:
- Added `isVue` and `isNuxt` boolean flags to `Extract()` method
- Updated `extractCtx` struct to carry framework state

****