### PR TITLE
feat: extend TypeScript file detection to include .js and .jsx

### DIFF
--- a/internal/extractors/tsextractor/ts.go
+++ b/internal/extractors/tsextractor/ts.go
@@ -737,7 +737,7 @@ func detectNextJSAt(dir string) bool {
 
 func isTypeScriptFile(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
-	return ext == ".ts" || ext == ".tsx" || ext == ".vue"
+	return ext == ".ts" || ext == ".tsx" || ext == ".vue" || ext == ".js" || ext == ".jsx"
 }
 
 // OwnsFile implements plugin.FileOwner for incremental caching.

--- a/internal/extractors/tsextractor/ts_test.go
+++ b/internal/extractors/tsextractor/ts_test.go
@@ -651,7 +651,9 @@ func TestIsTypeScriptFile(t *testing.T) {
 	}{
 		{"src/app.ts", true},
 		{"src/app.tsx", true},
-		{"src/app.js", false},
+		{"src/app.js", true},
+		{"src/app.jsx", true},
+		{"src/app.vue", true},
 		{"src/app.go", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Add JavaScript and JSX file support to TypeScript extractor

### Summary
This PR extends the TypeScript extractor to recognize and process JavaScript (`.js`) and JSX (`.jsx`) files, complementing existing support for TypeScript (`.ts`), TSX (`.tsx`), and Vue (`.vue`) files.

### Changes
- **`internal/extractors/tsextractor/ts.go`**: Updated `isTypeScriptFile()` to return `true` for `.js` and `.jsx` files in addition to existing TypeScript variants
- **`internal/extractors/tsextractor/ts_test.go`**: Added test cases for `.js` and `.jsx` files, and added missing test case for `.vue` files to ensure comprehensive coverage

### Motivation
JavaScript and JSX are increasingly common in modern web projects that also use TypeScript. This change allows the extractor to maintain accurate architectural snapshots for mixed JavaScript/TypeScript codebases.

### Testing
Updated test suite includes:
- `.js` file (now returns `true`)
- `.jsx` file (now returns `true`)  
- `.vue` file (explicit test case, returns `true`)
- Existing negative tests (`.go` returns `false`)