### PR TITLE
feat(engine): write graph-wide receipt to ~/.enola/receipt.json

### DIFF
--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -79,6 +79,12 @@ func main() {
 			log.Fatalf("failed to write artifacts: %v", err)
 		}
 
+		// Refresh the graph-wide receipt at ~/.enola/receipt.json. Non-fatal: a
+		// failure here must not abort an otherwise-successful snapshot.
+		if err := eng.WriteGlobalReceipt(); err != nil {
+			log.Printf("warning: failed to write global receipt: %v", err)
+		}
+
 		fmt.Fprintf(os.Stderr, "\nSnapshot complete:\n")
 		fmt.Fprintf(os.Stderr, "  Repository:  %s\n", snapshot.Meta.RepoPath)
 		fmt.Fprintf(os.Stderr, "  Facts:       %d\n", snapshot.Meta.FactCount)

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -1,0 +1,229 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/enola-labs/enola/internal/facts"
+	"github.com/enola-labs/enola/internal/version"
+)
+
+// globalReceiptDirName / globalReceiptFileName locate the graph-wide receipt under
+// the user's home directory (~/.enola/receipt.json).
+const (
+	globalReceiptDirName  = ".enola"
+	globalReceiptFileName = "receipt.json"
+)
+
+// globalReceiptPath resolves ~/.enola/receipt.json. It returns an error when the
+// home directory is unavailable (e.g. a sandboxed run with no $HOME) so callers
+// can degrade gracefully instead of failing the snapshot.
+func globalReceiptPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(home, globalReceiptDirName, globalReceiptFileName), nil
+}
+
+// repoEntries returns one GraphRepoEntry per repository currently in the graph.
+// In multi-repo (append) mode it iterates RepoPaths(); in single-repo mode it
+// falls back to the sole primary repo from the snapshot meta. Git state is captured
+// per repo via gitInfo (nil for non-git dirs) and fact counts come from the store's
+// byRepo index. AddedAt/CommitChangedAt are left to the merge step; InGraphFor is
+// derived at write time. Entries are sorted by Label for stable output.
+func (e *Engine) repoEntries() []facts.GraphRepoEntry {
+	// label -> absolute path for every repo in the graph.
+	repos := e.RepoPaths()
+	if len(repos) == 0 {
+		// Single-repo graph: RepoPaths() is nil until a repo is appended.
+		if e.snapshot == nil || e.snapshot.Meta.RepoPath == "" {
+			return nil
+		}
+		abs := e.snapshot.Meta.RepoPath
+		repos = map[string]string{filepath.Base(abs): abs}
+	}
+
+	entries := make([]facts.GraphRepoEntry, 0, len(repos))
+	for label, abs := range repos {
+		entries = append(entries, facts.GraphRepoEntry{
+			Label:     label,
+			Path:      abs,
+			Git:       gitInfo(abs),
+			FactCount: e.store.CountByRepo(label),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Label < entries[j].Label })
+	return entries
+}
+
+// crossRepoEdgeCount counts the consumer->provider edges in the cross-repo "graph
+// of graphs". Those edges are materialized as depends_on relations on the synthetic
+// KindService nodes (one per repo), so summing them reads the true cross-repo edge
+// count directly — and cheaply (there are only as many service nodes as repos). It
+// deliberately does NOT use ByKind(KindDependency): that kind also covers every
+// ordinary import/dependency fact, which would over-count by orders of magnitude.
+func crossRepoEdgeCount(store *facts.Store) int {
+	n := 0
+	for _, svc := range store.ByKind(facts.KindService) {
+		for _, r := range svc.Relations {
+			if r.Kind == facts.RelDependsOn {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// assembleGraphReceipt builds a GraphReceipt describing the current graph state.
+// Membership timestamps (AddedAt/CommitChangedAt) are set to their first-write
+// defaults here; WriteGlobalReceipt merges forward from any prior receipt.
+func (e *Engine) assembleGraphReceipt(now time.Time) facts.GraphReceipt {
+	nowStr := now.UTC().Format(time.RFC3339)
+
+	entries := e.repoEntries()
+	for i := range entries {
+		entries[i].AddedAt = nowStr
+		entries[i].InGraphFor = "0s"
+	}
+
+	gr := facts.GraphReceipt{
+		GeneratedAt:        nowStr,
+		EnolaVersion:       version.Version,
+		ServiceCount:       len(e.store.ByKind(facts.KindService)),
+		CrossRepoEdgeCount: crossRepoEdgeCount(e.store),
+		Coverage:           coverageSummary(e.store),
+		Repos:              entries,
+	}
+	if e.snapshot != nil {
+		gr.SnapshotID = e.snapshot.Meta.SnapshotID
+		gr.FactCount = e.snapshot.Meta.FactCount
+		gr.InsightCount = e.snapshot.Meta.InsightCount
+	}
+	return gr
+}
+
+// WriteGlobalReceipt writes ~/.enola/receipt.json for the current graph. It reads
+// any existing receipt to merge forward per-repo membership timestamps (so a repo's
+// added_at is preserved across regenerations and a moved commit does not reset it),
+// then atomically replaces the file. It never aborts a snapshot: a missing home dir
+// is logged and skipped, and a corrupt prior receipt is treated as no prior state.
+func (e *Engine) WriteGlobalReceipt() error {
+	if e.snapshot == nil {
+		return fmt.Errorf("no snapshot generated")
+	}
+
+	path, err := globalReceiptPath()
+	if err != nil {
+		log.Printf("[engine] global receipt skipped: %v", err)
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating global receipt dir: %w", err)
+	}
+
+	now := time.Now().UTC()
+	gr := e.assembleGraphReceipt(now)
+
+	// Merge forward membership timestamps from the prior receipt, if any. Repos
+	// present in the prior receipt but absent now are simply omitted: the receipt
+	// is rebuilt only from current entries, so departed repos drop out.
+	prevByLabel := readPriorGraphReceipt(path)
+	gr.Repos = mergeRepoEntries(gr.Repos, prevByLabel, now)
+
+	data, err := json.MarshalIndent(gr, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling global receipt: %w", err)
+	}
+	if err := writeFileAtomic(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing global receipt: %w", err)
+	}
+	log.Printf("[engine] wrote %s (%d repos)", path, len(gr.Repos))
+	return nil
+}
+
+// mergeRepoEntries carries per-repo membership state forward from a prior receipt
+// (keyed by label) onto the freshly-assembled current entries, and stamps each
+// entry's derived InGraphFor. For a repo already present, AddedAt is preserved (a
+// regeneration is not a re-entry) and a moved commit records CommitChangedAt=now
+// WITHOUT resetting AddedAt; an unchanged commit carries the prior CommitChangedAt
+// forward. A repo absent from prev keeps its default AddedAt=now. cur already
+// excludes departed repos, so they drop out.
+func mergeRepoEntries(cur []facts.GraphRepoEntry, prevByLabel map[string]facts.GraphRepoEntry, now time.Time) []facts.GraphRepoEntry {
+	nowStr := now.UTC().Format(time.RFC3339)
+	for i := range cur {
+		c := &cur[i]
+		if prev, ok := prevByLabel[c.Label]; ok {
+			c.AddedAt = prev.AddedAt
+			if prev.Git != nil && c.Git != nil && prev.Git.Commit != c.Git.Commit {
+				c.CommitChangedAt = nowStr
+			} else {
+				c.CommitChangedAt = prev.CommitChangedAt
+			}
+		}
+		c.InGraphFor = inGraphFor(c.AddedAt, now)
+	}
+	return cur
+}
+
+// readPriorGraphReceipt loads the existing global receipt keyed by repo label. A
+// missing or corrupt file yields an empty map (the corrupt case is logged), so a
+// hand-edited or truncated receipt self-heals rather than failing the write.
+func readPriorGraphReceipt(path string) map[string]facts.GraphRepoEntry {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil // missing (or unreadable) => no prior state
+	}
+	var prev facts.GraphReceipt
+	if err := json.Unmarshal(data, &prev); err != nil {
+		log.Printf("[engine] warning: ignoring corrupt global receipt %s: %v", path, err)
+		return nil
+	}
+	byLabel := make(map[string]facts.GraphRepoEntry, len(prev.Repos))
+	for _, r := range prev.Repos {
+		byLabel[r.Label] = r
+	}
+	return byLabel
+}
+
+// inGraphFor returns a human-readable duration since addedAt (RFC3339), rounded to
+// the second. It falls back to "0s" when addedAt cannot be parsed.
+func inGraphFor(addedAt string, now time.Time) string {
+	t, err := time.Parse(time.RFC3339, addedAt)
+	if err != nil {
+		return "0s"
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	return d.Round(time.Second).String()
+}
+
+// writeFileAtomic writes data to a temp file in the destination directory and
+// renames it over path, so a concurrent reader never sees a torn/partial receipt.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -214,9 +214,9 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName) // no-op after a successful rename
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Close(); err != nil {

--- a/internal/engine/global_receipt_test.go
+++ b/internal/engine/global_receipt_test.go
@@ -1,0 +1,244 @@
+package engine
+
+// The global receipt (~/.enola/receipt.json) describes the CURRENT graph and must
+// carry per-repo membership forward across regenerations: a repo's added_at is the
+// FIRST time it entered the graph, preserved even as the graph is rebuilt and even
+// as its commit moves. These tests pin that merge-forward contract plus the write/
+// read plumbing and the single-repo fallback.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func gi(commit string) *facts.GitInfo { return &facts.GitInfo{Commit: commit, Ref: "main"} }
+
+func TestMergeRepoEntries_PreservesAddedAtAndStampsNewRepos(t *testing.T) {
+	t0 := "2026-07-01T09:00:00Z"
+	now, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
+
+	prev := map[string]facts.GraphRepoEntry{
+		"A": {Label: "A", AddedAt: t0, Git: gi("x")},
+	}
+	// Current entries are freshly assembled: AddedAt defaults to now for all.
+	cur := []facts.GraphRepoEntry{
+		{Label: "A", AddedAt: now.Format(time.RFC3339), Git: gi("x")}, // unchanged commit
+		{Label: "B", AddedAt: now.Format(time.RFC3339), Git: gi("q")}, // brand new
+	}
+
+	got := mergeRepoEntries(cur, prev, now)
+	byLabel := index(got)
+
+	if byLabel["A"].AddedAt != t0 {
+		t.Errorf("A.AddedAt: got %q, want preserved %q", byLabel["A"].AddedAt, t0)
+	}
+	if byLabel["A"].CommitChangedAt != "" {
+		t.Errorf("A.CommitChangedAt: got %q, want empty (commit unchanged)", byLabel["A"].CommitChangedAt)
+	}
+	if byLabel["B"].AddedAt != now.Format(time.RFC3339) {
+		t.Errorf("B.AddedAt: got %q, want now %q", byLabel["B"].AddedAt, now.Format(time.RFC3339))
+	}
+	// InGraphFor is derived: A has been in for 7 days, B for 0.
+	if want := (7 * 24 * time.Hour).String(); byLabel["A"].InGraphFor != want {
+		t.Errorf("A.InGraphFor: got %q, want %q", byLabel["A"].InGraphFor, want)
+	}
+	if byLabel["B"].InGraphFor != "0s" {
+		t.Errorf("B.InGraphFor: got %q, want 0s", byLabel["B"].InGraphFor)
+	}
+}
+
+func TestMergeRepoEntries_CommitChangeKeepsAddedAt(t *testing.T) {
+	t0 := "2026-07-01T09:00:00Z"
+	now1, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
+
+	// Pass 1: commit moves x -> y. AddedAt preserved, CommitChangedAt = now1.
+	prev := map[string]facts.GraphRepoEntry{"A": {Label: "A", AddedAt: t0, Git: gi("x")}}
+	cur := []facts.GraphRepoEntry{{Label: "A", AddedAt: now1.Format(time.RFC3339), Git: gi("y")}}
+	got := index(mergeRepoEntries(cur, prev, now1))["A"]
+
+	if got.AddedAt != t0 {
+		t.Errorf("AddedAt reset on commit change: got %q, want %q", got.AddedAt, t0)
+	}
+	if got.CommitChangedAt != now1.Format(time.RFC3339) {
+		t.Errorf("CommitChangedAt: got %q, want %q", got.CommitChangedAt, now1.Format(time.RFC3339))
+	}
+
+	// Pass 2: commit stays y. CommitChangedAt carries forward (not reset to now2).
+	now2, _ := time.Parse(time.RFC3339, "2026-07-09T09:00:00Z")
+	prev2 := map[string]facts.GraphRepoEntry{"A": got}
+	cur2 := []facts.GraphRepoEntry{{Label: "A", AddedAt: now2.Format(time.RFC3339), Git: gi("y")}}
+	got2 := index(mergeRepoEntries(cur2, prev2, now2))["A"]
+
+	if got2.CommitChangedAt != now1.Format(time.RFC3339) {
+		t.Errorf("CommitChangedAt should carry forward: got %q, want %q", got2.CommitChangedAt, now1.Format(time.RFC3339))
+	}
+	if got2.AddedAt != t0 {
+		t.Errorf("AddedAt should still be preserved: got %q, want %q", got2.AddedAt, t0)
+	}
+}
+
+func TestMergeRepoEntries_DepartedRepoDropped(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
+	prev := map[string]facts.GraphRepoEntry{
+		"A": {Label: "A", AddedAt: "2026-07-01T09:00:00Z", Git: gi("x")},
+		"B": {Label: "B", AddedAt: "2026-07-01T09:00:00Z", Git: gi("y")},
+	}
+	cur := []facts.GraphRepoEntry{{Label: "A", AddedAt: now.Format(time.RFC3339), Git: gi("x")}}
+
+	got := mergeRepoEntries(cur, prev, now)
+	if len(got) != 1 || got[0].Label != "A" {
+		t.Fatalf("departed repo B should be dropped; got %+v", got)
+	}
+}
+
+func TestInGraphFor(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
+	if got := inGraphFor("2026-07-08T06:00:00Z", now); got != (3 * time.Hour).String() {
+		t.Errorf("inGraphFor: got %q, want 3h0m0s", got)
+	}
+	if got := inGraphFor("not-a-time", now); got != "0s" {
+		t.Errorf("inGraphFor(bad): got %q, want 0s", got)
+	}
+	// A future added_at (clock skew) clamps to 0 rather than a negative duration.
+	if got := inGraphFor("2026-07-08T12:00:00Z", now); got != "0s" {
+		t.Errorf("inGraphFor(future): got %q, want 0s", got)
+	}
+}
+
+func TestWriteAtomicAndReadPrior_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	orig := facts.GraphReceipt{
+		GeneratedAt: "2026-07-08T09:00:00Z",
+		Repos: []facts.GraphRepoEntry{
+			{Label: "A", AddedAt: "2026-07-01T09:00:00Z", Git: gi("x")},
+		},
+	}
+	data, _ := json.MarshalIndent(orig, "", "  ")
+	if err := writeFileAtomic(path, data, 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	byLabel := readPriorGraphReceipt(path)
+	if got := byLabel["A"].AddedAt; got != "2026-07-01T09:00:00Z" {
+		t.Errorf("round-tripped AddedAt: got %q", got)
+	}
+
+	// A corrupt file self-heals to "no prior" (empty map), not an error/panic.
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readPriorGraphReceipt(path); len(got) != 0 {
+		t.Errorf("corrupt receipt should yield no prior state, got %+v", got)
+	}
+	// A missing file also yields no prior state.
+	if got := readPriorGraphReceipt(filepath.Join(t.TempDir(), "nope.json")); len(got) != 0 {
+		t.Errorf("missing receipt should yield no prior state, got %+v", got)
+	}
+}
+
+func TestWriteGlobalReceipt_SingleRepoFallbackAndPersistence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // os.UserHomeDir() resolves ~ from $HOME on unix
+
+	eng, err := New(config.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Two facts tagged with the repo label; RepoPaths() stays nil so the single-repo
+	// fallback (label = base of snapshot RepoPath) must kick in.
+	eng.store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "m1", Repo: "myrepo"},
+		facts.Fact{Kind: facts.KindSymbol, Name: "s1", Repo: "myrepo"},
+	)
+	eng.snapshot = &facts.Snapshot{Meta: facts.SnapshotMeta{
+		RepoPath: filepath.Join("/tmp", "some", "myrepo"), SnapshotID: "sha256:abc", FactCount: 2, InsightCount: 0,
+	}}
+
+	if err := eng.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt: %v", err)
+	}
+
+	path := filepath.Join(home, ".enola", "receipt.json")
+	first := readReceiptFile(t, path)
+	if len(first.Repos) != 1 || first.Repos[0].Label != "myrepo" {
+		t.Fatalf("single-repo fallback: want one repo labelled myrepo, got %+v", first.Repos)
+	}
+	if first.Repos[0].FactCount != 2 {
+		t.Errorf("fact_count: got %d, want 2", first.Repos[0].FactCount)
+	}
+	if first.Repos[0].AddedAt == "" {
+		t.Errorf("added_at should be set")
+	}
+	if first.SnapshotID != "sha256:abc" || first.FactCount != 2 {
+		t.Errorf("graph-level fields: got id=%q fact_count=%d", first.SnapshotID, first.FactCount)
+	}
+	firstAdded := first.Repos[0].AddedAt
+
+	// Regenerate and rewrite: added_at must be preserved (repo did not re-enter).
+	eng.snapshot.Meta.SnapshotID = "sha256:def"
+	if err := eng.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt (2nd): %v", err)
+	}
+	second := readReceiptFile(t, path)
+	if second.Repos[0].AddedAt != firstAdded {
+		t.Errorf("added_at not preserved across regenerations: %q != %q", second.Repos[0].AddedAt, firstAdded)
+	}
+	if second.SnapshotID != "sha256:def" {
+		t.Errorf("snapshot_id should update: got %q", second.SnapshotID)
+	}
+}
+
+func TestCrossRepoEdgeCount(t *testing.T) {
+	st := facts.NewStore()
+	// Three repos as service nodes; A->B and A->C are the cross-repo edges, carried
+	// as depends_on relations on A's service node. Plenty of ordinary KindDependency
+	// facts also exist and must NOT be counted.
+	st.Add(
+		facts.Fact{Kind: facts.KindService, Name: "A", Repo: "A", Relations: []facts.Relation{
+			{Kind: facts.RelDependsOn, Target: "B"},
+			{Kind: facts.RelDependsOn, Target: "C"},
+		}},
+		facts.Fact{Kind: facts.KindService, Name: "B", Repo: "B"},
+		facts.Fact{Kind: facts.KindService, Name: "C", Repo: "C"},
+		facts.Fact{Kind: facts.KindDependency, Name: "some/import", Repo: "A"},
+		facts.Fact{Kind: facts.KindDependency, Name: "other/import", Repo: "B"},
+	)
+	if got := crossRepoEdgeCount(st); got != 2 {
+		t.Errorf("crossRepoEdgeCount: got %d, want 2 (must not count ordinary dependency facts)", got)
+	}
+
+	// Single-repo graph: no service nodes => zero cross-repo edges.
+	single := facts.NewStore()
+	single.Add(facts.Fact{Kind: facts.KindSymbol, Name: "s", Repo: "solo"})
+	if got := crossRepoEdgeCount(single); got != 0 {
+		t.Errorf("crossRepoEdgeCount(single-repo): got %d, want 0", got)
+	}
+}
+
+// index keys entries by label for order-independent assertions.
+func index(entries []facts.GraphRepoEntry) map[string]facts.GraphRepoEntry {
+	m := make(map[string]facts.GraphRepoEntry, len(entries))
+	for _, e := range entries {
+		m[e.Label] = e
+	}
+	return m
+}
+
+func readReceiptFile(t *testing.T, path string) facts.GraphReceipt {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var gr facts.GraphReceipt
+	if err := json.Unmarshal(data, &gr); err != nil {
+		t.Fatalf("unmarshaling receipt: %v", err)
+	}
+	return gr
+}

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -283,3 +283,33 @@ func (m SnapshotMeta) Receipt() Receipt {
 		},
 	}
 }
+
+// GraphReceipt is the graph-wide manifest written to ~/.enola/receipt.json — it
+// describes the CURRENT multi-repo "graph of graphs": which repositories compose
+// it, the git commit each sits on, when each entered the graph and how long it has
+// been a member, and what the graph consists of now. Unlike the per-repo Receipt
+// (which proves what one deterministic snapshot was generated over), this is a
+// machine-global picture of the live graph. It works for a single-repo graph too
+// (Repos then has one entry).
+type GraphReceipt struct {
+	GeneratedAt     string           `json:"generated_at"`       // RFC3339 UTC, this write
+	EnolaVersion    string           `json:"enola_version"`      // build version that produced the current graph
+	SnapshotID      string           `json:"snapshot_id"`        // whole-graph content fingerprint (SnapshotMeta.SnapshotID)
+	FactCount       int              `json:"fact_count"`         // total facts across all repos
+	InsightCount    int              `json:"insight_count"`      // total insights
+	ServiceCount    int              `json:"service_count"`         // KindService nodes = repos materialized in the cross-repo graph
+	CrossRepoEdgeCount int           `json:"cross_repo_edge_count"` // consumer->provider edges in the cross-repo "graph of graphs" (NOT the total dependency-fact count, which also covers ordinary imports)
+	Coverage        *CoverageSummary `json:"coverage,omitempty"`    // cross-repo edge-coverage rollup, nil in single-repo mode
+	Repos           []GraphRepoEntry `json:"repos"`              // one entry per repository in the graph, sorted by Label
+}
+
+// GraphRepoEntry describes one repository's membership in the current graph.
+type GraphRepoEntry struct {
+	Label           string   `json:"label"`                       // filepath.Base(absRepo); the store's repo label
+	Path            string   `json:"path"`                        // absolute repo root
+	Git             *GitInfo `json:"git,omitempty"`               // ref/commit/dirty; nil for non-git dirs
+	AddedAt         string   `json:"added_at"`                    // RFC3339 UTC, first time this label entered the graph (merged forward across regenerations)
+	InGraphFor      string   `json:"in_graph_for"`                // human duration since AddedAt (e.g. "72h3m0s"); derived, recomputed each write
+	FactCount       int      `json:"fact_count"`                  // facts tagged with this repo label
+	CommitChangedAt string   `json:"commit_changed_at,omitempty"` // RFC3339 UTC, last time the recorded commit moved; AddedAt is NOT reset when the commit changes
+}

--- a/internal/facts/store.go
+++ b/internal/facts/store.go
@@ -148,6 +148,14 @@ func (s *Store) ByRepo(repo string) []Fact {
 	return s.collectByIndex(s.byRepo[repo])
 }
 
+// CountByRepo returns how many facts carry the given repo label, in O(1) from the
+// byRepo index without materializing (and copying) the facts themselves.
+func (s *Store) CountByRepo(repo string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.byRepo[repo])
+}
+
 // ByRelation returns all facts that have a relation of the given kind.
 func (s *Store) ByRelation(relKind string) []Fact {
 	s.mu.RLock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -458,6 +458,11 @@ func (s *Server) registerTools() {
 			log.Printf("[server] warning: failed to write artifacts: %v", err)
 		}
 
+		// Refresh the graph-wide receipt at ~/.enola/receipt.json (non-fatal).
+		if err := s.eng.WriteGlobalReceipt(); err != nil {
+			log.Printf("[server] warning: failed to write global receipt: %v", err)
+		}
+
 		// Return summary
 		summary := fmt.Sprintf(
 			"Snapshot generated successfully.\n\n"+

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -99,6 +99,11 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	return e.eng.WriteArtifacts(repoPath)
 }
 
+// WriteGlobalReceipt refreshes the graph-wide receipt at ~/.enola/receipt.json.
+func (e *Engine) WriteGlobalReceipt() error {
+	return e.eng.WriteGlobalReceipt()
+}
+
 // SetBaseline pins the current on-disk snapshot as the diff baseline.
 func (e *Engine) SetBaseline(repoPath string) error {
 	return e.eng.SetBaseline(repoPath)


### PR DESCRIPTION
Add a global receipt describing the CURRENT multi-repo "graph of graphs": which repositories compose it, each repo's git commit/ref/dirty state, when each entered the graph and how long it has been a member, and what the graph consists of right now (fact/insight counts, cross-repo services and edges, coverage). Complements the existing per-repo <repo>/.enola/receipt.json.

- New GraphReceipt/GraphRepoEntry types (internal/facts/model.go)
- Engine.WriteGlobalReceipt(): per-repo git capture across every repo in the graph, merge-forward of added_at (preserved across regenerations; a moved commit keeps added_at and stamps commit_changed_at), atomic temp-file+rename write, graceful degradation when $HOME is unavailable (internal/engine/global_receipt.go)
- service_count / cross_repo_edge_count describe the graph-of-graphs topology (edges counted from service-node depends_on relations, not total dep facts)
- Store.CountByRepo() for O(1) per-repo fact counts (internal/facts/store.go)
- Wire into CLI --generate and the MCP generate_snapshot handler (non-fatal)
- Unit tests: merge-forward, commit-change, departed-repo, single-repo fallback, atomic write/read, cross-repo edge count