### PR TITLE
Expand cross-repo HTTP-client detection (TS options-object/openapi-fe…

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -129,7 +129,13 @@ import (
 // v68: the TypeScript extractor now sets abstract:true on `abstract class`
 // declarations (was previously indistinguishable from a concrete class), so
 // package-metrics abstractness for TS must re-extract to pick up the flag.
-const cacheVersion = "v68"
+// v69: HTTP-client detection expanded — TS options-object/openapi-fetch clients,
+// Swift endpoint-enum (APIEndpoint/TargetType) clients, Rails draw(:pkg) routes now
+// carry their /api/vN scope prefix, and Swift URLSession skips test/fixture sources.
+// v70: Swift endpoint extractor resolves the version prefix — repo-wide default
+// (protocol-extension urlPrefixComponent), single-value/switch-default overrides,
+// and version-constant interpolation — so prefix-less endpoints match backend routes.
+const cacheVersion = "v70"
 
 // extractorCache holds per-extractor facts keyed by a content hash of the files
 // the extractor depends on. It is loaded from disk at the start of a snapshot and

--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -135,7 +135,14 @@ import (
 // v70: Swift endpoint extractor resolves the version prefix — repo-wide default
 // (protocol-extension urlPrefixComponent), single-value/switch-default overrides,
 // and version-constant interpolation — so prefix-less endpoints match backend routes.
-const cacheVersion = "v70"
+// v71: Swift endpoint extractor resolves stored-method endpoint structs (path/prefix
+// computed, `method` a stored property) by reading the HTTP verb from each
+// instantiation site's `method:` argument, emitting one client route per (path, verb).
+// v72: Swift extractor also resolves request-wrapper endpoints (path supplied at the
+// call site's `urlPathComponent:` arg, verb from `method:`/`httpMethod:` or a type
+// default); Ruby extractor fixes nested Rails resource paths — a singular `resource`
+// gets no `:id`, and children of a plural `resources` nest under `:<singular>_id`.
+const cacheVersion = "v72"
 
 // extractorCache holds per-extractor facts keyed by a content hash of the files
 // the extractor depends on. It is loaded from disk at the start of a snapshot and

--- a/internal/extractors/rubyextractor/routes.go
+++ b/internal/extractors/rubyextractor/routes.go
@@ -92,6 +92,10 @@ func isRouteFile(relFile string) bool {
 type routeScope struct {
 	pathPrefix string
 	module     string
+	// memberParam is the parent member path parameter (`:<singular>_id`) that nested
+	// resources declared inside a *plural* `resources` block must nest under; empty for
+	// namespace/scope/singular-resource scopes, which add no member id to their children.
+	memberParam string
 }
 
 // buildPrefix constructs the current URL prefix from the scope stack.
@@ -123,6 +127,28 @@ func restfulActions(only, except map[string]bool) []restAction {
 		{name: "update", method: "PATCH", suffix: "/:id"},
 		{name: "edit", method: "GET", suffix: "/:id/edit"},
 		{name: "destroy", method: "DELETE", suffix: "/:id"},
+	}
+
+	if len(only) > 0 {
+		return filterActions(all, only, true)
+	}
+	if len(except) > 0 {
+		return filterActions(all, except, false)
+	}
+	return all
+}
+
+// restfulActionsSingular returns the REST actions for a singular `resource`
+// declaration. A singular resource has no index and no `:id` member segment — every
+// action acts on the single resource at its base path.
+func restfulActionsSingular(only, except map[string]bool) []restAction {
+	all := []restAction{
+		{name: "create", method: "POST", suffix: ""},
+		{name: "new", method: "GET", suffix: "/new"},
+		{name: "show", method: "GET", suffix: ""},
+		{name: "update", method: "PATCH", suffix: ""},
+		{name: "edit", method: "GET", suffix: "/edit"},
+		{name: "destroy", method: "DELETE", suffix: ""},
 	}
 
 	if len(only) > 0 {

--- a/internal/extractors/rubyextractor/routes.go
+++ b/internal/extractors/rubyextractor/routes.go
@@ -10,28 +10,59 @@ import (
 )
 
 // extractAllRoutes finds and parses all Rails route files in the repository.
+//
+// Rails commonly splits routes across config/routes/<pkg>.rb files pulled in by
+// draw(:pkg) from config/routes.rb, often inside a scope('/api')/namespace(:vN)
+// block. Parsed standalone, a delegated file loses that prefix, so its routes read
+// as "/devices" instead of "/api/v2/devices" and no longer match a client call. To
+// avoid that, the top-level config/routes.rb is parsed first to learn each
+// delegation's prefix, then each delegated file is parsed seeded with it.
 func extractAllRoutes(repoPath string, files []string) []facts.Fact {
-	var allFacts []facts.Fact
-
 	// Collect route files: config/routes.rb, config/routes/*.rb, packages/*/config/routes/*.rb
 	var routeFiles []string
 	for _, relFile := range files {
-		if !isRubyFile(relFile) {
-			continue
-		}
-		if isRouteFile(relFile) {
+		if isRubyFile(relFile) && isRouteFile(relFile) {
 			routeFiles = append(routeFiles, relFile)
 		}
 	}
 
-	for _, relFile := range routeFiles {
-		absFile := filepath.Join(repoPath, relFile)
-		src, err := os.ReadFile(absFile)
+	readSrc := func(relFile string) ([]byte, bool) {
+		src, err := os.ReadFile(filepath.Join(repoPath, relFile))
 		if err != nil {
 			log.Printf("[ruby-extractor] error reading route file %s: %v", relFile, err)
+			return nil, false
+		}
+		return src, true
+	}
+
+	mainFile := filepath.Join("config", "routes.rb")
+
+	// Pass 1: parse the top-level routes.rb, learning draw(:pkg) -> prefix. Each
+	// draw(:pkg) loads config/routes/<pkg>.rb (Rails convention).
+	var allFacts []facts.Fact
+	drawPrefix := map[string]string{}
+	for _, relFile := range routeFiles {
+		if relFile != mainFile {
 			continue
 		}
-		allFacts = append(allFacts, parseRouteFileAST(src, relFile)...)
+		if src, ok := readSrc(relFile); ok {
+			ff, draws := parseRouteFile(src, relFile, "")
+			allFacts = append(allFacts, ff...)
+			for pkg, prefix := range draws {
+				drawPrefix[filepath.Join("config", "routes", pkg+".rb")] = prefix
+			}
+		}
+	}
+
+	// Pass 2: parse the remaining route files, seeding any prefix learned in pass 1.
+	for _, relFile := range routeFiles {
+		if relFile == mainFile {
+			continue
+		}
+		if src, ok := readSrc(relFile); ok {
+			ff, _ := parseRouteFile(src, relFile, drawPrefix[relFile])
+			allFacts = append(allFacts, ff...)
+		}
 	}
 
 	return allFacts

--- a/internal/extractors/rubyextractor/routes_ast.go
+++ b/internal/extractors/rubyextractor/routes_ast.go
@@ -13,17 +13,30 @@ import (
 // facts. Block boundaries come from the grammar (do_block) rather than counting
 // `do`/`end`, so nested namespaces/resources/scopes are tracked precisely.
 func parseRouteFileAST(src []byte, relFile string) []facts.Fact {
+	ff, _ := parseRouteFile(src, relFile, "")
+	return ff
+}
+
+// parseRouteFile parses a Rails route file, seeding the scope stack with
+// initialPrefix (the URL prefix a parent routes.rb delegated this file under via
+// draw(:pkg)), and additionally returns the draw(:pkg) -> prefix map discovered in
+// this file, so the caller can inline each delegated file under its real scope.
+func parseRouteFile(src []byte, relFile, initialPrefix string) ([]facts.Fact, map[string]string) {
 	parser := sitter.NewParser()
 	defer parser.Close()
 	if err := parser.SetLanguage(sitter.NewLanguage(ruby.Language())); err != nil {
-		return nil
+		return nil, nil
 	}
 	tree := parser.Parse(src, nil)
 	defer tree.Close()
 
-	rw := &routeWalker{src: src, relFile: relFile, dir: filepath.Dir(relFile)}
-	rw.walk(tree.RootNode(), nil)
-	return rw.out
+	var stack []routeScope
+	if initialPrefix != "" {
+		stack = []routeScope{{pathPrefix: initialPrefix}}
+	}
+	rw := &routeWalker{src: src, relFile: relFile, dir: filepath.Dir(relFile), draws: map[string]string{}}
+	rw.walk(tree.RootNode(), stack)
+	return rw.out, rw.draws
 }
 
 type routeWalker struct {
@@ -31,6 +44,9 @@ type routeWalker struct {
 	relFile string
 	dir     string
 	out     []facts.Fact
+	// draws maps each draw(:pkg) delegation found in this file to the URL prefix it
+	// is scoped under, so the caller can parse config/routes/<pkg>.rb with it.
+	draws map[string]string
 }
 
 // walk iterates the statements of a program / body_statement, dispatching each
@@ -156,6 +172,13 @@ func (rw *routeWalker) handleCall(call *sitter.Node, stack []routeScope) {
 			return
 		}
 		if pkg := firstSymbolArg(args, rw.src); pkg != "" {
+			// Record the delegation so the caller can parse config/routes/<pkg>.rb
+			// seeded with this prefix, giving its routes their real /api/vN scope.
+			if rw.draws != nil {
+				rw.draws[pkg] = prefix
+			}
+			// A DRAW placeholder route is still emitted (it backs route helpers); the
+			// linker treats method "DRAW" as inert, so it never matches or is flagged.
 			rw.out = append(rw.out, facts.Fact{
 				Kind: facts.KindRoute,
 				Name: prefix + "/" + pkg,

--- a/internal/extractors/rubyextractor/routes_ast.go
+++ b/internal/extractors/rubyextractor/routes_ast.go
@@ -119,8 +119,25 @@ func (rw *routeWalker) handleCall(call *sitter.Node, stack []routeScope) {
 		}
 		only := pairSymbols(args, "only", rw.src)
 		except := pairSymbols(args, "except", rw.src)
-		resourcePath := prefix + "/" + name
-		for _, a := range restfulActions(only, except) {
+		singular := method == "resource"
+
+		// A resource nested inside a *plural* `resources` block nests under the parent
+		// member (`/widgets/:widget_id/...`); the parent supplies that param via the
+		// enclosing scope's memberParam.
+		parentMember := ""
+		if len(stack) > 0 {
+			if p := stack[len(stack)-1].memberParam; p != "" {
+				parentMember = "/:" + p
+			}
+		}
+		segment := parentMember + "/" + name
+		resourcePath := prefix + segment
+
+		actions := restfulActions(only, except)
+		if singular {
+			actions = restfulActionsSingular(only, except)
+		}
+		for _, a := range actions {
 			rw.emit(resourcePath+a.suffix, line(call), map[string]any{
 				"method":    a.method,
 				"framework": "rails",
@@ -130,7 +147,12 @@ func (rw *routeWalker) handleCall(call *sitter.Node, stack []routeScope) {
 			})
 		}
 		if body != nil {
-			rw.walk(body, append(stack, routeScope{pathPrefix: "/" + name}))
+			// A plural resource exposes a member id to its children; a singular one does not.
+			childMember := ""
+			if !singular {
+				childMember = singularize(name) + "_id"
+			}
+			rw.walk(body, append(stack, routeScope{pathPrefix: segment, memberParam: childMember}))
 		}
 
 	case "namespace":

--- a/internal/extractors/rubyextractor/ruby_test.go
+++ b/internal/extractors/rubyextractor/ruby_test.go
@@ -774,6 +774,63 @@ end
 	}
 }
 
+// TestRoutes_DrawPrefixSeeding verifies that (1) a top-level routes.rb reports the
+// prefix each draw(:pkg) is scoped under, and (2) parsing a delegated file seeded
+// with that prefix yields fully-qualified routes that a client call can match.
+func TestRoutes_DrawPrefixSeeding(t *testing.T) {
+	main := `Rails.application.routes.draw do
+  scope '/api', defaults: { format: 'json' } do
+    namespace(:core) do
+      namespace(:v3) do
+        draw(:api_core_v3_routes)
+      end
+    end
+    namespace(:v2) do
+      draw(:api_v2_routes)
+    end
+  end
+  draw(:admin_routes)
+end
+`
+	_, draws := parseRouteFile([]byte(main), "config/routes.rb", "")
+	if draws["api_core_v3_routes"] != "/api/core/v3" {
+		t.Errorf("api_core_v3_routes prefix = %q, want /api/core/v3", draws["api_core_v3_routes"])
+	}
+	if draws["api_v2_routes"] != "/api/v2" {
+		t.Errorf("api_v2_routes prefix = %q, want /api/v2", draws["api_v2_routes"])
+	}
+	if draws["admin_routes"] != "" {
+		t.Errorf("admin_routes prefix = %q, want empty", draws["admin_routes"])
+	}
+
+	// A delegated file parsed with the learned prefix produces qualified routes,
+	// including single-segment collections lifted above the 2-segment match floor.
+	sub := `resources :devices, only: [:destroy]
+resources :interactions, only: [:index]
+namespace :event do
+  resources :posts, only: [:create]
+end
+`
+	ff, _ := parseRouteFile([]byte(sub), "config/routes/api_v2_routes.rb", draws["api_v2_routes"])
+	names := map[string]bool{}
+	for _, f := range ff {
+		names[f.Name] = true
+	}
+	for _, want := range []string{"/api/v2/devices/:id", "/api/v2/interactions", "/api/v2/event/posts"} {
+		if !names[want] {
+			t.Errorf("missing seeded route %q; got %v", want, keys2(names))
+		}
+	}
+}
+
+func keys2(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestRoutes_VerbWithHandler(t *testing.T) {
 	src := `Rails.application.routes.draw do
   root to: "home#index"

--- a/internal/extractors/rubyextractor/ruby_test.go
+++ b/internal/extractors/rubyextractor/ruby_test.go
@@ -774,6 +774,91 @@ end
 	}
 }
 
+// routeMethods indexes route facts as name -> set of HTTP methods (a singular
+// resource emits several verbs on one path, so a plain name->fact map would drop them).
+func routeMethods(result []facts.Fact) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, f := range result {
+		if f.Kind != facts.KindRoute {
+			continue
+		}
+		if out[f.Name] == nil {
+			out[f.Name] = map[string]bool{}
+		}
+		if m, _ := f.Props["method"].(string); m != "" {
+			out[f.Name][m] = true
+		}
+	}
+	return out
+}
+
+// TestRoutes_NestedSingularResource: a singular `resource` nested in a plural
+// `resources` nests under the parent member (`/:<singular>_id`) and has no id of its
+// own — show/create/destroy all map to the base path.
+func TestRoutes_NestedSingularResource(t *testing.T) {
+	src := `Rails.application.routes.draw do
+  resources :widgets, only: [:show] do
+    resource :follow, only: [:show, :create, :destroy]
+  end
+end
+`
+	routes := routeMethods(parseRouteFileAST([]byte(src), "config/routes.rb"))
+
+	if _, ok := routes["/widgets/:id"]; !ok {
+		t.Errorf("missing parent route /widgets/:id; got %v", routes)
+	}
+	follow := routes["/widgets/:widget_id/follow"]
+	for _, m := range []string{"GET", "POST", "DELETE"} {
+		if !follow[m] {
+			t.Errorf("follow: missing %s among %v (route /widgets/:widget_id/follow)", m, follow)
+		}
+	}
+	// The old buggy shapes must NOT appear.
+	for _, absent := range []string{"/widgets/follow", "/widgets/follow/:id", "/widgets/:widget_id/follow/:id"} {
+		if _, ok := routes[absent]; ok {
+			t.Errorf("route %q should not be produced (nested singular resource)", absent)
+		}
+	}
+}
+
+// TestRoutes_NestedPluralResources: a plural `resources` nested in a plural
+// `resources` nests under the parent member id.
+func TestRoutes_NestedPluralResources(t *testing.T) {
+	src := `Rails.application.routes.draw do
+  resources :widgets do
+    resources :items, only: [:index, :show]
+  end
+end
+`
+	routes := routeMethods(parseRouteFileAST([]byte(src), "config/routes.rb"))
+	for _, want := range []string{"/widgets/:widget_id/items", "/widgets/:widget_id/items/:id"} {
+		if _, ok := routes[want]; !ok {
+			t.Errorf("missing route %q; got %v", want, routes)
+		}
+	}
+	if _, ok := routes["/widgets/items"]; ok {
+		t.Errorf("nested plural resources must nest under the parent member id")
+	}
+}
+
+// TestRoutes_TopLevelSingularResource: a top-level singular `resource` has no id.
+func TestRoutes_TopLevelSingularResource(t *testing.T) {
+	src := `Rails.application.routes.draw do
+  resource :session, only: [:show, :create, :destroy]
+end
+`
+	routes := routeMethods(parseRouteFileAST([]byte(src), "config/routes.rb"))
+	session := routes["/session"]
+	for _, m := range []string{"GET", "POST", "DELETE"} {
+		if !session[m] {
+			t.Errorf("session: missing %s among %v", m, session)
+		}
+	}
+	if _, ok := routes["/session/:id"]; ok {
+		t.Errorf("singular resource must not have an :id member path")
+	}
+}
+
 // TestRoutes_DrawPrefixSeeding verifies that (1) a top-level routes.rb reports the
 // prefix each draw(:pkg) is scoped under, and (2) parsing a delegated file seeded
 // with that prefix yields fully-qualified routes that a client call can match.

--- a/internal/extractors/swiftextractor/httpclient.go
+++ b/internal/extractors/swiftextractor/httpclient.go
@@ -2,6 +2,7 @@ package swiftextractor
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -38,7 +39,7 @@ var fileURLSignals = []string{
 var nonAPIExtensions = map[string]bool{
 	".mov": true, ".mp4": true, ".m4v": true, ".mp3": true, ".wav": true,
 	".pdf": true, ".png": true, ".jpg": true, ".jpeg": true, ".heic": true,
-	".gif": true, ".zip": true, ".plist": true, ".sqlite": true,
+	".gif": true, ".zip": true, ".plist": true, ".sqlite": true, ".bundle": true,
 }
 
 // extractURLSessionFacts emits a client-route fact for every URLSession request
@@ -55,6 +56,11 @@ func extractURLSessionFacts(src []byte, relFile string) []facts.Fact {
 // identity dir, so route facts declare into the file's resolved target module
 // rather than its leaf directory.
 func extractURLSessionFactsWithDir(src []byte, relFile, dir string) []facts.Fact {
+	// Test sources build request URLs against fixtures (e.g. an "APIResponses.bundle"
+	// path), which are not real endpoints — skip them so they don't emit phantom routes.
+	if isSwiftTestFile(relFile) {
+		return nil
+	}
 	// File-level gate: appendingPathComponent is also how Swift builds local file
 	// URLs. Only treat it as a network call in files that actually use URLSession /
 	// URLRequest, which excludes file-I/O and build-tooling sources outright.
@@ -180,4 +186,341 @@ func hasNonAPIExtension(path string) bool {
 func swiftAPIHint(relFile string) string {
 	base := filepath.Base(relFile)
 	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+// isSwiftTestFile reports whether a Swift source is test/fixture code (under a
+// Tests directory or a *Test(s)/*Spec file), whose request-building is against
+// fixtures, not real endpoints.
+func isSwiftTestFile(relFile string) bool {
+	slash := filepath.ToSlash(relFile)
+	if strings.Contains(slash, "/Tests/") || strings.HasPrefix(slash, "Tests/") {
+		return true
+	}
+	base := strings.TrimSuffix(filepath.Base(slash), filepath.Ext(slash))
+	return strings.HasSuffix(base, "Test") || strings.HasSuffix(base, "Tests") ||
+		strings.HasSuffix(base, "Spec") || strings.HasSuffix(base, "TestCase")
+}
+
+// --- endpoint-enum client detection (Moya TargetType-like idiom) ---
+
+// swiftVarFinders locate the opening brace of an endpoint's computed properties.
+// The idiom is convention-based (a path property + a `method` property, each a
+// `switch self`), independent of any specific protocol or app name.
+var swiftVarFinders = func() map[string]*regexp.Regexp {
+	m := map[string]*regexp.Regexp{}
+	for _, n := range []string{"urlPathComponent", "path", "urlPrefixComponent", "basePath", "method"} {
+		m[n] = regexp.MustCompile(`var\s+` + n + `\s*:\s*[^{]*\{`)
+	}
+	return m
+}()
+
+// swiftPathProps / swiftPrefixProps are the property names carrying an endpoint's
+// path and its optional version/base prefix, most specific first.
+var (
+	swiftPathProps   = []string{"urlPathComponent", "path"}
+	swiftPrefixProps = []string{"urlPrefixComponent", "basePath"}
+)
+
+// swiftReturnString captures the first string literal a `return` yields.
+var swiftReturnString = regexp.MustCompile(`return\s+"([^"]*)"`)
+
+// swiftReturnEnumCase captures the enum case a `return` yields, e.g. `.post`.
+var swiftReturnEnumCase = regexp.MustCompile(`return\s+\.([A-Za-z]+)`)
+
+// swiftCaseDot captures each `.label` token of a `case .a, .b(let x):` line.
+var swiftCaseDot = regexp.MustCompile(`\.([A-Za-z_]\w*)`)
+
+// extractEndpointFacts emits a client-route fact for every endpoint case in a
+// Swift file that defines an endpoint-enum type: a type exposing a path computed
+// property (urlPathComponent/path) and a `method` computed property, each a
+// `switch self` keyed by enum case. Path, version prefix, and method are joined
+// per case label. The version prefix is resolved in this order: the type's own
+// per-case value, its switch `default:` branch, its single-value computed prefix,
+// and finally defaultPrefix (the repo-wide protocol-extension default, e.g. "v2")
+// when the type declares no prefix property at all. Returns nil for non-idiom files.
+func extractEndpointFacts(src []byte, relFile, dir, defaultPrefix string) []facts.Fact {
+	if isSwiftTestFile(relFile) {
+		return nil
+	}
+	text := string(src)
+	pathBody, pathIdx := firstPropBody(text, swiftPathProps)
+	if pathBody == "" {
+		return nil
+	}
+	methodBody, _ := firstPropBody(text, []string{"method"})
+	if methodBody == "" {
+		return nil // a path property without a method is not the endpoint idiom
+	}
+	pathByCase := switchReturns(pathBody, swiftReturnString)
+	if len(pathByCase) == 0 {
+		return nil
+	}
+	methodByCase := switchReturns(methodBody, swiftReturnEnumCase)
+	resolvePrefix := prefixResolver(text, defaultPrefix)
+
+	api := swiftAPIHint(relFile)
+	line := 1 + strings.Count(text[:pathIdx], "\n")
+
+	var out []facts.Fact
+	seen := map[string]bool{}
+	for label, rawPath := range pathByCase {
+		if label == swiftDefaultLabel {
+			continue // a default: path branch has no concrete case to pair — skip
+		}
+		path := cleanSwiftPath(rawPath)
+		if path == "" || hasNonAPIExtension(path) {
+			continue
+		}
+		if prefix := resolvePrefix(label); prefix != "" {
+			path = joinURLPath(prefix, path)
+		}
+		method := "GET"
+		verb := methodByCase[label]
+		if verb == "" {
+			verb = methodByCase[swiftDefaultLabel]
+		}
+		if v := mapSwiftMethod(verb); v != "" {
+			method = v
+		}
+		key := method + "\x00" + path
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, facts.Fact{
+			Kind: facts.KindRoute,
+			Name: path,
+			File: relFile,
+			Line: line,
+			Props: map[string]any{
+				"role":      "client",
+				"method":    method,
+				"framework": "apiendpoint",
+				"language":  "swift",
+				"source":    "swift-endpoint",
+				"api":       api,
+			},
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: dir}},
+		})
+	}
+	return out
+}
+
+// prefixResolver returns a function mapping an enum-case label to the endpoint's
+// resolved version prefix (already cleaned). It reads the type's urlPrefixComponent
+// property in either form — a `switch self` (per-case + optional `default:`) or a
+// single-value computed body — and falls back to defaultPrefix only when the type
+// declares no prefix property at all, so an explicit per-type prefix is never
+// overridden.
+func prefixResolver(text, defaultPrefix string) func(string) string {
+	body, _ := firstPropBody(text, swiftPrefixProps)
+	if body == "" {
+		clean := resolvePrefixValue(defaultPrefix)
+		return func(string) string { return clean }
+	}
+	if containsSwitch(body) {
+		byCase := switchReturns(body, swiftReturnString)
+		return func(label string) string {
+			v, ok := byCase[label]
+			if !ok {
+				v = byCase[swiftDefaultLabel]
+			}
+			return resolvePrefixValue(v)
+		}
+	}
+	// Single-value computed prefix (implicit return), applies to every case.
+	clean := resolvePrefixValue(firstQuoted(body))
+	return func(string) string { return clean }
+}
+
+// firstPropBody returns the brace-delimited body of the first computed property
+// named one of `names`, plus the byte index where its declaration begins. Returns
+// ("", 0) if none is present.
+func firstPropBody(text string, names []string) (string, int) {
+	for _, name := range names {
+		re := swiftVarFinders[name]
+		if re == nil {
+			continue
+		}
+		loc := re.FindStringIndex(text)
+		if loc == nil {
+			continue
+		}
+		if body, ok := braceBody(text, loc[1]-1); ok {
+			return body, loc[0]
+		}
+	}
+	return "", 0
+}
+
+// braceBody returns the text between the brace at open and its matching close.
+// Swift string interpolation uses `\(…)` (not braces) and these property bodies
+// are plain switches, so simple depth counting is sufficient.
+func braceBody(text string, open int) (string, bool) {
+	depth := 0
+	for i := open; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[open+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// swiftDefaultLabel is the sentinel key under which switchReturns records a
+// `default:` branch's value, so callers can fall back to it for any case the
+// switch does not name explicitly.
+const swiftDefaultLabel = "\x00default"
+
+// switchReturns maps each enum-case label in a `switch self` body to the value its
+// branch returns, extracted by valueRe (group 1). Grouped cases ("case .a, .b:")
+// share the value; a `default:` branch is recorded under swiftDefaultLabel; the
+// first return wins per label.
+func switchReturns(body string, valueRe *regexp.Regexp) map[string]string {
+	out := map[string]string{}
+	if body == "" {
+		return out
+	}
+	var cur []string
+	for _, ln := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(ln)
+		switch {
+		case strings.HasPrefix(t, "case "):
+			cur = caseLabels(t)
+		case strings.HasPrefix(t, "default:"), strings.HasPrefix(t, "default :"):
+			cur = []string{swiftDefaultLabel}
+		}
+		if m := valueRe.FindStringSubmatch(t); m != nil {
+			for _, lbl := range cur {
+				if _, ok := out[lbl]; !ok {
+					out[lbl] = m[1]
+				}
+			}
+		}
+	}
+	return out
+}
+
+// caseLabels extracts the enum-case labels of a `case .a, .b(let x):` line, up to
+// the trailing colon (so a `.label` inside a where-clause value is not captured).
+func caseLabels(line string) []string {
+	if i := strings.IndexByte(line, ':'); i >= 0 {
+		line = line[:i]
+	}
+	var out []string
+	for _, m := range swiftCaseDot.FindAllStringSubmatch(line, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// mapSwiftMethod maps an HTTPMethod enum case (get/post/…) to a verb, or "" if
+// unrecognized (the caller defaults to GET).
+func mapSwiftMethod(v string) string {
+	switch strings.ToLower(v) {
+	case "get", "post", "put", "patch", "delete", "head", "options":
+		return strings.ToUpper(v)
+	}
+	return ""
+}
+
+// joinURLPath joins a prefix and path with a single slash, trimming surrounding
+// slashes (e.g. "v2" + "orders.json" -> "v2/orders.json").
+func joinURLPath(a, b string) string {
+	a, b = strings.Trim(a, "/"), strings.Trim(b, "/")
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	}
+	return a + "/" + b
+}
+
+// swiftFirstQuoted captures the first double-quoted string literal in a body.
+var swiftFirstQuoted = regexp.MustCompile(`"([^"]*)"`)
+
+// swiftVersionInterp matches a Swift interpolation whose expression names a
+// version constant, e.g. `\(APIVersion.v3)` or `\(.v2)`, capturing the digits.
+// Prefix segments interpolate a version enum rather than a runtime value, so this
+// resolves to the version token instead of the generic {} path-parameter placeholder.
+var swiftVersionInterp = regexp.MustCompile(`\\\([^)]*?\bv(\d+)\b[^)]*?\)`)
+
+// firstQuoted returns the first double-quoted string literal in s, or "".
+func firstQuoted(s string) string {
+	if m := swiftFirstQuoted.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// containsSwitch reports whether a property body is a `switch self` (vs a
+// single-value computed body).
+func containsSwitch(body string) bool {
+	return strings.Contains(body, "switch") || strings.Contains(body, "case ")
+}
+
+// resolvePrefixValue turns a raw urlPrefixComponent literal into a clean path
+// prefix: a version-constant interpolation `\(…vN…)` becomes `vN` (so
+// "core/\(APIVersion.v3)" -> "core/v3"), then cleanSwiftPath collapses any other
+// interpolation and strips a query string.
+func resolvePrefixValue(s string) string {
+	if s == "" {
+		return ""
+	}
+	s = swiftVersionInterp.ReplaceAllString(s, "v$1")
+	return cleanSwiftPath(s)
+}
+
+// swiftPrefixRequirement matches the endpoint protocol's urlPrefixComponent
+// requirement (`var urlPrefixComponent: <Type> { get }`), which uniquely marks the
+// file that declares the endpoint protocol — where the repo-wide default lives.
+var swiftPrefixRequirement = regexp.MustCompile(`urlPrefixComponent\s*:\s*[\w.]+\s*\{\s*get\b`)
+
+// detectDefaultURLPrefix returns the repo-wide default urlPrefixComponent value
+// (e.g. "v2") declared in the endpoint protocol's extension, or "" if none. It
+// looks only in the file that declares the protocol requirement, so a concrete
+// type's single-value override (e.g. `{ "core/v3" }`) cannot be mistaken for the
+// default. Meant to run once per repo before the per-file walk.
+func detectDefaultURLPrefix(repoPath string, files []string) string {
+	for _, relFile := range files {
+		if !isSwiftFile(relFile) || isSwiftTestFile(relFile) {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(repoPath, relFile))
+		if err != nil {
+			continue
+		}
+		text := string(src)
+		if !swiftPrefixRequirement.MatchString(text) {
+			continue
+		}
+		if v := defaultPrefixLiteral(text); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// defaultPrefixLiteral scans every urlPrefixComponent computed property in a
+// protocol-declaring file and returns the first single-value string literal it
+// finds (the extension default), skipping the `{ get }` requirement and any
+// `switch`-based body.
+func defaultPrefixLiteral(text string) string {
+	re := swiftVarFinders["urlPrefixComponent"]
+	for _, loc := range re.FindAllStringIndex(text, -1) {
+		body, ok := braceBody(text, loc[1]-1)
+		if !ok || containsSwitch(body) {
+			continue
+		}
+		if v := firstQuoted(body); v != "" {
+			return resolvePrefixValue(v)
+		}
+	}
+	return ""
 }

--- a/internal/extractors/swiftextractor/httpclient.go
+++ b/internal/extractors/swiftextractor/httpclient.go
@@ -524,3 +524,414 @@ func defaultPrefixLiteral(text string) string {
 	}
 	return ""
 }
+
+// --- call-site-driven endpoint idioms (cross-file resolution) ---
+//
+// Two endpoint idioms cannot be resolved from the type alone because part of the
+// request is supplied at each instantiation site. Both are resolved by indexing the
+// types by shape and reading the relevant init arguments at every call site.
+//
+// 1. Stored-method structs — path (and prefix) computed on the type, but `method` a
+//    STORED property set by the caller:
+//
+//	struct SomeEndpoint: EndpointProtocol {
+//	    var urlPrefixComponent: String { "core/v3" }
+//	    var urlPathComponent: String { "resource/\(id)/action" }
+//	    let method: HTTPMethod   // supplied at the call site, e.g. .post / .delete
+//	}
+//
+// 2. Request wrappers — the PATH itself is a stored, required property supplied at
+//    init; the prefix and a default verb live on the type:
+//
+//	struct SomeRequest: EndpointProtocol {
+//	    var urlPrefixComponent = "core/v3"
+//	    var urlPathComponent: String            // supplied at the call site
+//	    var method: HTTPMethod = .get           // default; overridable per call site
+//	}
+//	// SomeRequest(urlPathComponent: "resource/\(id)", method: .delete)
+//
+// extractEndpointFacts requires BOTH a computed path and a computed method, so it
+// skips both idioms; they are handled here.
+
+// swiftTypeDecl matches a struct/class/enum/actor declaration, capturing the type
+// name. Access modifiers and attributes preceding the keyword are tolerated because
+// the match anchors on the keyword itself.
+var swiftTypeDecl = regexp.MustCompile(`\b(?:struct|final\s+class|class|enum|actor)\s+(\w+)`)
+
+// swiftStoredMethod matches a STORED `method` property (`let/var method: <Type>`,
+// no computed `{ … }` body). Distinguishing a stored from a computed method is what
+// separates this pass from extractEndpointFacts, so the caller also confirms the
+// computed finder (swiftVarFinders["method"]) does NOT match the same body.
+var swiftStoredMethod = regexp.MustCompile(`\b(?:let|var)\s+method\s*:\s*[A-Za-z_][\w.<>]*`)
+
+// swiftConstructorCall matches a capitalized `TypeName(` call head, capturing the
+// type name. The trailing `(` is where the argument span begins.
+var swiftConstructorCall = regexp.MustCompile(`\b([A-Z]\w*)\s*\(`)
+
+// swiftVerbArg matches a direct enum-literal method initializer argument
+// (`method: .post` or `httpMethod: .put`), capturing the verb token. The leading-dot
+// anchor excludes dynamically-computed verbs (`method: cond ? .put : .post`), which
+// are out of scope.
+var swiftVerbArg = regexp.MustCompile(`\b(?:method|httpMethod)\s*:\s*\.([A-Za-z]+)`)
+
+// swiftPathArg matches a string-literal urlPathComponent initializer argument
+// (`urlPathComponent: "posts/\(id)"`), capturing the literal. Used for request-wrapper
+// endpoints where the path is supplied per call site.
+var swiftPathArg = regexp.MustCompile(`\burlPathComponent\s*:\s*"([^"]*)"`)
+
+// swiftStoredPathProp matches a STORED, required urlPathComponent property
+// (`var urlPathComponent: String` with no computed `{ … }` body and no `=` default) on
+// its own line — the marker of a request-wrapper type whose path is supplied at init.
+var swiftStoredPathProp = regexp.MustCompile(`(?m)^\s*(?:let|var)\s+urlPathComponent\s*:\s*String\s*(?://.*)?$`)
+
+// swiftStoredPrefix matches a stored urlPrefixComponent with a string-literal default
+// (`var urlPrefixComponent = "core/v3"`), capturing the literal. prefixResolver only
+// reads computed prefixes, so wrapper types (which store the prefix) need this.
+var swiftStoredPrefix = regexp.MustCompile(`\b(?:let|var)\s+urlPrefixComponent\b[^={\n]*=\s*"([^"]*)"`)
+
+// swiftStoredVerbDefault matches a stored method/httpMethod property with an
+// enum-literal default (`var method: HTTPMethod = .get`, `var httpMethod: HTTPMethod = .post`),
+// capturing the verb — a wrapper type's default verb when a call site omits it.
+var swiftStoredVerbDefault = regexp.MustCompile(`\b(?:method|httpMethod)\s*(?::[^=\n]*)?=\s*\.([A-Za-z]+)`)
+
+// storedEndpointDef is a stored-method endpoint type discovered in one file: its
+// simple type name, the resolved (prefix-joined) URL path, and where it lives.
+type storedEndpointDef struct {
+	typeName string
+	path     string
+	file     string
+	line     int
+	dir      string
+}
+
+// storedMethodEndpointDefs finds every stored-method endpoint type declared in a
+// single Swift source and resolves each one's URL path (prefix joined). It is pure
+// and per-file; the verbs are supplied later from call sites. A type qualifies when
+// its body has a single-value (non-switch) path property yielding a string literal
+// and a STORED (non-computed) `method` property.
+func storedMethodEndpointDefs(text, relFile, dir, defaultPrefix string) []storedEndpointDef {
+	var out []storedEndpointDef
+	for _, loc := range swiftTypeDecl.FindAllStringSubmatchIndex(text, -1) {
+		name := text[loc[2]:loc[3]]
+		// The type body starts at the first brace after the declaration head.
+		rel := strings.IndexByte(text[loc[1]:], '{')
+		if rel < 0 {
+			continue
+		}
+		body, ok := braceBody(text, loc[1]+rel)
+		if !ok {
+			continue
+		}
+		// A stored `method` (and not a computed one) is the shape gate.
+		if !swiftStoredMethod.MatchString(body) {
+			continue
+		}
+		if computed, _ := firstPropBody(body, []string{"method"}); computed != "" {
+			continue // computed method -> handled by extractEndpointFacts, not here
+		}
+		pathBody, _ := firstPropBody(body, swiftPathProps)
+		if pathBody == "" || containsSwitch(pathBody) {
+			continue // no single-value path property to resolve
+		}
+		path := cleanSwiftPath(firstQuoted(pathBody))
+		if path == "" || hasNonAPIExtension(path) {
+			continue
+		}
+		if prefix := prefixResolver(body, defaultPrefix)(""); prefix != "" {
+			path = joinURLPath(prefix, path)
+		}
+		out = append(out, storedEndpointDef{
+			typeName: name,
+			path:     path,
+			file:     relFile,
+			line:     1 + strings.Count(text[:loc[0]], "\n"),
+			dir:      dir,
+		})
+	}
+	return out
+}
+
+// endpointCallSite is one constructor call of a candidate endpoint type: the type
+// instantiated, the top-level `urlPathComponent:` literal (for wrapper types) and/or
+// `method:`/`httpMethod:` verb passed, and the call's location.
+type endpointCallSite struct {
+	typeName    string
+	pathArg     string // urlPathComponent: literal, if a top-level string literal
+	pathLiteral bool
+	verb        string // method:/httpMethod: enum-literal verb, if passed
+	file        string
+	line        int
+}
+
+// endpointCallSites scans a single Swift source for constructor calls, recording per
+// call the type name plus any top-level `urlPathComponent:` literal and
+// `method:`/`httpMethod:` verb argument. Only top-level arguments are read (via
+// depthAt), so an argument inside a nested call is attributed to that nested type.
+func endpointCallSites(text, relFile string) []endpointCallSite {
+	var out []endpointCallSite
+	for _, loc := range swiftConstructorCall.FindAllStringSubmatchIndex(text, -1) {
+		span, ok := parenBody(text, loc[1]-1) // loc[1]-1 is the '(' of the call head
+		if !ok {
+			continue
+		}
+		rec := endpointCallSite{
+			typeName: text[loc[2]:loc[3]],
+			file:     relFile,
+			line:     1 + strings.Count(text[:loc[0]], "\n"),
+		}
+		for _, m := range swiftPathArg.FindAllStringSubmatchIndex(span, -1) {
+			if depthAt(span[:m[0]]) != 0 {
+				continue
+			}
+			rec.pathArg, rec.pathLiteral = span[m[2]:m[3]], true
+			break
+		}
+		for _, m := range swiftVerbArg.FindAllStringSubmatchIndex(span, -1) {
+			if depthAt(span[:m[0]]) != 0 {
+				continue
+			}
+			rec.verb = span[m[2]:m[3]]
+			break
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// wrapperDef is a request-wrapper endpoint type: the path is supplied at each call
+// site (a stored `urlPathComponent: String`), while the prefix and default verb live
+// on the type.
+type wrapperDef struct {
+	typeName    string
+	prefix      string
+	defaultVerb string // an uppercase HTTP verb (the call-site fallback)
+	dir         string
+}
+
+// wrapperEndpointDefs finds request-wrapper endpoint types declared in one Swift
+// source: a type whose body stores a required `urlPathComponent: String` (the path is
+// an init argument) together with an endpoint signal (a prefix or method/httpMethod
+// property). Pure and per-file; the paths and verbs come from call sites.
+func wrapperEndpointDefs(text, relFile, dir, defaultPrefix string) []wrapperDef {
+	var out []wrapperDef
+	for _, loc := range swiftTypeDecl.FindAllStringSubmatchIndex(text, -1) {
+		name := text[loc[2]:loc[3]]
+		rel := strings.IndexByte(text[loc[1]:], '{')
+		if rel < 0 {
+			continue
+		}
+		body, ok := braceBody(text, loc[1]+rel)
+		if !ok {
+			continue
+		}
+		if !swiftStoredPathProp.MatchString(body) {
+			continue // path is not supplied at init — not a wrapper
+		}
+		if !strings.Contains(body, "urlPrefixComponent") && !hasVerbSignal(text) {
+			continue // no endpoint signal — avoid grabbing an arbitrary type
+		}
+		out = append(out, wrapperDef{
+			typeName:    name,
+			prefix:      wrapperPrefix(body, defaultPrefix),
+			defaultVerb: wrapperDefaultVerb(text, body),
+			dir:         dir,
+		})
+	}
+	return out
+}
+
+// hasVerbSignal reports whether a source declares a method/httpMethod verb — a stored
+// default or a computed `method` property — used as an endpoint signal for wrappers.
+func hasVerbSignal(text string) bool {
+	if swiftStoredVerbDefault.MatchString(text) {
+		return true
+	}
+	mb, _ := firstPropBody(text, []string{"method"})
+	return mb != ""
+}
+
+// wrapperPrefix resolves a wrapper type's URL prefix: a stored literal default first
+// (prefixResolver reads only computed prefixes), else the computed/default resolution.
+func wrapperPrefix(body, defaultPrefix string) string {
+	if m := swiftStoredPrefix.FindStringSubmatch(body); m != nil {
+		return resolvePrefixValue(m[1])
+	}
+	return prefixResolver(body, defaultPrefix)("")
+}
+
+// wrapperDefaultVerb resolves a wrapper type's default verb: a stored
+// method/httpMethod default first, else a single-value computed `method` (e.g. one
+// fixed in the conformance extension), else GET.
+func wrapperDefaultVerb(fileText, body string) string {
+	if m := swiftStoredVerbDefault.FindStringSubmatch(body); m != nil {
+		if v := mapSwiftMethod(m[1]); v != "" {
+			return v
+		}
+	}
+	if mb, _ := firstPropBody(fileText, []string{"method"}); mb != "" && !containsSwitch(mb) {
+		if cm := swiftCaseDot.FindStringSubmatch(mb); cm != nil {
+			if v := mapSwiftMethod(cm[1]); v != "" {
+				return v
+			}
+		}
+	}
+	return "GET"
+}
+
+// parenBody returns the text between the '(' at open and its matching ')', ignoring
+// parentheses inside double-quoted string literals (so a ')' in a Swift string does
+// not close the span early). text[open] must be '('.
+func parenBody(text string, open int) (string, bool) {
+	depth, inStr := 0, false
+	for i := open; i < len(text); i++ {
+		c := text[i]
+		if inStr {
+			switch c {
+			case '\\':
+				i++ // skip the escaped character
+			case '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return text[open+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// depthAt returns the net bracket nesting depth of s — how many (, [ or { are still
+// open at its end — ignoring brackets inside double-quoted string literals. Used to
+// keep call-site argument scanning at the top level of a single constructor call.
+func depthAt(s string) int {
+	depth, inStr := 0, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch c {
+			case '\\':
+				i++
+			case '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return depth
+}
+
+// extractCallSiteEndpointFacts resolves the two call-site-driven endpoint idioms
+// across a repository and emits client-route facts:
+//   - stored-method structs: the path lives on the type, the verb is read from each
+//     instantiation site's `method:` argument (route anchored at the definition).
+//   - request wrappers: the path is supplied at each call site's `urlPathComponent:`
+//     argument and the verb from `method:`/`httpMethod:` (or the type's default);
+//     each call site is a distinct route, anchored at the call site.
+//
+// A type with no discoverable (resolvable) call site emits nothing. The fact shape
+// matches extractEndpointFacts, so the cross-repo linker treats these identically.
+// Meant to run once per repo (iOS only).
+func extractCallSiteEndpointFacts(repoPath string, files []string, defaultPrefix string, moduleForFile func(string) string) []facts.Fact {
+	var storedDefs []storedEndpointDef
+	var wrappers []wrapperDef
+	var callSites []endpointCallSite
+
+	for _, relFile := range files {
+		if !isSwiftFile(relFile) || isSwiftTestFile(relFile) {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(repoPath, relFile))
+		if err != nil {
+			continue
+		}
+		text := string(src)
+		dir := moduleForFile(relFile)
+		storedDefs = append(storedDefs, storedMethodEndpointDefs(text, relFile, dir, defaultPrefix)...)
+		wrappers = append(wrappers, wrapperEndpointDefs(text, relFile, dir, defaultPrefix)...)
+		callSites = append(callSites, endpointCallSites(text, relFile)...)
+	}
+
+	storedByType := map[string][]storedEndpointDef{}
+	for _, d := range storedDefs {
+		storedByType[d.typeName] = append(storedByType[d.typeName], d)
+	}
+	wrapperByType := map[string]wrapperDef{}
+	for _, d := range wrappers {
+		wrapperByType[d.typeName] = d
+	}
+
+	var out []facts.Fact
+	seen := map[string]bool{}
+	emit := func(dir, method, path, file string, line int) {
+		key := dir + "\x00" + method + "\x00" + path
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, facts.Fact{
+			Kind: facts.KindRoute,
+			Name: path,
+			File: file,
+			Line: line,
+			Props: map[string]any{
+				"role":      "client",
+				"method":    method,
+				"framework": "apiendpoint",
+				"language":  "swift",
+				"source":    "swift-endpoint",
+				"api":       swiftAPIHint(file),
+			},
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: dir}},
+		})
+	}
+
+	for _, cs := range callSites {
+		if defs, ok := storedByType[cs.typeName]; ok {
+			// Path is on the type; the call site only supplies the verb.
+			method := mapSwiftMethod(cs.verb)
+			if method == "" {
+				continue
+			}
+			for _, d := range defs {
+				emit(d.dir, method, d.path, d.file, d.line)
+			}
+			continue
+		}
+		if d, ok := wrapperByType[cs.typeName]; ok {
+			// Path and verb come from the call site (verb falls back to the default).
+			if !cs.pathLiteral {
+				continue
+			}
+			path := cleanSwiftPath(cs.pathArg)
+			if path == "" || hasNonAPIExtension(path) {
+				continue
+			}
+			path = joinURLPath(d.prefix, path)
+			method := mapSwiftMethod(cs.verb)
+			if method == "" {
+				method = d.defaultVerb
+			}
+			emit(moduleForFile(cs.file), method, path, cs.file, cs.line)
+		}
+	}
+	return out
+}

--- a/internal/extractors/swiftextractor/httpclient_test.go
+++ b/internal/extractors/swiftextractor/httpclient_test.go
@@ -4,6 +4,242 @@ import (
 	"testing"
 )
 
+func TestExtractEndpointFacts(t *testing.T) {
+	// An endpoint-enum type (Moya TargetType-like idiom): path + prefix + method are
+	// per-case computed properties driven by `switch self`. Uses neutral names.
+	src := `import Foundation
+
+extension APIService {
+   enum Reports { case send([String: Any]); case list; case sourceType }
+}
+
+extension APIService.Reports: APIEndpoint {
+   var urlPrefixComponent: String {
+      switch self {
+      case .send: return "v2"
+      case .list, .sourceType: return "public/v1"
+      }
+   }
+   var urlPathComponent: String {
+      switch self {
+      case .send: return "reports.json"
+      case .list: return "report_reasons.json"
+      case .sourceType: return "report_source_types.json"
+      }
+   }
+   var method: HTTPMethod {
+      switch self {
+      case .send: return .post
+      case .list, .sourceType: return .get
+      }
+   }
+}
+`
+	// defaultPrefix "v2" is present but must be ignored — this type defines its own
+	// per-case prefix.
+	ff := extractEndpointFacts([]byte(src), "Sources/Core/APIService.Reports.swift", "Sources/Core", "v2")
+	got := map[string]string{}
+	for _, f := range ff {
+		if f.Props["role"] != "client" || f.Props["source"] != "swift-endpoint" {
+			t.Errorf("%s wrong props: %+v", f.Name, f.Props)
+		}
+		got[f.Name] = f.Props["method"].(string)
+	}
+	if got["v2/reports.json"] != "POST" {
+		t.Errorf("send: want v2/reports.json POST, got %+v", got)
+	}
+	if got["public/v1/report_reasons.json"] != "GET" {
+		t.Errorf("list: want public/v1/report_reasons.json GET, got %+v", got)
+	}
+	if got["public/v1/report_source_types.json"] != "GET" {
+		t.Errorf("sourceType: want GET, got %+v", got)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d: %+v", len(got), got)
+	}
+}
+
+// TestExtractEndpointFacts_Interpolated covers interpolated paths (associated
+// values) collapsing to the {} placeholder.
+func TestExtractEndpointFacts_Interpolated(t *testing.T) {
+	src := `extension APIService.Group: APIEndpoint {
+   var urlPathComponent: String {
+      switch self {
+      case .memberships(let groupId, let userId):
+         return "groups/\(groupId)/members/\(userId).json"
+      }
+   }
+   var method: HTTPMethod {
+      switch self {
+      case .memberships: return .delete
+      }
+   }
+}
+`
+	// No prefix property and empty defaultPrefix -> path stays base-relative.
+	ff := extractEndpointFacts([]byte(src), "Sources/Core/APIService.Group.swift", "Sources/Core", "")
+	if len(ff) != 1 || ff[0].Name != "groups/{}/members/{}.json" || ff[0].Props["method"] != "DELETE" {
+		t.Fatalf("interpolated endpoint mismatch: %+v", ff)
+	}
+}
+
+// TestExtractEndpointFacts_NotAnEndpointType ensures ordinary types with a `path`
+// or `method` alone are not treated as endpoint enums.
+func TestExtractEndpointFacts_NotAnEndpointType(t *testing.T) {
+	src := `struct FileHelper {
+   var path: String { return "/tmp/cache" }
+}
+`
+	if ff := extractEndpointFacts([]byte(src), "Sources/Core/FileHelper.swift", "Sources/Core", "v2"); len(ff) != 0 {
+		t.Errorf("a type with a path but no method must not be an endpoint: %+v", ff)
+	}
+}
+
+// TestExtractEndpointFacts_DefaultPrefix: a type with no urlPrefixComponent gets
+// the repo-wide default prefix applied to every case.
+func TestExtractEndpointFacts_DefaultPrefix(t *testing.T) {
+	src := `extension APIService.Device: APIEndpoint {
+   var urlPathComponent: String {
+      switch self {
+      case .register: return "devices.json"
+      case .unregister(let id): return "devices/\(id).json"
+      }
+   }
+   var method: HTTPMethod {
+      switch self {
+      case .register: return .post
+      case .unregister: return .delete
+      }
+   }
+}
+`
+	got := map[string]string{}
+	for _, f := range extractEndpointFacts([]byte(src), "Sources/Core/APIService.Device.swift", "Sources/Core", "v2") {
+		got[f.Name] = f.Props["method"].(string)
+	}
+	if got["v2/devices.json"] != "POST" {
+		t.Errorf("collection endpoint should get default v2 prefix: %+v", got)
+	}
+	if got["v2/devices/{}.json"] != "DELETE" {
+		t.Errorf("param endpoint should get default v2 prefix: %+v", got)
+	}
+}
+
+// TestExtractEndpointFacts_SingleValueOverride: a single-value computed prefix
+// (implicit return, no switch) overrides the default for all cases.
+func TestExtractEndpointFacts_SingleValueOverride(t *testing.T) {
+	src := `extension APIService.Interactions: APIEndpoint {
+   var urlPrefixComponent: String { "core/v3" }
+   var urlPathComponent: String {
+      switch self {
+      case .get: return "interactions"
+      }
+   }
+   var method: HTTPMethod {
+      switch self {
+      case .get: return .get
+      }
+   }
+}
+`
+	got := map[string]string{}
+	for _, f := range extractEndpointFacts([]byte(src), "Sources/Core/APIService.Interactions.swift", "Sources/Core", "v2") {
+		got[f.Name] = f.Props["method"].(string)
+	}
+	if _, ok := got["core/v3/interactions"]; !ok {
+		t.Errorf("single-value override should win over default: %+v", got)
+	}
+}
+
+// TestExtractEndpointFacts_VersionInterpPrefix: a version-constant interpolation in
+// the prefix resolves to the version token, not the {} placeholder.
+func TestExtractEndpointFacts_VersionInterpPrefix(t *testing.T) {
+	src := `extension APIService.Items: APIEndpoint {
+   var urlPrefixComponent: String { "core/\(APIVersion.v3)" }
+   var urlPathComponent: String {
+      switch self {
+      case .list: return "items"
+      }
+   }
+   var method: HTTPMethod {
+      switch self {
+      case .list: return .get
+      }
+   }
+}
+`
+	got := map[string]string{}
+	for _, f := range extractEndpointFacts([]byte(src), "Sources/Core/APIService.Items.swift", "Sources/Core", "v2") {
+		got[f.Name] = f.Props["method"].(string)
+	}
+	if _, ok := got["core/v3/items"]; !ok {
+		t.Errorf("version interpolation should resolve to core/v3: %+v", got)
+	}
+}
+
+// TestExtractEndpointFacts_SwitchPrefixDefault: a prefix switch with a `default:`
+// branch resolves unlisted cases to the default branch value.
+func TestExtractEndpointFacts_SwitchPrefixDefault(t *testing.T) {
+	src := `extension APIService.Account: APIEndpoint {
+   var urlPrefixComponent: String {
+      switch self {
+      case .generateToken, .deleteToken: return "core/v3"
+      default: return "v2"
+      }
+   }
+   var urlPathComponent: String {
+      switch self {
+      case .loadAccount: return "account.json"
+      case .generateToken: return "account/token.json"
+      }
+   }
+   var method: HTTPMethod {
+      switch self {
+      case .loadAccount: return .get
+      case .generateToken: return .post
+      }
+   }
+}
+`
+	got := map[string]string{}
+	for _, f := range extractEndpointFacts([]byte(src), "Sources/Core/APIService.Account.swift", "Sources/Core", "v2") {
+		got[f.Name] = f.Props["method"].(string)
+	}
+	if got["v2/account.json"] != "GET" {
+		t.Errorf("unlisted case should use switch default v2: %+v", got)
+	}
+	if got["core/v3/account/token.json"] != "POST" {
+		t.Errorf("explicit case should use core/v3: %+v", got)
+	}
+}
+
+// TestDetectDefaultURLPrefix: the default is read from the protocol-declaring file
+// and a concrete single-value override elsewhere is not mistaken for it.
+func TestDetectDefaultURLPrefix(t *testing.T) {
+	protoFile := "Sources/Core/APIEndpoint.swift"
+	proto := `public protocol APIEndpoint {
+   var urlPrefixComponent: String { get }
+   var urlPathComponent: String { get }
+}
+
+public extension APIEndpoint {
+   var urlPrefixComponent: String {
+      "v2" // default for all existing urls
+   }
+}
+`
+	concrete := "Sources/Core/APIService.Widget.swift"
+
+	dir := t.TempDir()
+	mustWrite(t, dir, protoFile, proto)
+	// A concrete single-value override — must NOT be picked as the default.
+	mustWrite(t, dir, concrete, "struct WidgetEndpoint: APIEndpoint {\n   var urlPrefixComponent: String { \"core/v3\" }\n}\n")
+
+	if got := detectDefaultURLPrefix(dir, []string{concrete, protoFile}); got != "v2" {
+		t.Errorf("detectDefaultURLPrefix = %q, want v2 (from the protocol file, ignoring the concrete override)", got)
+	}
+}
+
 func TestExtractURLSessionFacts(t *testing.T) {
 	src := `import Foundation
 

--- a/internal/extractors/swiftextractor/httpclient_test.go
+++ b/internal/extractors/swiftextractor/httpclient_test.go
@@ -1,8 +1,14 @@
 package swiftextractor
 
 import (
+	"path/filepath"
 	"testing"
 )
+
+// testModuleForFile is the module-identity resolver used by stored-method endpoint
+// tests: it maps a file to its leaf directory (the fallback the real resolver uses
+// for loose sources).
+func testModuleForFile(f string) string { return filepath.ToSlash(filepath.Dir(f)) }
 
 func TestExtractEndpointFacts(t *testing.T) {
 	// An endpoint-enum type (Moya TargetType-like idiom): path + prefix + method are
@@ -330,6 +336,293 @@ final class MediaAnalysisModal {
 	}
 	if ff[0].Name != "settings/visual-ai-coach/analyze" || ff[0].Props["method"] != "POST" {
 		t.Errorf("unexpected route: %+v", ff[0])
+	}
+}
+
+// --- stored-method endpoint structs (call-site verb resolution) ---
+
+// storedEndpointDefSource is a stored-method endpoint type: path + prefix are
+// computed, but `method` is a stored property set by the caller at init. Neutral
+// names throughout.
+const storedEndpointDefSource = `import Foundation
+
+struct WidgetActionEndpoint: APIEndpoint {
+   var urlPrefixComponent: String { "core/v3" }
+   var urlPathComponent: String { "widgets/\(id)/action" }
+   let id: String
+   let method: HTTPMethod
+}
+`
+
+// TestExtractStoredMethodEndpointFacts: a stored-method endpoint defined in one file
+// and instantiated with `.post` in another emits one client route with that verb.
+func TestExtractStoredMethodEndpointFacts(t *testing.T) {
+	dir := t.TempDir()
+	defFile := "Sources/Core/WidgetActionEndpoint.swift"
+	callFile := "Sources/Feature/WidgetService.swift"
+	mustWrite(t, dir, defFile, storedEndpointDefSource)
+	mustWrite(t, dir, callFile, `final class WidgetService {
+   func perform(id: String) {
+      let endpoint = WidgetActionEndpoint(id: id, method: .post)
+      client.send(endpoint)
+   }
+}
+`)
+
+	ff := extractCallSiteEndpointFacts(dir, []string{defFile, callFile}, "", testModuleForFile)
+	if len(ff) != 1 {
+		t.Fatalf("expected 1 client route, got %d: %+v", len(ff), ff)
+	}
+	f := ff[0]
+	if f.Name != "core/v3/widgets/{}/action" || f.Props["method"] != "POST" {
+		t.Errorf("route mismatch: name=%q method=%v", f.Name, f.Props["method"])
+	}
+	if f.Props["role"] != "client" || f.Props["source"] != "swift-endpoint" || f.Props["framework"] != "apiendpoint" {
+		t.Errorf("wrong props: %+v", f.Props)
+	}
+	if f.File != defFile {
+		t.Errorf("route should anchor at the type definition file, got %q", f.File)
+	}
+}
+
+// TestExtractStoredMethodEndpointFacts_MultipleVerbs: one type instantiated with two
+// different verbs yields two routes, one per verb.
+func TestExtractStoredMethodEndpointFacts_MultipleVerbs(t *testing.T) {
+	dir := t.TempDir()
+	defFile := "Sources/Core/WidgetActionEndpoint.swift"
+	callFile := "Sources/Feature/WidgetService.swift"
+	mustWrite(t, dir, defFile, storedEndpointDefSource)
+	mustWrite(t, dir, callFile, `final class WidgetService {
+   func create(id: String) { _ = WidgetActionEndpoint(id: id, method: .post) }
+   func remove(id: String) { _ = WidgetActionEndpoint(id: id, method: .delete) }
+}
+`)
+
+	got := map[string]bool{}
+	for _, f := range extractCallSiteEndpointFacts(dir, []string{defFile, callFile}, "", testModuleForFile) {
+		if f.Name != "core/v3/widgets/{}/action" {
+			t.Errorf("unexpected path: %q", f.Name)
+		}
+		got[f.Props["method"].(string)] = true
+	}
+	if !got["POST"] || !got["DELETE"] || len(got) != 2 {
+		t.Fatalf("want POST+DELETE, got %+v", got)
+	}
+}
+
+// TestExtractStoredMethodEndpointFacts_NoCallSite: a stored-method endpoint that is
+// never instantiated emits nothing (Approach A — the verb is unknowable).
+func TestExtractStoredMethodEndpointFacts_NoCallSite(t *testing.T) {
+	dir := t.TempDir()
+	defFile := "Sources/Core/WidgetActionEndpoint.swift"
+	mustWrite(t, dir, defFile, storedEndpointDefSource)
+
+	if ff := extractCallSiteEndpointFacts(dir, []string{defFile}, "", testModuleForFile); len(ff) != 0 {
+		t.Fatalf("expected no routes without a call site, got %d: %+v", len(ff), ff)
+	}
+}
+
+// TestExtractStoredMethodEndpointFacts_DefaultPrefix: a stored-method endpoint with
+// no prefix property inherits the repo-wide default prefix.
+func TestExtractStoredMethodEndpointFacts_DefaultPrefix(t *testing.T) {
+	dir := t.TempDir()
+	defFile := "Sources/Core/ItemEndpoint.swift"
+	callFile := "Sources/Feature/ItemService.swift"
+	mustWrite(t, dir, defFile, `struct ItemEndpoint: APIEndpoint {
+   var urlPathComponent: String { "items/\(id)" }
+   let id: String
+   let method: HTTPMethod
+}
+`)
+	mustWrite(t, dir, callFile, `func load(id: String) { _ = ItemEndpoint(id: id, method: .get) }
+`)
+
+	ff := extractCallSiteEndpointFacts(dir, []string{defFile, callFile}, "v2", testModuleForFile)
+	if len(ff) != 1 || ff[0].Name != "v2/items/{}" || ff[0].Props["method"] != "GET" {
+		t.Fatalf("default-prefix stored endpoint mismatch: %+v", ff)
+	}
+}
+
+// TestExtractStoredMethodEndpointFacts_NotEndpoints: a type with a stored `method`
+// but no path property, a computed-method endpoint (handled elsewhere), and an
+// unrelated constructor call all emit nothing from this pass.
+func TestExtractStoredMethodEndpointFacts_NotEndpoints(t *testing.T) {
+	dir := t.TempDir()
+	f1 := "Sources/A.swift"
+	f2 := "Sources/B.swift"
+	f3 := "Sources/C.swift"
+	// Stored method but no path property -> not an endpoint.
+	mustWrite(t, dir, f1, `struct PlainModel { let method: HTTPMethod }
+`)
+	// Computed method -> owned by extractEndpointFacts, not this pass.
+	mustWrite(t, dir, f2, `struct ComputedEndpoint: APIEndpoint {
+   var urlPathComponent: String { "things" }
+   var method: HTTPMethod { .get }
+}
+`)
+	// An unrelated constructor passing a method: arg for a non-endpoint type.
+	mustWrite(t, dir, f3, `func go() {
+   _ = PlainModel(method: .post)
+   _ = ComputedEndpoint()
+}
+`)
+
+	if ff := extractCallSiteEndpointFacts(dir, []string{f1, f2, f3}, "", testModuleForFile); len(ff) != 0 {
+		t.Fatalf("expected no routes, got %d: %+v", len(ff), ff)
+	}
+}
+
+// TestEndpointCallSites: top-level `method:`/`httpMethod:` verbs and
+// `urlPathComponent:` literals are read; a ternary/computed verb is skipped, and a
+// nested call's args are attributed to the nested type, not the outer one.
+func TestEndpointCallSites(t *testing.T) {
+	src := `let a = FooEndpoint(id: x, method: .post)
+let b = BarEndpoint(method: isEdit ? .put : .patch)
+let c = OuterEndpoint(body: InnerEndpoint(method: .delete), method: .get)
+let d = WrapRequest(urlPathComponent: "posts/\(id)", httpMethod: .put)
+`
+	byType := map[string]endpointCallSite{}
+	for _, cs := range endpointCallSites(src, "X.swift") {
+		byType[cs.typeName] = cs
+	}
+	if cs := byType["FooEndpoint"]; cs.verb != "post" {
+		t.Errorf("FooEndpoint verb = %q, want post", cs.verb)
+	}
+	if cs := byType["BarEndpoint"]; cs.verb != "" {
+		t.Errorf("BarEndpoint ternary verb should be skipped, got %q", cs.verb)
+	}
+	if cs := byType["OuterEndpoint"]; cs.verb != "get" || cs.pathLiteral {
+		t.Errorf("OuterEndpoint = %+v, want verb get and no path", cs)
+	}
+	if cs := byType["InnerEndpoint"]; cs.verb != "delete" {
+		t.Errorf("InnerEndpoint verb = %q, want delete", cs.verb)
+	}
+	if cs := byType["WrapRequest"]; !cs.pathLiteral || cs.pathArg != `posts/\(id)` || cs.verb != "put" {
+		t.Errorf("WrapRequest = %+v, want path posts/\\(id) + verb put", cs)
+	}
+}
+
+// wrapperDefSource is a request-wrapper endpoint: the path is a stored, required
+// property supplied at each call site; prefix and default verb live on the type.
+const wrapperDefSource = `import Foundation
+
+extension API {
+   struct SimpleRequest {
+      var urlPrefixComponent = "core/v3"
+      var urlPathComponent: String
+      var requestParams: [String: Any] = [:]
+      var method: HTTPMethod = .get
+   }
+}
+
+extension API.SimpleRequest: APIEndpoint {}
+`
+
+// TestWrapperEndpoint_PathAndVerbFromCallSite: a wrapper's path comes from the call
+// site's urlPathComponent: literal; the verb from method: or the type default.
+func TestWrapperEndpoint_PathAndVerbFromCallSite(t *testing.T) {
+	dir := t.TempDir()
+	defFile := "Sources/Core/SimpleRequest.swift"
+	callFile := "Sources/Feature/Service.swift"
+	mustWrite(t, dir, defFile, wrapperDefSource)
+	mustWrite(t, dir, callFile, `func f(id: String) {
+   _ = API.SimpleRequest(urlPathComponent: "posts/\(id)", method: .delete)
+   _ = API.SimpleRequest(urlPathComponent: "items?limit=10")
+}
+`)
+
+	got := map[string]string{}
+	for _, f := range extractCallSiteEndpointFacts(dir, []string{defFile, callFile}, "", testModuleForFile) {
+		got[f.Name] = f.Props["method"].(string)
+		if f.File != callFile {
+			t.Errorf("wrapper route should anchor at the call site, got %q", f.File)
+		}
+	}
+	if got["core/v3/posts/{}"] != "DELETE" {
+		t.Errorf("explicit verb: want core/v3/posts/{} DELETE, got %+v", got)
+	}
+	if got["core/v3/items"] != "GET" { // query string stripped; default verb .get
+		t.Errorf("default verb + query strip: want core/v3/items GET, got %+v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 routes, got %+v", got)
+	}
+}
+
+// TestWrapperEndpoint_HttpMethodArgAndComputedDefault covers the httpMethod: arg name
+// (with a stored default) and a verb fixed by a computed method in the conformance
+// extension.
+func TestWrapperEndpoint_HttpMethodArgAndComputedDefault(t *testing.T) {
+	dir := t.TempDir()
+	// httpMethod default .post, overridable via httpMethod: arg.
+	encFile := "Sources/Core/EncRequest.swift"
+	mustWrite(t, dir, encFile, `extension API {
+   struct EncRequest {
+      var urlPrefixComponent = "core/v3"
+      var urlPathComponent: String
+      var httpMethod: HTTPMethod = .post
+   }
+}
+extension API.EncRequest: APIEndpoint { public var method: HTTPMethod { httpMethod } }
+`)
+	// verb fixed by a computed method in the extension (no init verb).
+	putFile := "Sources/Core/PutOnly.swift"
+	mustWrite(t, dir, putFile, `extension API {
+   struct PutOnly {
+      var urlPrefixComponent = "core/v3"
+      var urlPathComponent: String
+   }
+}
+extension API.PutOnly: APIEndpoint { public var method: HTTPMethod { .put } }
+`)
+	callFile := "Sources/Feature/Svc.swift"
+	mustWrite(t, dir, callFile, `func f(id: String) {
+   _ = API.EncRequest(urlPathComponent: "a/\(id)")
+   _ = API.EncRequest(urlPathComponent: "b/\(id)", httpMethod: .put)
+   _ = API.PutOnly(urlPathComponent: "c/\(id)")
+}
+`)
+
+	got := map[string]string{}
+	for _, f := range extractCallSiteEndpointFacts(dir, []string{encFile, putFile, callFile}, "", testModuleForFile) {
+		got[f.Name] = f.Props["method"].(string)
+	}
+	if got["core/v3/a/{}"] != "POST" {
+		t.Errorf("EncRequest default: want core/v3/a/{} POST, got %+v", got)
+	}
+	if got["core/v3/b/{}"] != "PUT" {
+		t.Errorf("EncRequest httpMethod override: want core/v3/b/{} PUT, got %+v", got)
+	}
+	if got["core/v3/c/{}"] != "PUT" {
+		t.Errorf("PutOnly computed-fixed verb: want core/v3/c/{} PUT, got %+v", got)
+	}
+}
+
+// TestWrapperEndpoint_NonLiteralPathSkipped: a wrapper call site whose path is a
+// variable (not a literal) is unresolvable and emits nothing.
+func TestWrapperEndpoint_NonLiteralPathSkipped(t *testing.T) {
+	dir := t.TempDir()
+	defFile := "Sources/Core/SimpleRequest.swift"
+	callFile := "Sources/Feature/Service.swift"
+	mustWrite(t, dir, defFile, wrapperDefSource)
+	mustWrite(t, dir, callFile, `func f(path: String) {
+   _ = API.SimpleRequest(urlPathComponent: path, method: .get)
+}
+`)
+
+	if ff := extractCallSiteEndpointFacts(dir, []string{defFile, callFile}, "", testModuleForFile); len(ff) != 0 {
+		t.Fatalf("expected no routes for a variable path, got %d: %+v", len(ff), ff)
+	}
+}
+
+// TestParenBody_StringLiteral: a ')' inside a Swift string literal does not close
+// the argument span early.
+func TestParenBody_StringLiteral(t *testing.T) {
+	src := `Foo(label: "a )( b", method: .post)`
+	open := len("Foo")
+	body, ok := parenBody(src, open)
+	if !ok || body != `label: "a )( b", method: .post` {
+		t.Fatalf("parenBody = (%q, %v)", body, ok)
 	}
 }
 

--- a/internal/extractors/swiftextractor/swift.go
+++ b/internal/extractors/swiftextractor/swift.go
@@ -122,6 +122,14 @@ func (e *SwiftExtractor) Extract(ctx context.Context, repoPath string, files []s
 		return filepath.Dir(relFile)
 	}
 
+	// The repo-wide default urlPrefixComponent (e.g. "v2") that endpoint types
+	// inherit when they declare no prefix of their own. Only iOS uses the endpoint
+	// idiom, so the scan is gated on isiOS to avoid a wasted read pass elsewhere.
+	var defaultURLPrefix string
+	if isiOS {
+		defaultURLPrefix = detectDefaultURLPrefix(repoPath, files)
+	}
+
 	// extractFileAST/extractURLSessionFacts are pure; parse the source files in
 	// parallel. The indices below are rebuilt by iterating the per-file results in
 	// file order, so modules, dirToFile and typeIndex match a serial run exactly.
@@ -135,7 +143,8 @@ func (e *SwiftExtractor) Extract(ctx context.Context, repoPath string, files []s
 		}
 		dir := moduleForFile(relFile)
 		ff := extractFileASTWithDir(src, relFile, isiOS, dir)
-		return append(ff, extractURLSessionFactsWithDir(src, relFile, dir)...)
+		ff = append(ff, extractURLSessionFactsWithDir(src, relFile, dir)...)
+		return append(ff, extractEndpointFacts(src, relFile, dir, defaultURLPrefix)...)
 	})
 
 	for i, fileFacts := range perFileFacts {

--- a/internal/extractors/swiftextractor/swift.go
+++ b/internal/extractors/swiftextractor/swift.go
@@ -205,6 +205,15 @@ func (e *SwiftExtractor) Extract(ctx context.Context, repoPath string, files []s
 		}
 	}
 
+	// Some endpoint idioms supply part of the request (verb, or the path itself) at
+	// each instantiation site, so the per-file walk cannot resolve them. Index them
+	// repo-wide and read the missing init arguments from every call site. iOS-only,
+	// matching the endpoint idiom (and the defaultURLPrefix gate above).
+	if isiOS {
+		allFacts = append(allFacts,
+			extractCallSiteEndpointFacts(repoPath, files, defaultURLPrefix, moduleForFile)...)
+	}
+
 	// Parse Package.swift manifests: emit SPM target module facts + the inter-target
 	// dependency graph, and (by rerouting) keep the manifest's own `let package`
 	// binding and `import PackageDescription` out of the symbol/dependency facts.

--- a/internal/extractors/tsextractor/httpclient.go
+++ b/internal/extractors/tsextractor/httpclient.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -21,6 +22,35 @@ var httpClientCall = regexp.MustCompile("(?:fetch|makeRequest)\\s*(?:<[^>]*>)?\\
 // object.
 var httpClientMethod = regexp.MustCompile(`method\s*:\s*['"]([A-Za-z]+)['"]`)
 
+// verbNamedCall matches an openapi-fetch–style verb-named method call whose first
+// positional argument is a string/template literal path, where the HTTP method is
+// the (uppercase) method name itself, e.g.
+//
+//	API.getApi().GET('/api/v3/items/{id}', { params: … })
+//	ApiV3.getApi().DELETE('/api/v3/widgets/{id}/follow')
+//
+// Only uppercase verbs are matched: that is the generated-client convention and it
+// avoids colliding with ordinary lowercase methods like map.get()/cache.delete().
+var verbNamedCall = regexp.MustCompile("\\.(GET|POST|PUT|DELETE|PATCH)\\s*(?:<[^>]*>)?\\s*\\(\\s*(?:\"([^\"]*)\"|'([^']*)'|`([^`]*)`)")
+
+// urlProperty matches a `url:` object property whose value is a string/template
+// literal — the options-object client idiom, e.g.
+//
+//	request({ token, type: 'query', url: `/v2/messages/${id}.json` })
+//	{ type: 'post', payload: {…}, url: '/v2/messages.json' }
+var urlProperty = regexp.MustCompile("\\burl\\s*:\\s*(?:\"([^\"]*)\"|'([^']*)'|`([^`]*)`)")
+
+// requestVerbProperty extracts the verb of a request-options object from its
+// `type:`/`method:` property. The value may be an HTTP verb or an action verb
+// (query/post/put/delete); mapClientVerb reconciles both.
+var requestVerbProperty = regexp.MustCompile(`\b(?:type|method)\s*:\s*['"]([A-Za-z]+)['"]`)
+
+// requestDescriptorKey marks an object literal as an HTTP request descriptor
+// (rather than a plain link/href object): it carries a verb or a request-payload
+// sibling key. Requiring one of these next to a `url:` keeps router links and
+// config objects from being mistaken for outbound calls.
+var requestDescriptorKey = regexp.MustCompile(`\b(?:type|method|token|payload|pagination|signal|headers|body|query|params)\s*:`)
+
 // tsInterpolation matches a template-literal interpolation, e.g. ${id}.
 var tsInterpolation = regexp.MustCompile(`\$\{[^}]*\}`)
 
@@ -28,22 +58,57 @@ var tsInterpolation = regexp.MustCompile(`\$\{[^}]*\}`)
 // request's method option.
 const httpMethodWindow = 200
 
-// extractHTTPClientFacts emits a client-route fact for every hand-written
-// fetch()/makeRequest() call to the backend. The path is the call's first
-// string argument (its leading ${baseURL} token stripped) and the method comes
-// from a nearby `method:` option, defaulting to GET. Paths include the /api
-// prefix here; the cross-repo linker's suffix matching reconciles prefixes.
+// objectScanCap bounds how far on each side of a `url:` property to scan for the
+// braces of its enclosing object literal, so a pathological input cannot make the
+// scan run over a whole file.
+const objectScanCap = 4096
+
+// extractHTTPClientFacts emits a client-route fact for every hand-written HTTP
+// call to the backend, recognizing three shapes: (1) positional fetch()/
+// makeRequest() calls, (2) verb-named generated-client calls (.GET(/.POST(/…), and
+// (3) options-object clients carrying a `url:` property with a `type:`/`method:`
+// verb. Paths are kept as written (with the /api or /v2 prefix and any .json
+// suffix); the cross-repo linker's normalization reconciles prefixes and format
+// suffixes.
 func extractHTTPClientFacts(src []byte, relFile string) []facts.Fact {
 	dir := filepath.ToSlash(filepath.Dir(relFile))
 	api := tsAPIHint(relFile)
 
 	var out []facts.Fact
+	seen := map[string]bool{}
+	// add appends a client-route fact, de-duplicating on method+path+line so the
+	// three passes below cannot double-emit the same call site.
+	add := func(rawPath, method, framework string, off int) {
+		path, ok := cleanTSPath(rawPath)
+		if !ok {
+			return
+		}
+		line := 1 + bytes.Count(src[:off], []byte("\n"))
+		key := method + "\x00" + path + "\x00" + strconv.Itoa(line)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, facts.Fact{
+			Kind: facts.KindRoute,
+			Name: path,
+			File: relFile,
+			Line: line,
+			Props: map[string]any{
+				"role":      "client",
+				"method":    method,
+				"framework": framework,
+				"language":  "typescript",
+				"source":    "ts-http-client",
+				"api":       api,
+			},
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: dir}},
+		})
+	}
+
+	// Pass 1 — positional fetch()/makeRequest(), method from a nearby `method:`.
 	for _, m := range httpClientCall.FindAllSubmatchIndex(src, -1) {
 		raw := firstNonEmptyGroup(src, m, 1, 2, 3)
-		path, ok := cleanTSPath(raw)
-		if !ok {
-			continue
-		}
 		method := "GET"
 		end := m[1] + httpMethodWindow
 		if end > len(src) {
@@ -52,23 +117,94 @@ func extractHTTPClientFacts(src []byte, relFile string) []facts.Fact {
 		if mm := httpClientMethod.FindSubmatch(src[m[1]:end]); mm != nil {
 			method = strings.ToUpper(string(mm[1]))
 		}
-		out = append(out, facts.Fact{
-			Kind: facts.KindRoute,
-			Name: path,
-			File: relFile,
-			Line: 1 + bytes.Count(src[:m[0]], []byte("\n")),
-			Props: map[string]any{
-				"role":      "client",
-				"method":    method,
-				"framework": "fetch",
-				"language":  "typescript",
-				"source":    "ts-http-client",
-				"api":       api,
-			},
-			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: dir}},
-		})
+		add(raw, method, "fetch", m[0])
 	}
+
+	// Pass 2 — verb-named generated-client calls; the method is the call name.
+	for _, m := range verbNamedCall.FindAllSubmatchIndex(src, -1) {
+		method := strings.ToUpper(string(src[m[2]:m[3]]))
+		raw := firstNonEmptyGroup(src, m, 2, 3, 4)
+		add(raw, method, "openapi-fetch", m[0])
+	}
+
+	// Pass 3 — options-object clients: a `url:` property inside an object literal
+	// that also carries a request-descriptor key, with the verb from a sibling
+	// `type:`/`method:` (default GET). The scan is scoped to the enclosing object so
+	// a neighbouring object's verb cannot bleed in.
+	for _, m := range urlProperty.FindAllSubmatchIndex(src, -1) {
+		window := enclosingObject(src, m[0], m[1])
+		if window == nil || !requestDescriptorKey.Match(window) {
+			continue // no enclosing object, or a plain link/config object
+		}
+		method := "GET"
+		if vm := requestVerbProperty.FindSubmatch(window); vm != nil {
+			if v := mapClientVerb(string(vm[1])); v != "" {
+				method = v
+			}
+		}
+		raw := firstNonEmptyGroup(src, m, 1, 2, 3)
+		add(raw, method, "request-options", m[0])
+	}
+
 	return out
+}
+
+// enclosingObject returns the bytes of the object literal that immediately
+// encloses the [s,e) range (a `url:` property), by brace-matching outward from
+// either side while skipping the [s,e) value itself. Returns nil when the braces
+// are not found within objectScanCap bytes on a side. Nested braces (a `{ zip }`
+// sibling value, a `${…}` interpolation) are balanced by depth counting.
+func enclosingObject(src []byte, s, e int) []byte {
+	open := -1
+	depth := 0
+left:
+	for i := s - 1; i >= 0 && s-1-i < objectScanCap; i-- {
+		switch src[i] {
+		case '}':
+			depth++
+		case '{':
+			if depth == 0 {
+				open = i
+				break left
+			}
+			depth--
+		}
+	}
+	if open < 0 {
+		return nil
+	}
+	shut := -1
+	depth = 0
+right:
+	for i := e; i < len(src) && i-e < objectScanCap; i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			if depth == 0 {
+				shut = i
+				break right
+			}
+			depth--
+		}
+	}
+	if shut < 0 {
+		return nil
+	}
+	return src[open : shut+1]
+}
+
+// mapClientVerb maps a request-descriptor verb token to an HTTP method. Standard
+// HTTP verbs pass through; the action-style token "query" maps to GET (a read).
+// Returns "" for an unrecognized token so the caller can fall back to GET.
+func mapClientVerb(tok string) string {
+	switch strings.ToUpper(strings.TrimSpace(tok)) {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
+		return strings.ToUpper(strings.TrimSpace(tok))
+	case "QUERY":
+		return "GET"
+	}
+	return ""
 }
 
 // firstNonEmptyGroup returns the text of the first matched capture group among

--- a/internal/extractors/tsextractor/httpclient_test.go
+++ b/internal/extractors/tsextractor/httpclient_test.go
@@ -1,6 +1,75 @@
 package tsextractor
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// byNameMethod indexes emitted client routes by path -> method.
+func byNameMethod(ff []facts.Fact) map[string]string {
+	out := map[string]string{}
+	for _, f := range ff {
+		out[f.Name] = f.Props["method"].(string)
+	}
+	return out
+}
+
+// TestExtractHTTPClientFacts_VerbNamedCalls covers the openapi-fetch generated
+// client where the method is the (uppercase) call name and the path is the first
+// positional literal.
+func TestExtractHTTPClientFacts_VerbNamedCalls(t *testing.T) {
+	src := "async function load(id: number) {\n" +
+		"  await API.getApi().GET('/api/v3/items/{id}', { params });\n" +
+		"  API.getApi().POST('/api/v3/widgets/{id}/follow', { body });\n" +
+		"  API.getApi().DELETE('/api/v3/sessions');\n" +
+		"  const v = map.get('some-key');\n" + // lowercase .get must NOT match
+		"}\n"
+	got := byNameMethod(extractHTTPClientFacts([]byte(src), "client/feed/network.ts"))
+
+	// Literal {id} braces are left as written (the linker's normalizePath collapses
+	// them to {} at match time), like the Retrofit/Swift extractors.
+	if got["/api/v3/items/{id}"] != "GET" {
+		t.Errorf("GET call: got %+v", got)
+	}
+	if got["/api/v3/widgets/{id}/follow"] != "POST" {
+		t.Errorf("POST call: got %+v", got)
+	}
+	if got["/api/v3/sessions"] != "DELETE" {
+		t.Errorf("DELETE call: got %+v", got)
+	}
+	if _, found := got["some-key"]; found {
+		t.Errorf("lowercase map.get('some-key') must not be detected: %+v", got)
+	}
+}
+
+// TestExtractHTTPClientFacts_OptionsObject covers the options-object client where
+// the URL is a `url:` property and the verb is a `type:` property (with the
+// action verb "query" mapping to GET), including the declarative request object.
+func TestExtractHTTPClientFacts_OptionsObject(t *testing.T) {
+	src := "const a = createRequest({ url: '/v2/items.json', type: 'query', token });\n" +
+		"const b = createRequest({ url: `/v2/items/${id}.json`, type: 'delete', token });\n" +
+		"const post = { type: 'post', payload: {}, url: '/v2/messages.json' };\n" +
+		"const c = request({ query: { zip }, url: '/v2/lookup/address.json' });\n" + // no verb -> GET
+		"const link = { url: '/settings/profile', label: 'Profile' };\n" // plain link -> not a request
+	got := byNameMethod(extractHTTPClientFacts([]byte(src), "client/items/network.jsx"))
+
+	if got["/v2/items.json"] != "GET" {
+		t.Errorf("query verb should map to GET: %+v", got)
+	}
+	if got["/v2/items/{}.json"] != "DELETE" {
+		t.Errorf("delete verb + interpolation: %+v", got)
+	}
+	if got["/v2/messages.json"] != "POST" {
+		t.Errorf("declarative request object post: %+v", got)
+	}
+	if got["/v2/lookup/address.json"] != "GET" {
+		t.Errorf("verb-less request should default GET: %+v", got)
+	}
+	if _, found := got["/settings/profile"]; found {
+		t.Errorf("a plain link object (no request-descriptor key) must not be detected: %+v", got)
+	}
+}
 
 func TestExtractHTTPClientFacts(t *testing.T) {
 	src := "class FeedbackApi {\n" +

--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -250,7 +250,8 @@ func pickProvider(client facts.Fact, matches []routeRef) (string, bool) {
 // HTTP-client extractors, as opposed to generated OpenAPI client specs.
 var handWrittenClientSources = map[string]bool{
 	"ts-http-client": true, "retrofit": true, "urlsession": true,
-	"ruby-http-client": true, "go-http-client": true, "php-http-client": true,
+	"swift-endpoint": true, "ruby-http-client": true, "go-http-client": true,
+	"php-http-client": true,
 }
 
 // httpVia returns the via label for an HTTP edge derived from a client route:
@@ -421,6 +422,7 @@ func repoFromIdentity(id string) string {
 // --- signal (B): import / shared-lib references ---
 
 func linkImports(all []facts.Fact, normToLabel map[string]string, edges map[string]*edge) {
+	ownDirs := repoTopDirs(all)
 	for _, f := range all {
 		if f.Repo == "" || f.Kind == facts.KindService {
 			continue
@@ -429,7 +431,7 @@ func linkImports(all []facts.Fact, normToLabel map[string]string, edges map[stri
 			if rel.Kind != facts.RelImports && rel.Kind != facts.RelDependsOn {
 				continue
 			}
-			provider := importProvider(rel.Target, f.Repo, normToLabel)
+			provider := importProvider(rel.Target, f.Repo, normToLabel, ownDirs[f.Repo])
 			if provider == "" {
 				continue
 			}
@@ -446,11 +448,22 @@ func linkImports(all []facts.Fact, normToLabel map[string]string, edges map[stri
 // importProvider maps an import target to another loaded repo, or "" if none.
 // It checks candidate identifiers from the target (the @scope, then each leading
 // path segment) against the normalized repo labels, skipping self-matches.
-func importProvider(target, consumer string, normToLabel map[string]string) string {
+//
+// ownDirs is the consumer repo's own top-level source directories. A target rooted
+// at one of them is an intra-repo file/module reference whose interior path
+// segments may coincide with another repo's short label (e.g. a "com/acme/app/…"
+// package path vs a backend repo labeled "acme"), so it is skipped before any
+// candidate matching — this is what keeps a repo's own files from fabricating a
+// cross-repo edge, while still allowing genuine deep import paths (e.g. a Go
+// "github.com/org/repo/pkg", whose leading "github.com" is not a source dir).
+func importProvider(target, consumer string, normToLabel map[string]string, ownDirs map[string]bool) string {
 	target = strings.TrimSpace(target)
 	// Skip relative / absolute filesystem imports — they are intra-repo.
 	if target == "" || strings.HasPrefix(target, ".") || strings.HasPrefix(target, "/") {
 		return ""
+	}
+	if head := leadingSegment(target); head != "" && ownDirs[normalizeLabel(head)] {
+		return "" // intra-repo self-reference, not a cross-repo dependency
 	}
 	for _, cand := range importCandidates(target) {
 		if label, ok := normToLabel[normalizeLabel(cand)]; ok && label != consumer {
@@ -458,6 +471,39 @@ func importProvider(target, consumer string, normToLabel map[string]string) stri
 		}
 	}
 	return ""
+}
+
+// leadingSegment returns the first non-empty path segment of an import target or
+// module name, ignoring a leading "@" scope marker (so "@app-web/lib" -> "app-web",
+// "com/acme/app" -> "com", "acme" -> "acme").
+func leadingSegment(target string) string {
+	for _, p := range strings.Split(strings.TrimPrefix(target, "@"), "/") {
+		if p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+// repoTopDirs returns, per repo, the set of normalized leading path segments of
+// its module names — the repo's own top-level source roots. importProvider uses it
+// to recognize an import target as an intra-repo reference.
+func repoTopDirs(all []facts.Fact) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, f := range all {
+		if f.Kind != facts.KindModule || f.Repo == "" {
+			continue
+		}
+		head := leadingSegment(f.Name)
+		if head == "" {
+			continue
+		}
+		if out[f.Repo] == nil {
+			out[f.Repo] = map[string]bool{}
+		}
+		out[f.Repo][normalizeLabel(head)] = true
+	}
+	return out
 }
 
 // importCandidates extracts the identifier tokens an import target may name a
@@ -501,6 +547,7 @@ var genericTypeNames = map[string]bool{
 // dependency), so qualifying pairs get a bidirectional pair of edges.
 func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 	repoModules := moduleNamesByRepo(all)
+	repoLang := primaryLanguageByRepo(all)
 
 	// identity -> set of repos that declare a type with that identity.
 	idToRepos := map[string]map[string]bool{}
@@ -518,13 +565,21 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 		idToRepos[id][f.Repo] = true
 	}
 
-	// For each identity shared by 2+ repos, record it against every repo pair.
+	// For each identity shared by 2+ repos, record it against every repo pair — but
+	// only when the shared identity is a trustworthy coupling signal for that pair.
+	// A namespace-qualified identity (contains "::"/".", the mark of vendored/shared
+	// source) always counts, language-independent. A bare unqualified name counts
+	// only between same-language repos: two apps written in different languages
+	// sharing a plain domain type name (e.g. Kotlin and Swift both declaring
+	// "LoginViewModel") is parallel modeling of the same product, not shared code,
+	// and must not fabricate a dependency.
 	// pairShared["a\x00b"] (a<b) -> set of shared identities.
 	pairShared := map[string]map[string]bool{}
 	for id, repos := range idToRepos {
 		if len(repos) < 2 {
 			continue
 		}
+		qualified := isQualifiedIdentity(id)
 		rs := make([]string, 0, len(repos))
 		for r := range repos {
 			rs = append(rs, r)
@@ -532,6 +587,9 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 		sort.Strings(rs)
 		for i := 0; i < len(rs); i++ {
 			for j := i + 1; j < len(rs); j++ {
+				if !qualified && repoLang[rs[i]] != repoLang[rs[j]] {
+					continue
+				}
 				key := rs[i] + "\x00" + rs[j]
 				if pairShared[key] == nil {
 					pairShared[key] = map[string]bool{}
@@ -612,13 +670,53 @@ func isDistinctiveIdentity(id string) bool {
 	if id == "" {
 		return false
 	}
-	if strings.Contains(id, "::") || strings.Contains(id, ".") {
+	if isQualifiedIdentity(id) {
 		return true
 	}
 	if len(id) < 5 {
 		return false
 	}
 	return !genericTypeNames[strings.ToLower(id)]
+}
+
+// isQualifiedIdentity reports whether a type identity is namespace-qualified
+// (contains "::" or "."). A qualified identity shared across repos is a strong
+// vendored/shared-source signal, independent of language; an unqualified one is a
+// bare type name that two repos may coincidentally share.
+func isQualifiedIdentity(id string) bool {
+	return strings.Contains(id, "::") || strings.Contains(id, ".")
+}
+
+// primaryLanguageByRepo returns each repo's dominant source language (the most
+// common `language` prop across its facts), or "" when unknown. Used to gate
+// unqualified shared-symbol links to same-language repo pairs, so two apps in
+// different languages sharing a plain domain type name are not linked.
+func primaryLanguageByRepo(all []facts.Fact) map[string]string {
+	counts := map[string]map[string]int{}
+	for _, f := range all {
+		if f.Repo == "" {
+			continue
+		}
+		lang := propString(f, "language")
+		if lang == "" {
+			continue
+		}
+		if counts[f.Repo] == nil {
+			counts[f.Repo] = map[string]int{}
+		}
+		counts[f.Repo][lang]++
+	}
+	out := map[string]string{}
+	for repo, langs := range counts {
+		best, bestN := "", -1
+		for l, n := range langs {
+			if n > bestN || (n == bestN && l < best) {
+				best, bestN = l, n
+			}
+		}
+		out[repo] = best
+	}
+	return out
 }
 
 // --- materialization ---
@@ -761,7 +859,9 @@ func propString(f facts.Fact, key string) string {
 func normalizeMethod(m string) string {
 	m = strings.ToUpper(strings.TrimSpace(m))
 	switch m {
-	case "", "USE", "ALL", "MIDDLEWARE":
+	case "", "USE", "ALL", "MIDDLEWARE", "DRAW":
+		// DRAW is a Rails route-delegation placeholder (config/routes.rb draw(:pkg)),
+		// not a real HTTP method — inert for matching and unused-route flagging.
 		return ""
 	}
 	return m
@@ -769,9 +869,28 @@ func normalizeMethod(m string) string {
 
 func routeKey(normPath, method string) string { return normPath + "|" + method }
 
-// normalizePath trims a trailing slash and collapses path parameters in any
+// formatExtensions are response-format suffixes a client may append to a path
+// (Rails renders these as an optional ".:format" that never appears in the route
+// path) — so they must be stripped before comparing a client call to a server route.
+var formatExtensions = []string{".json", ".xml"}
+
+// stripFormatExtension removes a trailing response-format extension from a single
+// path segment: "orders.json" -> "orders", "{id}.json" -> "{id}" (so the later
+// {}-collapse still fires). Only the known format suffixes are stripped, so a
+// version-like segment ("v2.5") or a real dotted name is left intact.
+func stripFormatExtension(seg string) string {
+	for _, ext := range formatExtensions {
+		if len(seg) > len(ext) && strings.HasSuffix(seg, ext) {
+			return seg[:len(seg)-len(ext)]
+		}
+	}
+	return seg
+}
+
+// normalizePath trims a trailing slash, strips a trailing response-format extension
+// (.json/.xml) from the final segment, and collapses path parameters in any
 // framework syntax ({id}, :id, <id>) to a single "{}" placeholder, so a client
-// path matches the server path it calls regardless of param naming.
+// path matches the server path it calls regardless of param naming or format suffix.
 func normalizePath(p string) string {
 	p = strings.TrimSpace(p)
 	if p == "" {
@@ -781,6 +900,12 @@ func normalizePath(p string) string {
 		p = strings.TrimRight(p, "/")
 	}
 	segs := strings.Split(p, "/")
+	// Strip a format extension from the final segment before param collapse, so a
+	// client call "/devices/{id}.json" normalizes to the same "/devices/{}" the
+	// server route "/devices/:id" produces.
+	if n := len(segs); n > 0 {
+		segs[n-1] = stripFormatExtension(segs[n-1])
+	}
 	for i, s := range segs {
 		switch {
 		case strings.HasPrefix(s, ":"):

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -122,6 +122,12 @@ func TestNormalizePath(t *testing.T) {
 		"/api/items":              "/api/items",
 		"/":                       "/",
 		"/users/{uid}/pets/{pid}": "/users/{}/pets/{}",
+		// Response-format suffix stripped from the final segment (Rails ".:format").
+		"/v2/devices/{id}.json": "/v2/devices/{}",
+		"/v2/bookmarks.json":    "/v2/bookmarks",
+		"/v2/report.xml":        "/v2/report",
+		// A version-like or genuinely dotted segment is not a format suffix.
+		"/api/v2.5/items": "/api/v2.5/items",
 	}
 	for in, want := range cases {
 		if got := normalizePath(in); got != want {
@@ -223,6 +229,19 @@ func TestComputeLinks_HTTPNextjsDynamicSegment(t *testing.T) {
 	}
 	if !hasServiceEdge(ComputeLinks(in), "svc-alpha", "svc-beta") {
 		t.Errorf("Next.js [id] server segment did not match client {} placeholder")
+	}
+}
+
+// TestComputeLinks_HTTPFormatSuffixMatch checks that a client calling a
+// ".json"-suffixed path (Retrofit/redux-tools/URLSession idiom) resolves to the
+// backend route served without the format suffix.
+func TestComputeLinks_HTTPFormatSuffixMatch(t *testing.T) {
+	in := []facts.Fact{
+		clientRoute("android", "v2/devices/{id}.json", "DELETE", nil),
+		serverRoute("golf", "/devices/:id", "DELETE"),
+	}
+	if !hasServiceEdge(ComputeLinks(in), "android", "golf") {
+		t.Errorf("client .json path did not match server route without the suffix")
 	}
 }
 
@@ -353,6 +372,47 @@ func TestComputeLinks_ImportRelativeAndSelfIgnored(t *testing.T) {
 	}
 	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
 		t.Errorf("relative/self imports produced edges: %+v", edges)
+	}
+}
+
+// TestComputeLinks_ImportIntraRepoNamespaceSkipped guards the reverse-DNS false
+// positive: a consumer's own file whose path embeds another repo's short label as
+// an interior namespace segment (e.g. "de/backend/app/..." in an app whose top-level
+// source dir is "app", vs a backend repo "backend") must NOT fabricate an import
+// edge, while a genuine deep cross-repo path still links.
+func TestComputeLinks_ImportIntraRepoNamespaceSkipped(t *testing.T) {
+	in := []facts.Fact{
+		// consumer "mobile" declares a top-level "app" source dir and imports its own
+		// file whose path contains the interior segment "backend".
+		module("mobile", "app/src/main/java/de/backend/app/ui"),
+		importDep("mobile", "app/src/main/java/de/backend/app/ui/Screen"),
+		// a real backend repo happens to be labeled "backend".
+		serverRoute("backend", "/api/items/{id}", "GET"),
+		// a genuine deep cross-repo import still resolves (leading seg not a mobile dir).
+		importDep("mobile", "github.com/x/go-auth/adapters"),
+		module("go-auth", "adapters"),
+	}
+	out := ComputeLinks(in)
+	if findEdge(out, "mobile", "backend") != nil {
+		t.Errorf("intra-repo namespace path must not link to a same-named repo; got edge to backend")
+	}
+	if findEdge(out, "mobile", "go-auth") == nil {
+		t.Errorf("a genuine deep cross-repo import should still resolve to go-auth")
+	}
+}
+
+// TestComputeLinks_ImportSelfNamedTargetSkipped covers an app whose own module is
+// named the same short token as a backend repo (e.g. a mobile app target "acme"
+// alongside a backend repo also labeled "acme"): importing it is intra-repo, not a
+// call to the backend.
+func TestComputeLinks_ImportSelfNamedTargetSkipped(t *testing.T) {
+	in := []facts.Fact{
+		module("app-ios", "acme"), // the app's own target module
+		importDep("app-ios", "acme"),
+		serverRoute("acme", "/api/items/{id}", "GET"),
+	}
+	if findEdge(ComputeLinks(in), "app-ios", "acme") != nil {
+		t.Errorf("importing the app's own same-named module must not link to the backend repo")
 	}
 }
 
@@ -561,6 +621,70 @@ func TestComputeLinks_SharedSymbolsNonTypesIgnored(t *testing.T) {
 	}
 	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
 		t.Errorf("shared non-type symbols should not link: %+v", edges)
+	}
+}
+
+func typeSymLang(repo, name, kind, lang string) facts.Fact {
+	f := typeSym(repo, name, kind)
+	f.Props["language"] = lang
+	return f
+}
+
+// TestComputeLinks_SharedSymbolsCrossLanguageUnqualifiedSkipped covers the parallel-
+// app false positive: two apps in different languages declaring the same plain
+// domain type names (e.g. Kotlin and Swift both defining LoginViewModel/FeedItem/
+// AccountViewModel) are modeling the same product, not sharing code — no link.
+func TestComputeLinks_SharedSymbolsCrossLanguageUnqualifiedSkipped(t *testing.T) {
+	in := []facts.Fact{
+		module("android", "app"),
+		typeSymLang("android", "app.LoginViewModel", facts.SymbolClass, "kotlin"),
+		typeSymLang("android", "app.FeedItem", facts.SymbolClass, "kotlin"),
+		typeSymLang("android", "app.AccountViewModel", facts.SymbolClass, "kotlin"),
+		module("ios", "Sources"),
+		typeSymLang("ios", "Sources.LoginViewModel", facts.SymbolClass, "swift"),
+		typeSymLang("ios", "Sources.FeedItem", facts.SymbolClass, "swift"),
+		typeSymLang("ios", "Sources.AccountViewModel", facts.SymbolClass, "swift"),
+	}
+	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+		t.Errorf("unqualified domain types shared across languages must not link: %+v", edges)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsSameLanguageUnqualifiedLinks confirms the fix does
+// not over-reach: enough unqualified types shared between SAME-language repos still
+// link (genuine copied source).
+func TestComputeLinks_SharedSymbolsSameLanguageUnqualifiedLinks(t *testing.T) {
+	in := []facts.Fact{
+		module("svc-a", "core"),
+		typeSymLang("svc-a", "core.WidgetRegistry", facts.SymbolClass, "go"),
+		typeSymLang("svc-a", "core.PaymentLedger", facts.SymbolClass, "go"),
+		typeSymLang("svc-a", "core.RetryPolicy", facts.SymbolClass, "go"),
+		module("svc-b", "lib"),
+		typeSymLang("svc-b", "lib.WidgetRegistry", facts.SymbolClass, "go"),
+		typeSymLang("svc-b", "lib.PaymentLedger", facts.SymbolClass, "go"),
+		typeSymLang("svc-b", "lib.RetryPolicy", facts.SymbolClass, "go"),
+	}
+	if findEdge(ComputeLinks(in), "svc-a", "svc-b") == nil {
+		t.Errorf("same-language repos sharing distinctive types should still link")
+	}
+}
+
+// TestComputeLinks_SharedSymbolsQualifiedCrossLanguageLinks confirms a namespace-
+// qualified identity (the vendored/shared-source signal) links regardless of the
+// per-repo dominant language.
+func TestComputeLinks_SharedSymbolsQualifiedCrossLanguageLinks(t *testing.T) {
+	in := []facts.Fact{
+		module("repo-a", "src"),
+		typeSymLang("repo-a", "src.onelab::clientA", facts.SymbolClass, "cpp"),
+		typeSymLang("repo-a", "src.onelab::clientB", facts.SymbolClass, "cpp"),
+		typeSymLang("repo-a", "src.onelab::clientC", facts.SymbolClass, "cpp"),
+		module("repo-b", "vendor"),
+		typeSymLang("repo-b", "vendor.onelab::clientA", facts.SymbolClass, "c"),
+		typeSymLang("repo-b", "vendor.onelab::clientB", facts.SymbolClass, "c"),
+		typeSymLang("repo-b", "vendor.onelab::clientC", facts.SymbolClass, "c"),
+	}
+	if findEdge(ComputeLinks(in), "repo-a", "repo-b") == nil {
+		t.Errorf("qualified shared identities should link even across languages")
 	}
 }
 


### PR DESCRIPTION
…tch, Swift endpoint enums with prefix resolution, Rails draw() scope prefixes) and remove import/shared-symbol false positives