### PR TITLE
fix(explainers): fix 7 correctness/determinism bugs and harden test c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ enola --explain /path/to/repo
 
 Every finding carries a confidence score, and it means something exact: `1.0` is a structural fact (a cycle exists; an export ratio measured), while anything below is a flagged heuristic for you to review (a god class is a statistical fan-in outlier, not a rule). The analyses are computed by graph algorithms — Tarjan's SCC for cycles, longest-path for dependency depth, mean+2σ outlier tests for the rest — so the same commit yields the same report.
 
-Here's the actual report for [Apache Airflow](https://github.com/apache/airflow) — a large polyglot codebase (Python, Java, TypeScript, and OpenAPI specs) analyzed in a single pass, 112,792 facts in ~3.5s (extraction parses files in parallel across cores; timing measured on a 16-core machine):
+Here's the actual report for [Apache Airflow](https://github.com/apache/airflow) — a large polyglot codebase (Python, Java, TypeScript, gRPC, and OpenAPI specs) analyzed in a single pass, 122,772 facts in ~2s (extraction parses files in parallel across cores):
 
 ```
 ════════════════════════════════════════════════════════════
@@ -323,87 +323,89 @@ Here's the actual report for [Apache Airflow](https://github.com/apache/airflow)
 ════════════════════════════════════════════════════════════
 
 Overview
-  Generated:           2026-06-24T11:28:08Z
-  Analysis time:       3.522345875s
-  Languages:           java, openapi, python, typescript
-  Total facts:         112792
+  Generated:           2026-07-07T20:51:51Z
+  Analysis time:       2.100326959s
+  Languages:           python, typescript, java, grpc
+  Total facts:         122772
 
 Architectural kinds
-  module                   2492
-  symbol                  64192
-  route                    6359
+  module                   2499
+  symbol                  64148
+  route                    6426
   storage                    64
-  dependency              39685
+  dependency              44371
 
 Symbol breakdown
-  method                  41127
-  function                12371
-  class                    8621
+  method                  40976
+  function                12409
+  class                    8583
   type                     1393
-  variable                  636
-  interface                  36
+  variable                  732
+  interface                  37
+  struct                     10
   enum                        6
   constant                    2
 
 API & data surface
-  routes                   6359
-    (unspecified)          6182
-    GET                     105
-    POST                     28
-    PATCH                    22
-    DELETE                   16
-    PUT                       6
+  routes                   6426
+    PATCH                  6038
+    GET                     247
+    POST                     74
+    DELETE                   46
+    PUT                      20
+    HEAD                      1
   storage                    64
 
 Dependencies
-  internal                17810
-  stdlib                  12430
-  external                 9445
+  internal                20905
+  stdlib                  12858
+  external                10607
+  unclassified                1
 
 Architecture
   Pattern:             (none detected)
-  cyclic dependencies        26
+  cyclic dependencies        27
   layer violations            0
 
 Impact analysis (hotspots)
-  coupled modules           840
-    high criticality        486
-    medium criticality      354
+  coupled modules           915
+    high criticality        547
+    medium criticality      368
   Top hotspots (by coupling):
     module                            fan-in  fan-out crit     blast radius
-    airflow-core/src/airflow/models     1396      315 high     56732
-    devel-common/src/tests_common/t…    1450       85 high     35780
-    providers/common/compat/src/air…    1214        1 high     51068
-    airflow-core/src/airflow/utils      1029       69 high     62870
-    airflow-core/src/airflow             871       39 high     67265
-    providers/common/compat/tests/u…     690        0 high     61945
-    providers/google/src/airflow/pr…     323      284 high     14305
-    providers/amazon/tests/system/a…       1      510 high     177
+    airflow-core/src/airflow/models     1661      380 high     66716
+    devel-common/src/tests_common/t…    1496      161 high     39422
+    providers/common/compat/src/air…    1295        2 high     59376
+    airflow-core/src/airflow/utils      1124      132 high     68653
+    airflow-core/src/airflow            1172       71 high     71697
+    providers/common/compat/tests/u…     776        0 high     65589
+    providers/google/src/airflow/pr…     327      329 high     14701
+    task-sdk/src/airflow/sdk             591       15 high     64026
 
 Code health
-  god classes (high fan-in)    298
-    airflow-core/src/airflow/ui/openapi-gen/req… 153 dependents
-    airflow-ctl/tests/airflow_ctl/api/test_oper… 79 dependents
-    providers/cncf/kubernetes/tests/unit/cncf/k… 71 dependents
-    airflow-core/tests/unit/ti_deps/deps/test_t… 49 dependents
-    providers/hashicorp/tests/unit/hashicorp/ho… 45 dependents
-  call-graph hotspots       133
-    airflow-core/src/airflow/ui/openapi-gen/req… fan-in 153 / out 12
-    providers/cncf/kubernetes/tests/unit/cncf/k… fan-in 71 / out 6
-    providers/openlineage/tests/unit/openlineag… fan-in 3 / out 21
-    providers/edge3/src/airflow/providers/edge3… fan-in 3 / out 3
-    providers/google/src/airflow/providers/goog… fan-in 10 / out 18
+  god classes (high fan-in)    254
+    chart/tests/chart_utils/helm_template_gener… 1193 dependents
+    devel-common/src/tests_common/test_utils/co… 557 dependents
+    devel-common/src/tests_common/test_utils/sy… 476 dependents
+    dev/breeze/src/airflow_breeze/utils/console… 376 dependents
+    airflow-core/src/airflow/utils/session.crea… 288 dependents
+  call-graph hotspots       152
+    chart/tests/chart_utils/helm_template_gener… fan-in 1193 / out 7
+    devel-common/src/tests_common/test_utils/co… fan-in 557 / out 10
+    task-sdk/src/airflow/sdk/execution_time/tas… fan-in 101 / out 37
+    airflow-core/src/airflow/utils/session.crea… fan-in 288 / out 6
+    dev/breeze/src/airflow_breeze/utils/run_uti… fan-in 179 / out 9
   deep dependency chains     10
-    airflow-core/tests/unit/api_fastapi/core_ap… depth 57
-    airflow-core/tests/unit/api_fastapi/core_ap… depth 56
-    airflow-core/tests/unit/assets               depth 56
-    airflow-core/tests/unit/jobs                 depth 56
-    providers/fab/tests/unit/fab/plugins         depth 56
+    chart/docs                                   depth 196
+    dev/breeze/tests                             depth 196
+    dev/breeze/tests/integration_tests           depth 196
+    scripts/tools                                depth 196
+    airflow-core/tests/unit/api_fastapi/core_ap… depth 195
   large public surfaces      20
-    airflow-core/src/airflow/ui/openapi-gen/req… 911/911 (100%)
     airflow-core/src/airflow/ui/openapi-gen/que… 864/864 (100%)
+    airflow-core/src/airflow/ui/openapi-gen/req… 720/720 (100%)
     task-sdk/src/airflow/sdk/execution_time/com… 119/129 (92%)
-    providers/edge3/src/airflow/providers/edge3… 3/3 (100%)
+    providers/edge3/src/airflow/providers/edge3… 100/100 (100%)
     task-sdk/src/airflow/sdk/definitions/mapped… 100/111 (90%)
   complexity outliers        15
     airflow-core/src/airflow/jobs/scheduler_job… complexity 69

--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -6,6 +6,7 @@ package common
 
 import (
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -160,4 +161,79 @@ func MeanStdDev(values []float64) (mean, std float64) {
 func OutlierThreshold(values []float64, k float64) float64 {
 	mean, std := MeanStdDev(values)
 	return mean + k*std
+}
+
+// StronglyConnectedComponents returns the strongly-connected components of a
+// directed graph (adjacency list: node -> successors) using Tarjan's algorithm.
+//
+// The result is deterministic regardless of Go's randomized map iteration: nodes
+// are visited in sorted order with sorted neighbor lists, each component's members
+// are sorted, and the component list is ordered by each component's smallest
+// member. Every key of graph appears in exactly one component (a node that appears
+// only as a neighbor is included as its own singleton). Shared by the cycles and
+// dependency-depth explainers, which both need a cycle-safe view of the module
+// graph — factoring it here keeps a single, tested implementation.
+func StronglyConnectedComponents(graph map[string][]string) [][]string {
+	nodes := make([]string, 0, len(graph))
+	for v := range graph {
+		nodes = append(nodes, v)
+	}
+	sort.Strings(nodes)
+
+	var (
+		index    int
+		stack    []string
+		onStack  = make(map[string]bool)
+		indices  = make(map[string]int)
+		lowlinks = make(map[string]int)
+		sccs     [][]string
+	)
+
+	var strongConnect func(v string)
+	strongConnect = func(v string) {
+		indices[v] = index
+		lowlinks[v] = index
+		index++
+		stack = append(stack, v)
+		onStack[v] = true
+
+		neighbors := append([]string(nil), graph[v]...)
+		sort.Strings(neighbors)
+		for _, w := range neighbors {
+			if _, visited := indices[w]; !visited {
+				strongConnect(w)
+				if lowlinks[w] < lowlinks[v] {
+					lowlinks[v] = lowlinks[w]
+				}
+			} else if onStack[w] {
+				if indices[w] < lowlinks[v] {
+					lowlinks[v] = indices[w]
+				}
+			}
+		}
+
+		if lowlinks[v] == indices[v] {
+			var scc []string
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				scc = append(scc, w)
+				if w == v {
+					break
+				}
+			}
+			sort.Strings(scc)
+			sccs = append(sccs, scc)
+		}
+	}
+
+	for _, v := range nodes {
+		if _, visited := indices[v]; !visited {
+			strongConnect(v)
+		}
+	}
+
+	sort.Slice(sccs, func(i, j int) bool { return sccs[i][0] < sccs[j][0] })
+	return sccs
 }

--- a/internal/explainers/common/common_test.go
+++ b/internal/explainers/common/common_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -146,5 +147,89 @@ func TestMeanStdDev(t *testing.T) {
 	}
 	if got := OutlierThreshold(vals, 2); math.Abs(got-9) > 1e-9 {
 		t.Errorf("OutlierThreshold(vals, 2) = %v, want 9", got)
+	}
+}
+
+// TestOutlierThreshold_ZeroStdDev: with identical values the std dev is 0, so the
+// threshold equals the mean — every value is <= it, so nothing is a strict
+// outlier (why an all-equal fan-in/complexity distribution flags nothing).
+func TestOutlierThreshold_ZeroStdDev(t *testing.T) {
+	vals := []float64{7, 7, 7, 7}
+	mean, std := MeanStdDev(vals)
+	if std != 0 {
+		t.Errorf("std of identical values = %v, want 0", std)
+	}
+	if got := OutlierThreshold(vals, 2); got != mean {
+		t.Errorf("OutlierThreshold(identical, 2) = %v, want mean %v", got, mean)
+	}
+}
+
+// sccKey renders a component partition as a stable string for comparison.
+func sccKey(sccs [][]string) string {
+	parts := make([]string, len(sccs))
+	for i, scc := range sccs {
+		parts[i] = strings.Join(scc, ",")
+	}
+	return strings.Join(parts, " | ")
+}
+
+func TestStronglyConnectedComponents(t *testing.T) {
+	tests := []struct {
+		name  string
+		graph map[string][]string
+		want  string // sccKey of the expected (sorted) partition
+	}{
+		{"empty", map[string][]string{}, ""},
+		{"single isolated", map[string][]string{"a": nil}, "a"},
+		{"simple cycle", map[string][]string{"b": {"a"}, "a": {"b"}}, "a,b"},
+		{"triangle + tail", map[string][]string{"a": {"b"}, "b": {"c"}, "c": {"a", "d"}, "d": nil}, "a,b,c | d"},
+		{"two disjoint cycles", map[string][]string{"a": {"b"}, "b": {"a"}, "c": {"d"}, "d": {"c"}}, "a,b | c,d"},
+		{"self loop is singleton", map[string][]string{"a": {"a"}}, "a"},
+		{"neighbor-only node included", map[string][]string{"a": {"b"}}, "a | b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sccKey(StronglyConnectedComponents(tt.graph)); got != tt.want {
+				t.Errorf("SCC(%v) = %q, want %q", tt.graph, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStronglyConnectedComponents_Deterministic: repeated calls re-range the
+// graph map (Go randomizes iteration), but the sorted output must be identical.
+func TestStronglyConnectedComponents_Deterministic(t *testing.T) {
+	graph := map[string][]string{
+		"a": {"b"}, "b": {"c"}, "c": {"a", "d"},
+		"d": {"e"}, "e": {"d"},
+		"f": {"a"}, "g": nil,
+	}
+	want := sccKey(StronglyConnectedComponents(graph))
+	for i := 0; i < 50; i++ {
+		if got := sccKey(StronglyConnectedComponents(graph)); got != want {
+			t.Fatalf("non-deterministic SCC output on iteration %d:\nwant %q\ngot  %q", i, want, got)
+		}
+	}
+}
+
+// TestBuildModuleGraph_ExcludesTestRole: modules tagged module_role=test are
+// dropped as both nodes and edge endpoints.
+func TestBuildModuleGraph_ExcludesTestRole(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{Kind: facts.KindModule, Name: "src/app"})
+	s.Add(facts.Fact{Kind: facts.KindModule, Name: "src/apptest",
+		Props: map[string]any{facts.PropModuleRole: facts.ModuleRoleTest}})
+	// app imports the test module and vice versa; the test edges must not appear.
+	s.Add(facts.Fact{Kind: facts.KindDependency, File: "src/app/f.go",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "src/apptest"}}})
+	s.Add(facts.Fact{Kind: facts.KindDependency, File: "src/apptest/f.go",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "src/app"}}})
+
+	graph := BuildModuleGraph(s)
+	if _, ok := graph["src/apptest"]; ok {
+		t.Error("test-role module should not be a graph node")
+	}
+	if len(graph["src/app"]) != 0 {
+		t.Errorf("edge to a test-role module should be dropped, got %v", graph["src/app"])
 	}
 }

--- a/internal/explainers/complexity/complexity_test.go
+++ b/internal/explainers/complexity/complexity_test.go
@@ -73,6 +73,96 @@ func TestExplain_BelowFloor(t *testing.T) {
 	}
 }
 
+// TestExplain_MinComplexityBoundary: a function at exactly minComplexity that is
+// also a statistical outlier is reported.
+func TestExplain_MinComplexityBoundary(t *testing.T) {
+	s := facts.NewStore()
+	for i := 0; i < 20; i++ {
+		s.Add(fn(fmt.Sprintf("pkg/x.simple%d", i), 2))
+	}
+	s.Add(fn("pkg/x.Edge", minComplexity)) // exactly the floor, and an outlier vs the 2s
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 || !strings.Contains(insights[0].Title, "pkg/x.Edge") {
+		t.Errorf("complexity == minComplexity (%d) outlier should be reported, got %+v", minComplexity, titlesOf(insights))
+	}
+}
+
+// TestExplain_Int64PropForm: intProp accepts the int64 shape too.
+func TestExplain_Int64PropForm(t *testing.T) {
+	s := facts.NewStore()
+	for i := 0; i < 20; i++ {
+		s.Add(fn(fmt.Sprintf("pkg/x.simple%d", i), int64(2)))
+	}
+	s.Add(fn("pkg/x.Monster", int64(30)))
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight with int64 props, got %d", len(insights))
+	}
+}
+
+// TestExplain_MissingSymbolKindCounted locks the documented behavior: a symbol
+// carrying cyclomatic but no symbol_kind is allowed through (so a missing prop
+// never silently drops a real function).
+func TestExplain_MissingSymbolKindCounted(t *testing.T) {
+	s := facts.NewStore()
+	for i := 0; i < 20; i++ {
+		s.Add(fn(fmt.Sprintf("pkg/x.simple%d", i), 2))
+	}
+	// No symbol_kind prop, but has cyclomatic.
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "pkg/x.NoKind", File: "pkg/x/f.go",
+		Props: map[string]any{"cyclomatic": 30}})
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 || !strings.Contains(insights[0].Title, "pkg/x.NoKind") {
+		t.Errorf("symbol with cyclomatic but no kind should be counted, got %+v", titlesOf(insights))
+	}
+}
+
+// TestExplain_CapsAtMaxInsightsMostComplexFirst: more outliers than the cap are
+// trimmed to maxInsights, deepest complexity first.
+func TestExplain_CapsAtMaxInsightsMostComplexFirst(t *testing.T) {
+	s := facts.NewStore()
+	// A large simple baseline keeps the mean+2σ threshold well below the outliers,
+	// so all 16 (> maxInsights) qualify and exercise the cap.
+	for i := 0; i < 200; i++ {
+		s.Add(fn(fmt.Sprintf("pkg/x.simple%d", i), 1))
+	}
+	// 16 distinct outliers with complexity 40..55.
+	for i := 0; i < 16; i++ {
+		s.Add(fn(fmt.Sprintf("pkg/x.M%02d", i), 40+i))
+	}
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != maxInsights {
+		t.Fatalf("expected output capped at %d, got %d", maxInsights, len(insights))
+	}
+	if !strings.Contains(insights[0].Title, "(55)") {
+		t.Errorf("most-complex (55) should rank first, got %q", insights[0].Title)
+	}
+}
+
+func titlesOf(ins []facts.Insight) []string {
+	out := make([]string, len(ins))
+	for i, in := range ins {
+		out[i] = in.Title
+	}
+	return out
+}
+
 func TestExplain_IgnoresNonCallable(t *testing.T) {
 	s := facts.NewStore()
 	for i := 0; i < 20; i++ {

--- a/internal/explainers/coverage/coverage_test.go
+++ b/internal/explainers/coverage/coverage_test.go
@@ -65,6 +65,66 @@ func TestExplain_DistinguishesGapFromPartial(t *testing.T) {
 	}
 }
 
+// TestExplain_JSONLRoundTripShape: a service reloaded from facts.jsonl carries
+// edge_coverage as []any of map[string]any with float64 numbers. readCoverage
+// must classify it identically to the in-memory []map[string]any/int form.
+func TestExplain_JSONLRoundTripShape(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(facts.Fact{Kind: facts.KindService, Name: "svc-gap", Repo: "svc-gap",
+		Props: map[string]any{"edge_coverage": []any{
+			map[string]any{"edge_type": "http_client", "detected": float64(5), "resolved": float64(0), "unresolved": float64(5)},
+		}}})
+
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight from JSONL-shape coverage, got %d", len(insights))
+	}
+	if !strings.HasPrefix(insights[0].Title, "Coverage gap") {
+		t.Errorf("JSONL-shape gap misclassified: %q", insights[0].Title)
+	}
+	if insights[0].Confidence != 0.9 {
+		t.Errorf("gap confidence = %v, want 0.9", insights[0].Confidence)
+	}
+}
+
+// TestExplain_MultipleEdgeTypes: counts across edge types are summed, and the
+// service is a partial (not a gap) because it has a resolved outbound edge.
+func TestExplain_MultipleEdgeTypes(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(facts.Fact{Kind: facts.KindService, Name: "svc", Repo: "svc",
+		Relations: []facts.Relation{{Kind: facts.RelDependsOn, Target: "other"}},
+		Props: map[string]any{"edge_coverage": []map[string]any{
+			{"edge_type": "http_client", "detected": 4, "resolved": 3, "unresolved": 1},
+			{"edge_type": "grpc_client", "detected": 3, "resolved": 1, "unresolved": 2},
+		}}})
+
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	in := insights[0]
+	if !strings.HasPrefix(in.Title, "Partial coverage") {
+		t.Errorf("want partial coverage (has a resolved edge), got %q", in.Title)
+	}
+	// 1 + 2 = 3 unresolved across the two edge types.
+	if !strings.Contains(in.Title, "3 unresolved") {
+		t.Errorf("summed unresolved should be 3, got %q", in.Title)
+	}
+	if in.Confidence != 0.75 {
+		t.Errorf("partial confidence = %v, want 0.75", in.Confidence)
+	}
+	// Detail renders both edge types in stable insertion order.
+	if !strings.Contains(in.Description, "http_client") || !strings.Contains(in.Description, "grpc_client") {
+		t.Errorf("detail should mention both edge types: %q", in.Description)
+	}
+}
+
 func TestExplain_NoServicesNoInsights(t *testing.T) {
 	store := facts.NewStore()
 	store.Add(facts.Fact{Kind: facts.KindModule, Name: "internal/foo"})

--- a/internal/explainers/crossrepo/crossrepo.go
+++ b/internal/explainers/crossrepo/crossrepo.go
@@ -65,7 +65,7 @@ func (e *CrossRepoExplainer) Explain(ctx context.Context, store *facts.Store) ([
 // edgeDetail renders a short description of what justifies a cross-repo edge.
 func edgeDetail(d facts.Fact) string {
 	var parts []string
-	if v, ok := d.Props["via"].([]string); ok && len(v) > 0 {
+	if v := stringSlice(d.Props["via"]); len(v) > 0 {
 		parts = append(parts, "via "+strings.Join(v, "+"))
 	}
 	if n := propInt(d, "endpoint_count"); n > 0 {
@@ -81,6 +81,26 @@ func edgeDetail(d facts.Fact) string {
 		return "cross-repo dependency"
 	}
 	return strings.Join(parts, ", ")
+}
+
+// stringSlice reads a string-slice prop, tolerating both the in-memory []string
+// form and the []any form a JSON round-trip through facts.jsonl produces (JSON
+// arrays decode as []any, not []string) — the slice analog of propInt's float64
+// handling. Non-string elements are skipped.
+func stringSlice(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // propInt reads an int-valued prop, tolerating the float64 form that survives a

--- a/internal/explainers/crossrepo/crossrepo_test.go
+++ b/internal/explainers/crossrepo/crossrepo_test.go
@@ -2,6 +2,7 @@ package crossrepo
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -66,5 +67,74 @@ func TestPropInt_JSONRoundTripForm(t *testing.T) {
 	d := facts.Fact{Props: map[string]any{"endpoint_count": float64(5)}}
 	if got := propInt(d, "endpoint_count"); got != 5 {
 		t.Errorf("propInt(float64 5) = %d, want 5", got)
+	}
+}
+
+// TestExplain_ViaJSONLRoundTripForm guards BUG-4: a store reloaded from
+// facts.jsonl decodes the "via" array as []any, not []string. edgeDetail used to
+// type-assert []string only, so the "via ..." clause silently vanished on a
+// reloaded snapshot. Both int (float64) and slice ([]any) props must survive.
+func TestExplain_ViaJSONLRoundTripForm(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{
+		Kind: facts.KindDependency, Name: "svc-a -> svc-b", Repo: "svc-a",
+		Props: map[string]any{
+			"type": "cross_repo",
+			"via":  []any{"http", "import"}, // JSONL round-trip shape
+			// endpoint_count as float64, the JSON number shape.
+			"endpoint_count": float64(4),
+		},
+	})
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("insights = %d, want 1", len(insights))
+	}
+	desc := insights[0].Description
+	if !strings.Contains(desc, "via http+import") {
+		t.Errorf("description missing 'via http+import' (dropped on JSONL form): %q", desc)
+	}
+	if !strings.Contains(desc, "4 endpoint") {
+		t.Errorf("description missing '4 endpoint(s)' from float64 count: %q", desc)
+	}
+}
+
+// TestExplain_DeterministicSortedByName: edges added out of name order must be
+// reported sorted, so insights.json is stable.
+func TestExplain_DeterministicSortedByName(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(
+		facts.Fact{Kind: facts.KindDependency, Name: "z-svc -> y-svc", Props: map[string]any{"type": "cross_repo", "via": []string{"http"}}},
+		facts.Fact{Kind: facts.KindDependency, Name: "a-svc -> b-svc", Props: map[string]any{"type": "cross_repo", "via": []string{"http"}}},
+		facts.Fact{Kind: facts.KindDependency, Name: "m-svc -> n-svc", Props: map[string]any{"type": "cross_repo", "via": []string{"http"}}},
+	)
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	var order []string
+	for _, ev := range insights[0].Evidence {
+		order = append(order, ev.Fact)
+	}
+	want := []string{"a-svc -> b-svc", "m-svc -> n-svc", "z-svc -> y-svc"}
+	if !reflect.DeepEqual(order, want) {
+		t.Errorf("evidence order = %v, want sorted %v", order, want)
+	}
+}
+
+// TestExplain_AllZeroCountsFallback: a cross_repo edge with no via/counts falls
+// back to the generic "cross-repo dependency" detail rather than an empty string.
+func TestExplain_AllZeroCountsFallback(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{Kind: facts.KindDependency, Name: "svc-a -> svc-b", Props: map[string]any{"type": "cross_repo"}})
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if !strings.Contains(insights[0].Description, "cross-repo dependency") {
+		t.Errorf("expected generic fallback detail, got %q", insights[0].Description)
 	}
 }

--- a/internal/explainers/cycles/cycles.go
+++ b/internal/explainers/cycles/cycles.go
@@ -61,59 +61,11 @@ func (e *CycleExplainer) Explain(ctx context.Context, store *facts.Store) ([]fac
 	return insights, nil
 }
 
-// tarjanSCC implements Tarjan's strongly connected components algorithm.
+// tarjanSCC computes strongly connected components of the module graph. It
+// delegates to common.StronglyConnectedComponents, whose output is deterministic
+// (sorted components with sorted members) — so the emitted cycle path, evidence
+// order, and multi-cycle insight order no longer depend on Go's randomized map
+// iteration.
 func tarjanSCC(graph map[string][]string) [][]string {
-	var (
-		index    int
-		stack    []string
-		onStack  = make(map[string]bool)
-		indices  = make(map[string]int)
-		lowlinks = make(map[string]int)
-		sccs     [][]string
-	)
-
-	var strongConnect func(v string)
-	strongConnect = func(v string) {
-		indices[v] = index
-		lowlinks[v] = index
-		index++
-		stack = append(stack, v)
-		onStack[v] = true
-
-		for _, w := range graph[v] {
-			if _, visited := indices[w]; !visited {
-				strongConnect(w)
-				if lowlinks[w] < lowlinks[v] {
-					lowlinks[v] = lowlinks[w]
-				}
-			} else if onStack[w] {
-				if indices[w] < lowlinks[v] {
-					lowlinks[v] = indices[w]
-				}
-			}
-		}
-
-		// Root of an SCC
-		if lowlinks[v] == indices[v] {
-			var scc []string
-			for {
-				w := stack[len(stack)-1]
-				stack = stack[:len(stack)-1]
-				onStack[w] = false
-				scc = append(scc, w)
-				if w == v {
-					break
-				}
-			}
-			sccs = append(sccs, scc)
-		}
-	}
-
-	for v := range graph {
-		if _, visited := indices[v]; !visited {
-			strongConnect(v)
-		}
-	}
-
-	return sccs
+	return common.StronglyConnectedComponents(graph)
 }

--- a/internal/explainers/cycles/cycles_test.go
+++ b/internal/explainers/cycles/cycles_test.go
@@ -2,7 +2,9 @@ package cycles
 
 import (
 	"context"
+	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -197,6 +199,131 @@ func TestExplain_WithCycle(t *testing.T) {
 		if !evidenceModules[mod] {
 			t.Errorf("module %q missing from cycle evidence", mod)
 		}
+	}
+}
+
+// TestExplain_Deterministic guards BUG-2: the cycle path, evidence order, and
+// multi-cycle insight order used to depend on Go's randomized map iteration
+// (tarjanSCC ranged the graph map directly and never sorted). Each Explain call
+// re-ranges the maps, so 50 runs exercise many iteration orders; the fully
+// rendered output (title + description + evidence facts) must be byte-identical
+// every time — enola's core determinism promise for insights.json.
+func TestExplain_Deterministic(t *testing.T) {
+	store := makeStore(
+		[]string{"src/a", "src/b", "src/c", "src/d", "src/e", "src/f"},
+		map[string][]string{
+			"src/a": {"src/b"},
+			"src/b": {"src/c"},
+			"src/c": {"src/a"}, // cycle 1: a,b,c
+			"src/d": {"src/e"},
+			"src/e": {"src/f"},
+			"src/f": {"src/d"}, // cycle 2: d,e,f
+		},
+	)
+
+	render := func() string {
+		insights, err := New().Explain(context.Background(), store)
+		if err != nil {
+			t.Fatalf("Explain: %v", err)
+		}
+		var b strings.Builder
+		for _, in := range insights {
+			b.WriteString(in.Title)
+			b.WriteByte('\n')
+			b.WriteString(in.Description)
+			b.WriteByte('\n')
+			for _, ev := range in.Evidence {
+				b.WriteString(ev.Fact)
+				b.WriteByte(',')
+			}
+			b.WriteByte('\n')
+		}
+		return b.String()
+	}
+
+	want := render()
+	for i := 0; i < 50; i++ {
+		if got := render(); got != want {
+			t.Fatalf("non-deterministic output on iteration %d:\nwant:\n%s\ngot:\n%s", i, want, got)
+		}
+	}
+}
+
+// TestExplain_EvidenceCanonicalOrder locks that a cycle's evidence lists its
+// members in sorted order (the canonicalization behind the determinism fix).
+func TestExplain_EvidenceCanonicalOrder(t *testing.T) {
+	store := makeStore(
+		[]string{"src/c", "src/a", "src/b"},
+		map[string][]string{
+			"src/a": {"src/b"},
+			"src/b": {"src/c"},
+			"src/c": {"src/a"},
+		},
+	)
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	var got []string
+	for _, ev := range insights[0].Evidence {
+		got = append(got, ev.Fact)
+	}
+	want := []string{"src/a", "src/b", "src/c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("evidence order = %v, want sorted %v", got, want)
+	}
+}
+
+// TestExplain_SelfLoopNoInsight runs a self-importing module through the full
+// Explain (not just tarjanSCC): a size-1 SCC is not a cycle, so no insight and
+// no panic.
+func TestExplain_SelfLoopNoInsight(t *testing.T) {
+	store := makeStore(
+		[]string{"src/a"},
+		map[string][]string{"src/a": {"src/a"}},
+	)
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 0 {
+		t.Errorf("self-loop should produce no cycle insight, got %d", len(insights))
+	}
+}
+
+// TestExplain_SharedNodeSingleInsight: two cycles sharing a node collapse into
+// one SCC, so Explain emits a single insight covering all three modules.
+func TestExplain_SharedNodeSingleInsight(t *testing.T) {
+	store := makeStore(
+		[]string{"src/a", "src/b", "src/c"},
+		map[string][]string{
+			"src/a": {"src/b"},
+			"src/b": {"src/a", "src/c"},
+			"src/c": {"src/b"},
+		},
+	)
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight for two cycles sharing a node, got %d", len(insights))
+	}
+	if len(insights[0].Evidence) != 3 {
+		t.Errorf("expected all 3 modules as evidence, got %d", len(insights[0].Evidence))
+	}
+}
+
+func TestExplain_EmptyStore(t *testing.T) {
+	insights, err := New().Explain(context.Background(), facts.NewStore())
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 0 {
+		t.Errorf("empty store should yield no insights, got %d", len(insights))
 	}
 }
 

--- a/internal/explainers/depth/depth.go
+++ b/internal/explainers/depth/depth.go
@@ -36,43 +36,104 @@ func (e *DepthExplainer) Name() string {
 
 // Explain builds the module import graph and computes each module's longest
 // downstream dependency chain (cycle-safe), reporting the deepest ones.
+//
+// Cycles are handled by collapsing each strongly-connected component to a single
+// super-node (the condensation), which is a DAG, then taking the longest path by
+// module count over that DAG. A component contributes its full size to any chain
+// passing through it. This is an intentional over-approximation: the exact
+// longest *simple* path is NP-hard, and inside a cycle every member is mutually
+// reachable, so counting the whole component is a safe cycle-safe upper bound
+// that never double-counts a module. A module's reported depth is its component's
+// depth; one insight is emitted per component (keyed by its smallest member),
+// so a cycle yields a single finding rather than one per entangled module.
 func (e *DepthExplainer) Explain(ctx context.Context, store *facts.Store) ([]facts.Insight, error) {
 	graph := common.BuildModuleGraph(store)
 	if len(graph) == 0 {
 		return nil, nil
 	}
 
-	// Determinism: sort each neighbor list and the root iteration order so the
-	// memoized longest-path results don't depend on Go's randomized map
-	// iteration. Without this, cycles make the computed depths vary run to run.
-	roots := make([]string, 0, len(graph))
-	for mod := range graph {
-		roots = append(roots, mod)
-		sort.Strings(graph[mod])
+	// Condense the module graph into its SCC DAG. Components come back sorted
+	// (sorted members, ordered by smallest member) so the whole computation is
+	// deterministic regardless of Go's randomized map iteration.
+	sccs := common.StronglyConnectedComponents(graph)
+	sccOf := make(map[string]int, len(graph))
+	for i, scc := range sccs {
+		for _, m := range scc {
+			sccOf[m] = i
+		}
 	}
-	sort.Strings(roots)
 
-	memo := make(map[string][]string) // module -> deepest chain starting at module
-	visiting := make(map[string]bool)
-	for _, mod := range roots {
-		longestChain(mod, graph, memo, visiting)
+	// Build the condensed adjacency (successor component indices), deduped and
+	// sorted. Self-edges and intra-component edges are dropped — the condensation
+	// is acyclic by construction.
+	succ := make([][]int, len(sccs))
+	seen := make([]map[int]bool, len(sccs))
+	for i := range seen {
+		seen[i] = map[int]bool{}
+	}
+	for mod, neighbors := range graph {
+		si := sccOf[mod]
+		for _, n := range neighbors {
+			sj, ok := sccOf[n]
+			if !ok || sj == si {
+				continue
+			}
+			if !seen[si][sj] {
+				seen[si][sj] = true
+				succ[si] = append(succ[si], sj)
+			}
+		}
+	}
+	for i := range succ {
+		sort.Ints(succ[i])
+	}
+
+	// Longest path (by module count) over the DAG, memoized. Each component's
+	// depth is its own size plus the deepest successor chain; bestSucc lets us
+	// reconstruct a concrete chain of distinct modules for the evidence.
+	depth := make([]int, len(sccs))
+	bestSucc := make([]int, len(sccs))
+	computed := make([]bool, len(sccs))
+	for i := range bestSucc {
+		bestSucc[i] = -1
+	}
+	var compute func(i int) int
+	compute = func(i int) int {
+		if computed[i] {
+			return depth[i]
+		}
+		computed[i] = true // condensation is a DAG, so no cycle guard is needed
+		best, bi := 0, -1
+		for _, j := range succ[i] {
+			if d := compute(j); d > best {
+				best, bi = d, j
+			}
+		}
+		depth[i] = len(sccs[i]) + best
+		bestSucc[i] = bi
+		return depth[i]
+	}
+	for i := range sccs {
+		compute(i)
 	}
 
 	type result struct {
 		module string
+		depth  int
 		chain  []string
 	}
 	var results []result
-	for mod, chain := range memo {
-		if len(chain) >= minDepth {
-			results = append(results, result{module: mod, chain: chain})
+	for i, scc := range sccs {
+		if depth[i] < minDepth {
+			continue
 		}
+		results = append(results, result{module: scc[0], depth: depth[i], chain: chainFor(i, sccs, bestSucc)})
 	}
 
-	// Deepest first; break ties by name for determinism.
+	// Deepest first; break ties by module name for determinism.
 	sort.Slice(results, func(i, j int) bool {
-		if len(results[i].chain) != len(results[j].chain) {
-			return len(results[i].chain) > len(results[j].chain)
+		if results[i].depth != results[j].depth {
+			return results[i].depth > results[j].depth
 		}
 		return results[i].module < results[j].module
 	})
@@ -82,7 +143,6 @@ func (e *DepthExplainer) Explain(ctx context.Context, store *facts.Store) ([]fac
 		if i >= maxInsights {
 			break
 		}
-		depth := len(r.chain)
 		evidence := make([]facts.Evidence, 0, len(r.chain))
 		for _, m := range r.chain {
 			evidence = append(evidence, facts.Evidence{Fact: m})
@@ -90,12 +150,12 @@ func (e *DepthExplainer) Explain(ctx context.Context, store *facts.Store) ([]fac
 
 		insights = append(insights, facts.Insight{
 			// Title format is parsed by pkg/explain (Code health section); keep stable.
-			Title: fmt.Sprintf("Deep dependency chain: %s (depth %d)", r.module, depth),
+			Title: fmt.Sprintf("Deep dependency chain: %s (depth %d)", r.module, r.depth),
 			Description: fmt.Sprintf(
 				"Module %q has a longest dependency chain of %d modules: %s. "+
 					"Deep chains slow comprehension and widen rebuild/retest impact when a "+
 					"module near the bottom changes.",
-				r.module, depth, strings.Join(r.chain, " -> "),
+				r.module, r.depth, strings.Join(r.chain, " -> "),
 			),
 			Confidence: 0.7,
 			Evidence:   evidence,
@@ -110,35 +170,14 @@ func (e *DepthExplainer) Explain(ctx context.Context, store *facts.Store) ([]fac
 	return insights, nil
 }
 
-// longestChain returns the longest dependency chain starting at module, as a
-// slice beginning with module. Results are memoized. The visiting set breaks
-// cycles: a back-edge to a module already on the current path contributes no
-// further depth, so cyclic graphs terminate.
-func longestChain(module string, graph map[string][]string, memo map[string][]string, visiting map[string]bool) []string {
-	if chain, ok := memo[module]; ok {
-		return chain
+// chainFor reconstructs the deepest chain of distinct modules starting at
+// component i: all of i's (sorted) members, then the members of its best
+// successor component, and so on down the DAG.
+func chainFor(i int, sccs [][]string, bestSucc []int) []string {
+	var out []string
+	for i != -1 {
+		out = append(out, sccs[i]...)
+		i = bestSucc[i]
 	}
-	if visiting[module] {
-		// Cycle back-edge: the target is already on the current path, so
-		// following it would revisit a module. Contribute no further depth
-		// (returning the module here would double-count it up the chain).
-		return nil
-	}
-	visiting[module] = true
-
-	var best []string
-	for _, dep := range graph[module] {
-		if dep == module {
-			continue // self-import; ignore
-		}
-		child := longestChain(dep, graph, memo, visiting)
-		if len(child) > len(best) {
-			best = child
-		}
-	}
-
-	visiting[module] = false
-	chain := append([]string{module}, best...)
-	memo[module] = chain
-	return chain
+	return out
 }

--- a/internal/explainers/depth/depth_test.go
+++ b/internal/explainers/depth/depth_test.go
@@ -128,6 +128,111 @@ func TestExplain_CycleDoesNotInflateDepth(t *testing.T) {
 	}
 }
 
+// TestExplain_CycleUnderCountRegression guards BUG-3: the old memoized
+// longestChain cached a node's depth even when it was truncated by the cycle
+// back-edge cut, then reused that truncated value globally. In this graph
+// (m/a<->m/b cycle, tail m/c->m/d->m/e, feeder m/r->m/b) computing m/a first
+// memoized m/b at depth 1, so m/r's true depth-6 chain (r->b->a->c->d->e) was
+// never reported. The SCC-condensation rewrite reports it correctly.
+func TestExplain_CycleUnderCountRegression(t *testing.T) {
+	store := makeStore(
+		[]string{"m/a", "m/b", "m/c", "m/d", "m/e", "m/r"},
+		map[string][]string{
+			"m/a": {"m/b", "m/c"},
+			"m/b": {"m/a"},
+			"m/c": {"m/d"},
+			"m/d": {"m/e"},
+			"m/r": {"m/b"},
+		},
+	)
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+
+	byModule := map[string]facts.Insight{}
+	for _, in := range insights {
+		for _, m := range []string{"m/r", "m/a"} {
+			if strings.Contains(in.Title, m+" (") {
+				byModule[m] = in
+			}
+		}
+	}
+
+	rIn, ok := byModule["m/r"]
+	if !ok {
+		t.Fatalf("m/r (true depth 6) was not reported — under-count regression; got %+v", titles(insights))
+	}
+	if !strings.Contains(rIn.Title, "depth 6") {
+		t.Errorf("m/r should be reported at depth 6, got title %q", rIn.Title)
+	}
+	if len(rIn.Evidence) != 6 {
+		t.Errorf("m/r chain should span 6 distinct modules, got %d", len(rIn.Evidence))
+	}
+	seen := map[string]bool{}
+	for _, ev := range rIn.Evidence {
+		if seen[ev.Fact] {
+			t.Errorf("chain double-counts %q", ev.Fact)
+		}
+		seen[ev.Fact] = true
+	}
+	// The cycle members m/a and m/b share a depth of 5 (>= minDepth) and must be
+	// reported too — as a single component insight keyed on the smallest member.
+	if _, ok := byModule["m/a"]; !ok {
+		t.Errorf("cycle component (m/a) at depth 5 should be reported; got %v", titles(insights))
+	}
+}
+
+func titles(ins []facts.Insight) []string {
+	out := make([]string, len(ins))
+	for i, in := range ins {
+		out[i] = in.Title
+	}
+	return out
+}
+
+func TestExplain_CapsAtMaxInsights(t *testing.T) {
+	// A single long chain: a/m0..a/m15. Modules a/m0..a/m11 have depth >= minDepth
+	// (5), i.e. 12 qualifying modules — more than the cap of 10.
+	mods, deps := chain(16)
+	insights, err := New().Explain(context.Background(), makeStore(mods, deps))
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != maxInsights {
+		t.Fatalf("expected output capped at %d, got %d", maxInsights, len(insights))
+	}
+	if !strings.Contains(insights[0].Title, "a/m0 (") || !strings.Contains(insights[0].Title, "depth 16") {
+		t.Errorf("deepest module a/m0 (depth 16) should rank first, got %q", insights[0].Title)
+	}
+}
+
+func TestExplain_SelfImportDoesNotAddDepth(t *testing.T) {
+	// a/m0 imports itself and a/m1; the self-import must not inflate its depth.
+	mods, deps := chain(5)
+	deps["a/m0"] = append(deps["a/m0"], "a/m0")
+	insights, err := New().Explain(context.Background(), makeStore(mods, deps))
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	if !strings.Contains(insights[0].Title, "depth 5") {
+		t.Errorf("self-import should not add depth; want depth 5, got %q", insights[0].Title)
+	}
+}
+
+func TestExplain_EmptyGraph(t *testing.T) {
+	insights, err := New().Explain(context.Background(), facts.NewStore())
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 0 {
+		t.Errorf("empty store should yield no insights, got %d", len(insights))
+	}
+}
+
 // TestExplain_Deterministic guards against the regression where cycle handling
 // depended on Go's randomized map iteration order. Each Explain call re-ranges
 // the graph map, so repeated calls exercise different iteration orders; the

--- a/internal/explainers/godclass/godclass_test.go
+++ b/internal/explainers/godclass/godclass_test.go
@@ -89,3 +89,95 @@ func TestExplain_BelowFloor(t *testing.T) {
 		t.Errorf("expected 0 insights below fan-in floor, got %d", len(insights))
 	}
 }
+
+// TestExplain_FloorBoundary: a hub with exactly minFanIn (8) dependents amid
+// low-fan-in noise is reported (it clears both the floor and the outlier test);
+// one with 7 is below the floor and silent.
+func TestExplain_FloorBoundary(t *testing.T) {
+	at := makeStore("core.Hub", manyCallers(minFanIn), []string{"leaf.A", "leaf.B", "leaf.C"})
+	got, err := New().Explain(context.Background(), at)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("fan-in == minFanIn (%d) should be reported, got %d insights", minFanIn, len(got))
+	}
+
+	below := makeStore("core.Hub", manyCallers(minFanIn-1), []string{"leaf.A", "leaf.B", "leaf.C"})
+	got, err = New().Explain(context.Background(), below)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("fan-in == minFanIn-1 (%d) is below the floor, want 0 insights, got %d", minFanIn-1, len(got))
+	}
+}
+
+// TestExplain_EvidenceCappedAndSorted: the hub is evidence[0]; its dependents
+// follow, sorted and capped at maxEvidence.
+func TestExplain_EvidenceCappedAndSorted(t *testing.T) {
+	store := makeStore("core.Hub", manyCallers(15), nil)
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	ev := insights[0].Evidence
+	if len(ev) != maxEvidence+1 {
+		t.Fatalf("evidence should be hub + %d dependents, got %d", maxEvidence, len(ev))
+	}
+	deps := ev[1:]
+	for i := 1; i < len(deps); i++ {
+		if deps[i-1].Symbol > deps[i].Symbol {
+			t.Errorf("dependents not sorted at %d: %q > %q", i, deps[i-1].Symbol, deps[i].Symbol)
+		}
+	}
+}
+
+// TestExplain_MultipleHubsOrderedByFanIn: the higher-fan-in hub ranks first.
+func TestExplain_MultipleHubsOrderedByFanIn(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "core.Big", File: "core/big.go"})
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "core.Small", File: "core/small.go"})
+	for i := 0; i < 20; i++ {
+		s.Add(facts.Fact{Kind: facts.KindSymbol, Name: fmt.Sprintf("a/c%d.Fn", i), File: "a/c.go",
+			Relations: []facts.Relation{{Kind: facts.RelCalls, Target: "core.Big"}}})
+	}
+	for i := 0; i < 10; i++ {
+		s.Add(facts.Fact{Kind: facts.KindSymbol, Name: fmt.Sprintf("b/c%d.Fn", i), File: "b/c.go",
+			Relations: []facts.Relation{{Kind: facts.RelCalls, Target: "core.Small"}}})
+	}
+	s.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) < 2 {
+		t.Fatalf("expected both hubs reported, got %d", len(insights))
+	}
+	if !strings.Contains(insights[0].Title, "core.Big") {
+		t.Errorf("higher fan-in hub should rank first, got %q", insights[0].Title)
+	}
+}
+
+// TestConfidenceMath locks the 0.5→1.0 scaling and its clamps.
+func TestConfidenceMath(t *testing.T) {
+	tests := []struct {
+		value, threshold, want float64
+	}{
+		{10, 10, 0.5},  // at threshold
+		{15, 10, 0.75}, // halfway to 2x
+		{20, 10, 1.0},  // 2x threshold
+		{40, 10, 1.0},  // clamps at 1.0
+		{5, 10, 0.5},   // below threshold clamps at 0.5
+		{5, 0, 0.6},    // degenerate threshold
+	}
+	for _, tt := range tests {
+		if got := confidence(tt.value, tt.threshold); got != tt.want {
+			t.Errorf("confidence(%v, %v) = %v, want %v", tt.value, tt.threshold, got, tt.want)
+		}
+	}
+}

--- a/internal/explainers/hotspots/hotspots_test.go
+++ b/internal/explainers/hotspots/hotspots_test.go
@@ -79,3 +79,91 @@ func TestExplain_BelowDegreeFloor(t *testing.T) {
 		t.Errorf("expected 0 insights when one side is below the degree floor, got %d", len(insights))
 	}
 }
+
+// TestExplain_DegreeBoundary: exactly minDegree on both sides qualifies (it's a
+// clear outlier against the zero-score neighbors); one side at minDegree-1 does not.
+func TestExplain_DegreeBoundary(t *testing.T) {
+	at := makeStore("core.Hub", minDegree, minDegree)
+	got, err := New().Explain(context.Background(), at)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("in==out==minDegree (%d) should be a hotspot, got %d insights", minDegree, len(got))
+	}
+
+	below := makeStore("core.Hub", minDegree-1, 10)
+	got, err = New().Explain(context.Background(), below)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("fan-in == minDegree-1 (%d) should not qualify, got %d", minDegree-1, len(got))
+	}
+}
+
+// TestExplain_NeighborsCappedAndSorted: evidence is the hub plus up to
+// maxNeighbors in-callers and maxNeighbors out-callees, each sorted.
+func TestExplain_NeighborsCappedAndSorted(t *testing.T) {
+	store := makeStore("core.Hub", 8, 8) // more neighbors than the cap on each side
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	ev := insights[0].Evidence
+	// hub + up to maxNeighbors in + up to maxNeighbors out.
+	if len(ev) > 1+2*maxNeighbors {
+		t.Errorf("neighbor evidence not capped: got %d, want <= %d", len(ev), 1+2*maxNeighbors)
+	}
+	in, out := 0, 0
+	for _, e := range ev[1:] {
+		switch {
+		case strings.HasPrefix(e.Detail, "calls into"):
+			in++
+		case strings.HasPrefix(e.Detail, "called by"):
+			out++
+		}
+	}
+	if in > maxNeighbors || out > maxNeighbors {
+		t.Errorf("per-side cap exceeded: in=%d out=%d, cap=%d", in, out, maxNeighbors)
+	}
+}
+
+// TestExplain_OrderedByScore: the higher fanIn×fanOut hotspot ranks first.
+func TestExplain_OrderedByScore(t *testing.T) {
+	s := facts.NewStore()
+	// Big: 6x6 = 36; Small: 3x3 = 9. Give each disjoint callers/callees.
+	addHub := func(name, dir string, in, out int) {
+		calls := make([]facts.Relation, 0, out)
+		for i := 0; i < out; i++ {
+			tgt := fmt.Sprintf("%s/t%d.Fn", dir, i)
+			calls = append(calls, facts.Relation{Kind: facts.RelCalls, Target: tgt})
+			s.Add(facts.Fact{Kind: facts.KindSymbol, Name: tgt, File: dir + "/t.go"})
+		}
+		s.Add(facts.Fact{Kind: facts.KindSymbol, Name: name, File: dir + "/h.go", Relations: calls})
+		for i := 0; i < in; i++ {
+			s.Add(facts.Fact{Kind: facts.KindSymbol, Name: fmt.Sprintf("%s/c%d.Fn", dir, i), File: dir + "/c.go",
+				Relations: []facts.Relation{{Kind: facts.RelCalls, Target: name}}})
+		}
+	}
+	addHub("big.Hub", "big", 6, 6)
+	addHub("small.Hub", "small", 3, 3)
+	s.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) < 1 || !strings.Contains(insights[0].Title, "big.Hub") {
+		t.Errorf("highest-score hotspot should rank first, got %v", func() []string {
+			out := make([]string, len(insights))
+			for i, in := range insights {
+				out[i] = in.Title
+			}
+			return out
+		}())
+	}
+}

--- a/internal/explainers/layers/layers.go
+++ b/internal/explainers/layers/layers.go
@@ -3,6 +3,7 @@ package layers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/enola-labs/enola/internal/explainers/common"
@@ -222,8 +223,16 @@ func (e *LayerExplainer) Explain(ctx context.Context, store *facts.Store) ([]fac
 
 	// Report detected architecture pattern
 	if best := e.bestPattern(patterns); best != nil {
-		evidence := make([]facts.Evidence, 0)
-		for mod, layer := range best.Modules {
+		// Sort the classified modules so the evidence order is deterministic —
+		// ranging best.Modules directly would follow Go's randomized map order.
+		mods := make([]string, 0, len(best.Modules))
+		for mod := range best.Modules {
+			mods = append(mods, mod)
+		}
+		sort.Strings(mods)
+		evidence := make([]facts.Evidence, 0, len(mods))
+		for _, mod := range mods {
+			layer := best.Modules[mod]
 			evidence = append(evidence, facts.Evidence{
 				Fact:   mod,
 				Detail: fmt.Sprintf("module %q maps to layer %q", mod, layer),
@@ -374,12 +383,25 @@ func presentFrameworks(store *facts.Store) map[string]bool {
 	return out
 }
 
-// detectViolations checks for layer boundary violations (inner layer importing outer layer).
+// detectViolations checks for layer boundary violations (inner layer importing
+// outer layer). Each distinct (source module -> target module) pair is reported
+// once: two files in the same module importing the same outer module are one
+// violation, not two, so the count the renderer derives isn't inflated. Relative
+// import targets (`./x`, `../y`) are resolved against the source module the same
+// way the shared module-graph builder does, so JS/TS-style relative imports match
+// a classified layer instead of silently missing. Output is sorted for
+// determinism.
 func (e *LayerExplainer) detectViolations(store *facts.Store, pattern *archPattern) []facts.Insight {
-	var insights []facts.Insight
+	type violation struct {
+		sourceModule, targetModule string
+		sourceLayer, targetLayer   string
+		sourceLevel, targetLevel   int
+		file                       string
+	}
+	seen := make(map[string]bool)
+	var violations []violation
 
-	deps := store.ByKind(facts.KindDependency)
-	for _, dep := range deps {
+	for _, dep := range store.ByKind(facts.KindDependency) {
 		sourceModule := common.FileDir(dep.File)
 		sourceLayer, sourceOK := pattern.Modules[sourceModule]
 		if !sourceOK {
@@ -391,36 +413,63 @@ func (e *LayerExplainer) detectViolations(store *facts.Store, pattern *archPatte
 				continue
 			}
 
-			targetLayer, targetOK := pattern.Modules[rel.Target]
+			target := rel.Target
+			if strings.HasPrefix(target, ".") {
+				target = common.ResolveRelativeImport(sourceModule, target)
+			}
+
+			targetLayer, targetOK := pattern.Modules[target]
 			if !targetOK {
 				continue
 			}
 
-			// Check if source layer level is lower than target
 			sourceDef := pattern.Layers[sourceLayer]
 			targetDef := pattern.Layers[targetLayer]
-
-			if sourceDef != nil && targetDef != nil && sourceDef.Level < targetDef.Level {
-				insights = append(insights, facts.Insight{
-					Title: fmt.Sprintf("Layer violation: %s -> %s", sourceLayer, targetLayer),
-					Description: fmt.Sprintf(
-						"Module %q (layer: %s, level %d) imports module %q (layer: %s, level %d). "+
-							"Inner layers should not depend on outer layers.",
-						sourceModule, sourceLayer, sourceDef.Level,
-						rel.Target, targetLayer, targetDef.Level,
-					),
-					Confidence: 0.8,
-					Evidence: []facts.Evidence{
-						{File: dep.File, Detail: fmt.Sprintf("import of %s", rel.Target)},
-					},
-					Actions: []string{
-						"Introduce an interface/port in the inner layer",
-						"Move shared types to a common package",
-						"Invert the dependency using dependency injection",
-					},
-				})
+			if sourceDef == nil || targetDef == nil || sourceDef.Level >= targetDef.Level {
+				continue
 			}
+
+			key := sourceModule + "\x00" + target
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			violations = append(violations, violation{
+				sourceModule: sourceModule, targetModule: target,
+				sourceLayer: sourceLayer, targetLayer: targetLayer,
+				sourceLevel: sourceDef.Level, targetLevel: targetDef.Level,
+				file: dep.File,
+			})
 		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].sourceModule != violations[j].sourceModule {
+			return violations[i].sourceModule < violations[j].sourceModule
+		}
+		return violations[i].targetModule < violations[j].targetModule
+	})
+
+	insights := make([]facts.Insight, 0, len(violations))
+	for _, v := range violations {
+		insights = append(insights, facts.Insight{
+			Title: fmt.Sprintf("Layer violation: %s -> %s", v.sourceLayer, v.targetLayer),
+			Description: fmt.Sprintf(
+				"Module %q (layer: %s, level %d) imports module %q (layer: %s, level %d). "+
+					"Inner layers should not depend on outer layers.",
+				v.sourceModule, v.sourceLayer, v.sourceLevel,
+				v.targetModule, v.targetLayer, v.targetLevel,
+			),
+			Confidence: 0.8,
+			Evidence: []facts.Evidence{
+				{File: v.file, Detail: fmt.Sprintf("import of %s", v.targetModule)},
+			},
+			Actions: []string{
+				"Introduce an interface/port in the inner layer",
+				"Move shared types to a common package",
+				"Invert the dependency using dependency injection",
+			},
+		})
 	}
 
 	return insights

--- a/internal/explainers/layers/layers_test.go
+++ b/internal/explainers/layers/layers_test.go
@@ -3,6 +3,7 @@ package layers
 import (
 	"context"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -430,6 +431,119 @@ func TestDetectViolations_OuterImportsInner(t *testing.T) {
 	for _, insight := range insights {
 		if insight.Confidence == 0.8 {
 			t.Errorf("unexpected layer violation: %s", insight.Title)
+		}
+	}
+}
+
+// addDep adds a single import dependency fact from a specific file.
+func addDep(s *facts.Store, file, target string) {
+	s.Add(facts.Fact{Kind: facts.KindDependency, File: file,
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: target}}})
+}
+
+func countViolations(insights []facts.Insight) int {
+	n := 0
+	for _, in := range insights {
+		if in.Confidence == 0.8 {
+			n++
+		}
+	}
+	return n
+}
+
+// TestDetectViolations_Dedup: two files in the same source module importing the
+// same outer module produce ONE violation, not two — so the renderer's
+// title-prefix count isn't inflated.
+func TestDetectViolations_Dedup(t *testing.T) {
+	s := facts.NewStore()
+	for _, m := range []string{"domain/entity", "presentation/views", "adapter/rest", "application/svc"} {
+		s.Add(facts.Fact{Kind: facts.KindModule, Name: m})
+	}
+	addDep(s, "domain/entity/a.go", "presentation/views")
+	addDep(s, "domain/entity/b.go", "presentation/views") // same (source module, target) pair
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if got := countViolations(insights); got != 1 {
+		t.Errorf("duplicate import across two files should yield 1 violation, got %d", got)
+	}
+}
+
+// TestDetectViolations_LevelEqualNoViolation: an import between two same-level
+// layers (application -> port, both level 1) is not a violation.
+func TestDetectViolations_LevelEqualNoViolation(t *testing.T) {
+	s := facts.NewStore()
+	for _, m := range []string{"application/svc", "port/iface", "adapter/rest", "domain/entity"} {
+		s.Add(facts.Fact{Kind: facts.KindModule, Name: m})
+	}
+	addDep(s, "application/svc/a.go", "port/iface")
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if got := countViolations(insights); got != 0 {
+		t.Errorf("same-level import should not be a violation, got %d", got)
+	}
+}
+
+// TestDetectViolations_RelativeImportResolved guards the fix where a JS/TS-style
+// relative import target ("../pages") is resolved against the source module
+// before matching a layer — previously the raw target never matched, so the
+// violation was missed.
+func TestDetectViolations_RelativeImportResolved(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(makeModulesLang("typescript", "pages", "components", "lib", "hooks")...)
+	s.Add(frameworkFact("nextjs"))
+	// lib (level 0) imports "../pages" (level 3) via a relative path -> violation.
+	addDep(s, "lib/util.ts", "../pages")
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	found := false
+	for _, in := range insights {
+		if in.Confidence == 0.8 && strings.Contains(in.Title, "lib -> pages") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("relative import lib -> ../pages should resolve to a lib->pages violation; got %v", func() []string {
+			out := make([]string, len(insights))
+			for i, in := range insights {
+				out[i] = in.Title
+			}
+			return out
+		}())
+	}
+}
+
+// TestExplain_PatternEvidenceDeterministic: the architecture-pattern insight's
+// evidence used to be built by ranging a map, so its order churned run to run.
+func TestExplain_PatternEvidenceDeterministic(t *testing.T) {
+	store := makeStore(
+		[]string{"domain/entity", "presentation/views", "adapter/rest", "application/svc"},
+		map[string][]string{},
+	)
+	render := func() string {
+		insights, err := New().Explain(context.Background(), store)
+		if err != nil {
+			t.Fatalf("Explain: %v", err)
+		}
+		var b strings.Builder
+		for _, ev := range insights[0].Evidence { // insights[0] is the architecture pattern
+			b.WriteString(ev.Fact)
+			b.WriteByte(',')
+		}
+		return b.String()
+	}
+	want := render()
+	for i := 0; i < 50; i++ {
+		if got := render(); got != want {
+			t.Fatalf("non-deterministic pattern evidence on iteration %d:\nwant %q\ngot  %q", i, want, got)
 		}
 	}
 }

--- a/internal/explainers/surface/surface_test.go
+++ b/internal/explainers/surface/surface_test.go
@@ -104,6 +104,95 @@ func TestExplain_CappedAndRankedBySurface(t *testing.T) {
 	}
 }
 
+// TestExplain_MinSymbolsBoundary: a module with exactly minSymbols (all exported)
+// is reported; one symbol fewer is exempt.
+func TestExplain_MinSymbolsBoundary(t *testing.T) {
+	at := facts.NewStore()
+	addModuleSymbols(at, "pkg/edge", minSymbols, minSymbols)
+	got, err := New().Explain(context.Background(), at)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("module with exactly minSymbols (%d) should be reported, got %d", minSymbols, len(got))
+	}
+
+	below := facts.NewStore()
+	addModuleSymbols(below, "pkg/edge", minSymbols-1, minSymbols-1)
+	got, err = New().Explain(context.Background(), below)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("module with minSymbols-1 (%d) should be exempt, got %d", minSymbols-1, len(got))
+	}
+}
+
+// TestExplain_RatioBoundary: a module at exactly minExportedRatio is reported
+// (the gate is >=), just below is not.
+func TestExplain_RatioBoundary(t *testing.T) {
+	at := facts.NewStore()
+	addModuleSymbols(at, "pkg/edge", 20, 17) // 17/20 = 0.85 == minExportedRatio
+	got, err := New().Explain(context.Background(), at)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("ratio == minExportedRatio (0.85) should be reported, got %d", len(got))
+	}
+
+	below := facts.NewStore()
+	addModuleSymbols(below, "pkg/edge", 20, 16) // 0.80 < 0.85
+	got, err = New().Explain(context.Background(), below)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ratio below minExportedRatio should not be reported, got %d", len(got))
+	}
+}
+
+// TestExplain_MixedVisibilityRatioOnKnownOnly: symbols without an "exported" prop
+// are excluded from the tally, so the ratio is computed over known-visibility
+// symbols only.
+func TestExplain_MixedVisibilityRatioOnKnownOnly(t *testing.T) {
+	s := facts.NewStore()
+	addModuleSymbols(s, "pkg/mixed", 20, 19) // 20 known, 19 exported -> 95%
+	// Add symbols with unknown visibility; these must not change the ratio.
+	for i := 0; i < 10; i++ {
+		s.Add(facts.Fact{Kind: facts.KindSymbol, Name: fmt.Sprintf("pkg/mixed.Unknown%d", i), File: "pkg/mixed/u.go"})
+	}
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	// Title reflects 19 of 20 (known only), not 19 of 30.
+	if !strings.Contains(insights[0].Title, "19 of 20") {
+		t.Errorf("ratio should be over known-visibility symbols only, got %q", insights[0].Title)
+	}
+}
+
+// TestExplain_TitleFormatWithDigitName locks the title contract pkg/explain
+// parses, for a module whose name contains digits (ties to the explain BUG-1 fix).
+func TestExplain_TitleFormatWithDigitName(t *testing.T) {
+	s := facts.NewStore()
+	addModuleSymbols(s, "pkg/oauth2", 44, 40) // 40/44 = 90.9% -> "91%"
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	want := "Large public surface: pkg/oauth2 exports 40 of 44 symbols (91%)"
+	if insights[0].Title != want {
+		t.Errorf("title = %q, want %q", insights[0].Title, want)
+	}
+}
+
 func TestExplain_MissingVisibilityIgnored(t *testing.T) {
 	s := facts.NewStore()
 	for i := 0; i < 20; i++ {

--- a/internal/explainers/unusedroutes/unusedroutes_test.go
+++ b/internal/explainers/unusedroutes/unusedroutes_test.go
@@ -2,6 +2,7 @@ package unusedroutes
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -50,6 +51,87 @@ func TestExplain_FlagsCandidatesWithCaveat(t *testing.T) {
 	}
 	if in.Confidence >= 0.9 {
 		t.Errorf("confidence %v too high for a candidate-with-caveat signal", in.Confidence)
+	}
+}
+
+func TestExplain_CapsSamplesAndEvidence(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(facts.Fact{Kind: facts.KindService, Name: "golf", Repo: "golf"})
+	const n = 30 // > maxSamples (25)
+	for i := 0; i < n; i++ {
+		store.Add(flaggedRoute("golf", fmt.Sprintf("/api/ep%02d", i), "POST"))
+	}
+
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	in := insights[0]
+	// The title counts ALL flagged routes, not just the sampled ones.
+	if !strings.Contains(in.Title, fmt.Sprintf("%d route", n)) {
+		t.Errorf("title should report full count %d, got %q", n, in.Title)
+	}
+	// Samples are truncated with a "+N more" marker.
+	if !strings.Contains(in.Description, "(+5 more)") {
+		t.Errorf("description should note 5 elided samples, got %q", in.Description)
+	}
+	// Evidence is capped at maxSamples.
+	if len(in.Evidence) != maxSamples {
+		t.Errorf("evidence should be capped at %d, got %d", maxSamples, len(in.Evidence))
+	}
+}
+
+func TestExplain_MultipleReposSortedAndRoutesSorted(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindService, Name: "zulu", Repo: "zulu"},
+		facts.Fact{Kind: facts.KindService, Name: "alpha", Repo: "alpha"},
+		flaggedRoute("zulu", "/api/z2", "GET"),
+		flaggedRoute("zulu", "/api/z1", "GET"),
+		flaggedRoute("alpha", "/api/a1", "POST"),
+	)
+
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 2 {
+		t.Fatalf("expected one insight per repo, got %d", len(insights))
+	}
+	// Repos are reported in sorted order: alpha before zulu.
+	if !strings.Contains(insights[0].Title, "alpha") || !strings.Contains(insights[1].Title, "zulu") {
+		t.Errorf("repos not sorted: %q then %q", insights[0].Title, insights[1].Title)
+	}
+	// Routes within a repo are sorted: z1 before z2.
+	zulu := insights[1]
+	if len(zulu.Evidence) != 2 || zulu.Evidence[0].Fact != "GET /api/z1" || zulu.Evidence[1].Fact != "GET /api/z2" {
+		t.Errorf("routes within repo not sorted: %+v", zulu.Evidence)
+	}
+}
+
+func TestExplain_NoMethodFallbackAndUnlabeledRepo(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindService, Name: "svc", Repo: "svc"},
+		// No Repo label -> "(unlabeled)" bucket; no method prop -> label is the bare name.
+		facts.Fact{Kind: facts.KindRoute, Name: "/api/loose", Props: map[string]any{"unmatched_by_clients": true}},
+	)
+
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("expected 1 insight, got %d", len(insights))
+	}
+	if !strings.Contains(insights[0].Title, "(unlabeled)") {
+		t.Errorf("blank repo should bucket under (unlabeled), got %q", insights[0].Title)
+	}
+	if insights[0].Evidence[0].Fact != "/api/loose" {
+		t.Errorf("route with no method should fall back to its name, got %q", insights[0].Evidence[0].Fact)
 	}
 }
 

--- a/pkg/explain/explain.go
+++ b/pkg/explain/explain.go
@@ -220,14 +220,17 @@ func Compute(eng *bootstrap.Engine) *Report {
 				addFinding(godClass, name, fmt.Sprintf("%d dependents", firstParenInt(in.Title)))
 			case strings.HasPrefix(in.Title, "Call-graph hotspot:"):
 				name := nameBetween(in.Title, "Call-graph hotspot:", " (")
-				ints := allInts(in.Title)
-				addFinding(hotspots, name, fanDetail(ints))
+				// Scan for metrics only after "(" so digits in the symbol name
+				// (e.g. "Sha256Hash", "oauth2") aren't mistaken for fan-in/out.
+				addFinding(hotspots, name, fanDetail(metricInts(in.Title, "(")))
 			case strings.HasPrefix(in.Title, "Deep dependency chain:"):
 				name := nameBetween(in.Title, "Deep dependency chain:", " (")
 				addFinding(deepChains, name, fmt.Sprintf("depth %d", firstParenInt(in.Title)))
 			case strings.HasPrefix(in.Title, "Large public surface:"):
 				name := nameBetween(in.Title, "Large public surface:", " exports")
-				addFinding(surfaces, name, surfaceDetail(allInts(in.Title)))
+				// Scan for metrics only after " exports" so digits in the module
+				// name (e.g. "oauth2", "utf8") aren't parsed as exported/total.
+				addFinding(surfaces, name, surfaceDetail(metricInts(in.Title, " exports")))
 			case strings.HasPrefix(in.Title, "High cyclomatic complexity:"):
 				name := nameBetween(in.Title, "High cyclomatic complexity:", " (")
 				addFinding(complexFns, name, fmt.Sprintf("complexity %d", firstParenInt(in.Title)))
@@ -453,6 +456,19 @@ func nameBetween(title, prefix, stop string) string {
 		s = s[:i]
 	}
 	return strings.TrimSpace(s)
+}
+
+// metricInts parses the integer metrics out of an insight title, starting the
+// scan at the first occurrence of marker. Names precede the metric section (a
+// symbol/module name has no "(" and appears before " exports"), so cutting at
+// the marker keeps digits inside a name — "Sha256Hash", "oauth2", "utf8" — from
+// being misread as metrics. Falls back to scanning the whole title if the marker
+// is absent.
+func metricInts(title, marker string) []int {
+	if i := strings.Index(title, marker); i >= 0 {
+		return allInts(title[i:])
+	}
+	return allInts(title)
 }
 
 // allInts returns every run of digits in s as integers, in order. Used to pull

--- a/pkg/explain/explain_test.go
+++ b/pkg/explain/explain_test.go
@@ -404,6 +404,13 @@ func TestCodeHealthHelpers(t *testing.T) {
 	if got := fanDetail([]int{64, 20}); got != "fan-in 64 / out 20" {
 		t.Errorf("fanDetail: got %q", got)
 	}
+	// metricInts must ignore digits that appear before the marker (i.e. in the name).
+	if got := metricInts("Call-graph hotspot: pkg/x.Sha256Hash (fan-in 30, fan-out 12)", "("); len(got) != 2 || got[0] != 30 || got[1] != 12 {
+		t.Errorf("metricInts (hotspot, digit name): got %v, want [30 12]", got)
+	}
+	if got := metricInts("Large public surface: pkg/oauth2 exports 40 of 44 symbols (91%)", " exports"); len(got) != 3 || got[0] != 40 || got[1] != 44 || got[2] != 91 {
+		t.Errorf("metricInts (surface, digit name): got %v, want [40 44 91]", got)
+	}
 }
 
 // codeHealthInsights covers all 5 new explainer titles, with 6 god-class entries
@@ -422,6 +429,49 @@ func codeHealthInsights() []facts.Insight {
 		})
 	}
 	return ins
+}
+
+// TestCompute_CodeHealth_DigitsInNames is a regression guard: metric parsing
+// must not be corrupted by digits inside a symbol/module name (Sha256Hash,
+// oauth2, x509, ...). Before the fix, allInts scanned the whole title, so name
+// digits were misread — a hotspot on "Sha256Hash" rendered "fan-in 256 / out 30"
+// and a surface on "oauth2" rendered "2/40 (44%)". The digit-free codeHealth
+// fixtures never exercised this.
+func TestCompute_CodeHealth_DigitsInNames(t *testing.T) {
+	eng := newTestEngine(t)
+	eng.Store().Add(fixtureFacts()...)
+	eng.Store().BuildGraph()
+	eng.SetSnapshot(&facts.Snapshot{
+		Meta: facts.SnapshotMeta{RepoPath: "/repo/digits"},
+		Insights: []facts.Insight{
+			{Title: "Call-graph hotspot: pkg/x.Sha256Hash (fan-in 30, fan-out 12)"},
+			{Title: "Large public surface: pkg/oauth2 exports 40 of 44 symbols (91%)"},
+			{Title: "High fan-in symbol: pkg/x.Base64Encoder (18 dependents)"},
+			{Title: "Deep dependency chain: pkg/utf8 (depth 9)"},
+			{Title: "High cyclomatic complexity: pkg/x.ParseX509 (108)"},
+		},
+	})
+	r := Compute(eng)
+
+	byLabel := map[string]FindingGroup{}
+	for _, g := range r.CodeHealth {
+		byLabel[g.Label] = g
+	}
+	if d := byLabel["call-graph hotspots"].Top[0]; d.Name != "pkg/x.Sha256Hash" || d.Detail != "fan-in 30 / out 12" {
+		t.Errorf("hotspot with digit name: got name=%q detail=%q, want pkg/x.Sha256Hash / 'fan-in 30 / out 12'", d.Name, d.Detail)
+	}
+	if d := byLabel["large public surfaces"].Top[0]; d.Name != "pkg/oauth2" || d.Detail != "40/44 (91%)" {
+		t.Errorf("surface with digit name: got name=%q detail=%q, want pkg/oauth2 / '40/44 (91%%)'", d.Name, d.Detail)
+	}
+	if d := byLabel["god classes (high fan-in)"].Top[0]; d.Name != "pkg/x.Base64Encoder" || d.Detail != "18 dependents" {
+		t.Errorf("god-class with digit name: got name=%q detail=%q", d.Name, d.Detail)
+	}
+	if d := byLabel["deep dependency chains"].Top[0]; d.Name != "pkg/utf8" || d.Detail != "depth 9" {
+		t.Errorf("depth with digit name: got name=%q detail=%q", d.Name, d.Detail)
+	}
+	if d := byLabel["complexity outliers"].Top[0]; d.Name != "pkg/x.ParseX509" || d.Detail != "complexity 108" {
+		t.Errorf("complexity with digit name: got name=%q detail=%q", d.Name, d.Detail)
+	}
 }
 
 func computeCodeHealth(t *testing.T) *Report {


### PR DESCRIPTION
…overage

Bulletproof the explainer suite with unit tests and fix the bugs found while doing so. Explainer output feeds query_insights and pkg/explain, so correctness and byte-for-byte determinism matter.

Confirmed bugs fixed (each with a regression test proven to fail pre-fix):
- pkg/explain: metric parsing corrupted by digits in symbol/module names — allInts scanned the whole title, so a hotspot on "Sha256Hash" rendered "fan-in 256 / out 30" and a surface on "oauth2" rendered "2/40 (44%)". Parse only the metric section via metricInts(title, marker).
- cycles: nondeterministic cycle path / evidence order / insight order (map iteration + unsorted neighbors). Factored a deterministic common.StronglyConnectedComponents shared with depth.
- depth: under-counted chains hidden behind a cycle (a memoized chain truncated by the back-edge cut was reused globally). Rewrote over the SCC condensation (longest path on the DAG, cycle = its full member count as a cycle-safe upper bound).
- crossrepo: "via" detail dropped after a facts.jsonl round-trip (asserted []string only; JSON decodes arrays as []any). Handle both shapes.

layers fixes:
- deterministic pattern-insight evidence (was map iteration order)
- dedup layer violations by (source, target) module so the count isn't inflated
- resolve relative import targets (./x, ../y) before matching a layer

Tests: added threshold-boundary, determinism, float64/JSONL prop, evidence-cap, and sort-order coverage across every explainer and common. Full suite green under -race; engine golden/determinism gate unaffected (fixes touch insights, not facts.jsonl).

Docs: refreshed the Apache Airflow --explain example in README.md (fact counts, hotspots, and the now-corrected depth numbers).