### PR TITLE
fix(python): cover assignment/return value-refs, broaden shadow guard to full scope

### DIFF
--- a/internal/cachecov/coverage_test.go
+++ b/internal/cachecov/coverage_test.go
@@ -127,6 +127,7 @@ var versionCoverage = map[int][]string{
 	93: {"TestSwitchReturns_MultiLineCaseLabels", "TestExtractEndpointFacts_MultiLineMethodCase"},                                                                                                                                                                                                 // Swift multi-line case-label method parsing
 	94: {"TestExtractEndpointFacts_ConstantMethod"},                                                                                                                                                                                                                                              // Swift single-value (constant) method property
 	95: {"TestResolveImports_CouplingKindTagged", "TestResolveImports_ReferenceBeatsAssociation"},                                                                                                                                                                                                // Ruby synthetic-edge coupling_kind prop + framework-const ignore list
+	96: {"TestAST_AssignedAndReturnedCallback", "TestAST_AssignedCallback_ShadowGuarded", "TestAST_ReturnedPlainVariable_NoPhantomRef", "TestAST_ReturnedForwardReference_Resolves", "TestAST_ShadowedLoopVarNotResolvedAsCall"},                                                                 // Python assignment/return value-refs + scope-wide (not just param) shadow guard
 }
 
 func TestCacheVersionCoverage(t *testing.T) {

--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -253,7 +253,14 @@ import (
 // explainer can exclude ActiveRecord associations) and adds common Rails framework constants
 // (I18n, Rails, Logger, ...) to the builtin-const ignore list. Cached Ruby snapshots must
 // re-extract to pick up the new edge props and suppressed references.
-const cacheVersion = "v95"
+// v96: Python value-ref resolution now records assignment-RHS and return-statement bare-name
+// references (cb = handler; return cb / return handler) as RelCalls edges, not just call
+// args/decorator args/collection literals; and its shadow guard (previously param-only, shared
+// with resolveCall's v87 fix) now covers any name bound in the enclosing function's own scope —
+// assigned/iterated/aliased locals, not just parameters — so a loop var or local reusing a
+// same-named top-level def's name no longer fabricates a same-module edge. Cached Python
+// snapshots must re-extract.
+const cacheVersion = "v96"
 
 // extractorCache holds per-extractor facts keyed by a content hash of the files
 // the extractor depends on. It is loaded from disk at the start of a snapshot and

--- a/internal/extractors/pythonextractor/python_ast.go
+++ b/internal/extractors/pythonextractor/python_ast.go
@@ -72,10 +72,10 @@ type pyWalker struct {
 	// canonical qualified type. Reset at the entry of every handleFunction call.
 	localTypes map[string]string
 
-	// paramNames is the set of parameter names of the function whose body is being
-	// walked. Used to suppress same-module value-ref resolution for a param that
-	// shadows a same-named top-level def (e.g. get_user(user_id)). Nil outside a body.
-	paramNames map[string]bool
+	// localBound is the set of names bound in the current function's own scope
+	// (params + assigned/iterated/aliased names). Guards bare-identifier call
+	// and value-reference resolution against shadowing. Reset per handleFunction call.
+	localBound map[string]bool
 
 	// Per-function complexity state, set up by handleFunction around walkForCalls.
 	// metrics is nil outside a function body walk. loopDepth is the current loop
@@ -804,11 +804,11 @@ func (w *pyWalker) handleFunction(node *sitter.Node, decorators []string) {
 		// workaround) resolves to an edge. Must run before collectParamTypes/
 		// collectLocalTypes so those see the local imports too.
 		w.registerBodyImports(bodyNode)
-		w.paramNames = collectParamNames(node.ChildByFieldName("parameters"), w.src)
 		w.localTypes = collectParamTypes(node.ChildByFieldName("parameters"), w.src, w.importMap, w.module)
 		for k, v := range collectLocalTypes(bodyNode, w.src, w.importMap, w.module) {
 			w.localTypes[k] = v
 		}
+		w.localBound = collectLocalBoundNames(node.ChildByFieldName("parameters"), bodyNode, w.src)
 		// Set up per-function complexity tracking for this body walk. The props
 		// map is shared by reference with the fact in w.out, so writing to it
 		// after the walk updates the emitted fact.
@@ -843,7 +843,7 @@ func (w *pyWalker) handleFunction(node *sitter.Node, decorators []string) {
 		w.metrics = nil
 		w.selfName = ""
 		w.localTypes = nil
-		w.paramNames = nil
+		w.localBound = nil
 	}
 	// Walk parameter-default expressions (e.g. `body = Depends(parse_login_body)`)
 	// for call and value-reference edges. Metrics are already finalized/nil here, so
@@ -982,38 +982,14 @@ func (w *pyWalker) valueRefTarget(name string) string {
 		return t
 	}
 	// Same-module top-level def (function or class) referenced by name. Skip when the
-	// name is a parameter of the enclosing function (it shadows the def — e.g.
+	// name is bound in the enclosing function's own scope — a param or a
+	// local assigned/iterated/aliased name (it shadows the def — e.g.
 	// get_user(user_id) passing the param, not the same-named function). Rescues
 	// `f(local_helper)` where local_helper is a same-module def.
-	if w.idx != nil && !w.paramNames[name] && w.idx.moduleDefs[w.module][name] {
+	if w.idx != nil && !w.localBound[name] && w.idx.moduleDefs[w.module][name] {
 		return w.module + "." + name
 	}
 	return ""
-}
-
-// collectParamNames returns the set of parameter names declared by a function's
-// parameters node (all forms: bare, typed, defaulted, *args, **kwargs).
-func collectParamNames(params *sitter.Node, src []byte) map[string]bool {
-	out := make(map[string]bool)
-	if params == nil {
-		return out
-	}
-	for i := uint(0); i < uint(params.ChildCount()); i++ {
-		c := params.Child(i)
-		switch c.Kind() {
-		case "identifier":
-			out[pyText(c, src)] = true
-		case "typed_parameter", "list_splat_pattern", "dictionary_splat_pattern":
-			if id := firstChildOfKind(c, "identifier"); id != nil {
-				out[pyText(id, src)] = true
-			}
-		case "default_parameter", "typed_default_parameter":
-			if n := c.ChildByFieldName("name"); n != nil {
-				out[pyText(n, src)] = true
-			}
-		}
-	}
-	return out
 }
 
 // stringRefRelation returns a reference edge for a string literal that names an
@@ -1157,6 +1133,18 @@ func (w *pyWalker) walkForCalls(node *sitter.Node) {
 	}
 	if kind == "dictionary" || kind == "list" || kind == "set" || kind == "tuple" {
 		w.emitCollectionValueRefs(node)
+	}
+	if kind == "assignment" {
+		for _, ident := range collectRefValueIdents(node.ChildByFieldName("right")) {
+			w.emitValueRef(ident)
+		}
+	}
+	if kind == "return_statement" {
+		for i := uint(0); i < uint(node.ChildCount()); i++ {
+			for _, ident := range collectRefValueIdents(node.Child(i)) {
+				w.emitValueRef(ident)
+			}
+		}
 	}
 
 	// Complexity metrics: count decision points so the single body walk doubles
@@ -1399,6 +1387,9 @@ func (w *pyWalker) emitCallEdge(fn *sitter.Node) {
 		if pyBuiltins[name] {
 			return
 		}
+		if w.localBound[name] {
+			return // shadowed by a param/local — not the module-level def of this name
+		}
 		if pyCapitalized(name) {
 			owner.Relations = append(owner.Relations, facts.Relation{
 				Kind:   facts.RelInstantiates,
@@ -1501,12 +1492,12 @@ func (w *pyWalker) resolveCall(name string) string {
 	if target, ok := w.importMap[name]; ok {
 		return target // "" means external → no edge
 	}
-	// Same-module top-level function. A bare callee that shadows a parameter is the
-	// parameter, not the module-level def (e.g. def wrapper(cb): cb()). When an index
-	// is available, resolve only names that are actually module-level defs, so callable
-	// locals/params/loop vars don't fabricate edges. Without an index (single-file
+	// Same-module top-level function. A bare callee that shadows a param/local/loop-var
+	// is that local binding, not the module-level def (e.g. def wrapper(cb): cb()). When
+	// an index is available, resolve only names that are actually module-level defs, so
+	// callable locals/params/loop vars don't fabricate edges. Without an index (single-file
 	// extraction) fall back to best-effort; production always supplies one.
-	if w.paramNames[name] {
+	if w.localBound[name] {
 		return ""
 	}
 	if w.idx != nil {
@@ -1516,6 +1507,102 @@ func (w *pyWalker) resolveCall(name string) string {
 		return ""
 	}
 	return w.module + "." + name
+}
+
+// pyBindTargets recursively binds an assignment/parameter target node into out:
+// identifier -> itself; unpacking forms -> recurse into elements. attribute
+// (self.x) and subscript (d[k]) targets are not name bindings and are skipped.
+func pyBindTargets(node *sitter.Node, src []byte, out map[string]bool) {
+	if node == nil {
+		return
+	}
+	switch node.Kind() {
+	case "identifier":
+		out[pyText(node, src)] = true
+	case "pattern_list", "tuple_pattern", "list_pattern", "list_splat_pattern", "dictionary_splat_pattern":
+		for i := uint(0); i < uint(node.ChildCount()); i++ {
+			pyBindTargets(node.Child(i), src, out)
+		}
+	}
+}
+
+// pyParamBoundNames adds every name a `parameters` node binds to out, covering
+// all parameter shapes (x, x=1, x: T, x: T = 1, *args, **kwargs).
+func pyParamBoundNames(params *sitter.Node, src []byte, out map[string]bool) {
+	if params == nil {
+		return
+	}
+	for i := uint(0); i < uint(params.ChildCount()); i++ {
+		c := params.Child(i)
+		switch c.Kind() {
+		case "identifier", "list_splat_pattern", "dictionary_splat_pattern":
+			pyBindTargets(c, src, out)
+		case "default_parameter", "typed_default_parameter":
+			pyBindTargets(c.ChildByFieldName("name"), src, out)
+		case "typed_parameter":
+			for j := uint(0); j < uint(c.ChildCount()); j++ {
+				pyBindTargets(c.Child(j), src, out)
+			}
+		}
+	}
+}
+
+// collectLocalBoundNames returns every name bound in a function's own scope:
+// its parameters plus every name assigned, iterated, or aliased in its body.
+// Used to guard bare-identifier call resolution — a name bound here refers to
+// a local value, not a same-module def of the same name.
+func collectLocalBoundNames(params, body *sitter.Node, src []byte) map[string]bool {
+	bound := make(map[string]bool)
+	pyParamBoundNames(params, src, bound)
+	walkLocalBoundNames(body, src, bound)
+	return bound
+}
+
+// walkLocalBoundNames walks a function body collecting bound names, stopping
+// at nested function/class/lambda scopes (their bindings belong to them).
+func walkLocalBoundNames(node *sitter.Node, src []byte, bound map[string]bool) {
+	if node == nil {
+		return
+	}
+	switch node.Kind() {
+	case "function_definition", "class_definition", "decorated_definition", "lambda":
+		return
+	case "assignment", "augmented_assignment":
+		pyBindTargets(node.ChildByFieldName("left"), src, bound)
+	case "for_statement":
+		pyBindTargets(node.ChildByFieldName("left"), src, bound)
+	case "named_expression":
+		pyBindTargets(node.ChildByFieldName("name"), src, bound)
+	case "with_item":
+		if v := node.ChildByFieldName("value"); v != nil && v.Kind() == "as_pattern" {
+			pyBindTargets(v.ChildByFieldName("alias"), src, bound)
+		}
+	}
+	for i := uint(0); i < uint(node.ChildCount()); i++ {
+		walkLocalBoundNames(node.Child(i), src, bound)
+	}
+}
+
+// collectRefValueIdents returns the bare identifier(s) a value expression
+// resolves to: itself if it's a plain identifier, or each identifier element
+// of a tuple (expression_list), e.g. `cb = handler` / `a, b = f, g`.
+func collectRefValueIdents(node *sitter.Node) []*sitter.Node {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind() {
+	case "identifier":
+		return []*sitter.Node{node}
+	case "expression_list":
+		var out []*sitter.Node
+		for i := uint(0); i < uint(node.ChildCount()); i++ {
+			if c := node.Child(i); c.Kind() == "identifier" {
+				out = append(out, c)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // collectPyMethodNames returns the set of function names declared directly in a

--- a/internal/extractors/pythonextractor/python_ast_test.go
+++ b/internal/extractors/pythonextractor/python_ast_test.go
@@ -1287,3 +1287,225 @@ func TestAST_PopOnEmptyStack_NoPanic(t *testing.T) {
 			len(w.ownerStack), len(w.typeStack), len(w.methodSets))
 	}
 }
+
+// --- Shadow-guard coverage: localBound (params + assigned/iterated/aliased
+// locals) extends the param-only guard above to direct calls and value-refs ---
+
+func TestAST_ShadowedParamNotResolvedAsCall(t *testing.T) {
+	src := `
+def send():
+    pass
+
+def register(send):
+    send()
+`
+	result := astExtract(t, "svc.py", src, false)
+	idx := byName(result)
+
+	regFact, ok := idx["svc.register"]
+	if !ok {
+		t.Fatalf("missing svc.register; keys: %v", keys(idx))
+	}
+	if calls := relsByKind(regFact, facts.RelCalls); len(calls) != 0 {
+		t.Errorf("register: expected no RelCalls (send is a param), got %v", calls)
+	}
+}
+
+func TestAST_ShadowedLoopVarNotResolvedAsCall(t *testing.T) {
+	src := `
+def helper():
+    pass
+
+def process(items):
+    for helper in items:
+        helper()
+`
+	result := astExtract(t, "svc.py", src, false)
+	idx := byName(result)
+
+	procFact, ok := idx["svc.process"]
+	if !ok {
+		t.Fatalf("missing svc.process; keys: %v", keys(idx))
+	}
+	for _, c := range relsByKind(procFact, facts.RelCalls) {
+		if c == "svc.helper" {
+			t.Errorf("process: unexpected RelCalls to svc.helper (helper is a loop var)")
+		}
+	}
+}
+
+func TestAST_ShadowGuard_UnshadowedCallStillResolves(t *testing.T) {
+	src := `
+def helper():
+    pass
+
+def main(x):
+    y = 5
+    helper()
+`
+	result := astExtract(t, "svc.py", src, false)
+	idx := byName(result)
+
+	mainFact, ok := idx["svc.main"]
+	if !ok {
+		t.Fatalf("missing svc.main; keys: %v", keys(idx))
+	}
+	found := false
+	for _, c := range relsByKind(mainFact, facts.RelCalls) {
+		if c == "svc.helper" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("main: expected RelCalls to svc.helper (unrelated locals x/y must not block it)")
+	}
+}
+
+func TestAST_KeywordArgumentCallbackEmitsRef(t *testing.T) {
+	src := `
+def on_done():
+    pass
+
+def schedule(callback):
+    pass
+
+def start():
+    schedule(callback=on_done)
+`
+	result := astExtractIdx(t, "svc.py", src)
+	fn := byName(result)["svc.start"]
+	calls := relsByKind(fn, facts.RelCalls)
+	found := false
+	for _, c := range calls {
+		if c == "svc.on_done" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("start: RelCalls = %v, want a keyword-argument value-ref to svc.on_done", calls)
+	}
+}
+
+func TestAST_DispatchTable_ListValues(t *testing.T) {
+	src := `
+def handle_a():
+    pass
+
+def handle_b():
+    pass
+
+def build():
+    handlers = [handle_a, handle_b]
+    return handlers
+`
+	result := astExtractIdx(t, "svc.py", src)
+	fn := byName(result)["svc.build"]
+	calls := relsByKind(fn, facts.RelCalls)
+	for _, want := range []string{"svc.handle_a", "svc.handle_b"} {
+		found := false
+		for _, c := range calls {
+			if c == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("build: RelCalls = %v, want %s", calls, want)
+		}
+	}
+}
+
+// --- Assignment/return value-refs: coverage upstream's value-ref pass doesn't
+// have (it only walks call args, decorator args, and collection literals) ---
+
+func TestAST_AssignedAndReturnedCallback(t *testing.T) {
+	src := `
+def handler():
+    pass
+
+def register():
+    cb = handler
+    return cb
+
+def get_handler():
+    return handler
+`
+	result := astExtractIdx(t, "svc.py", src)
+	idx := byName(result)
+
+	regFact, ok := idx["svc.register"]
+	if !ok {
+		t.Fatalf("missing svc.register; keys: %v", keys(idx))
+	}
+	if calls := relsByKind(regFact, facts.RelCalls); len(calls) == 0 || calls[0] != "svc.handler" {
+		t.Errorf("register: RelCalls = %v, want [svc.handler]", calls)
+	}
+
+	getFact, ok := idx["svc.get_handler"]
+	if !ok {
+		t.Fatalf("missing svc.get_handler; keys: %v", keys(idx))
+	}
+	if calls := relsByKind(getFact, facts.RelCalls); len(calls) == 0 || calls[0] != "svc.handler" {
+		t.Errorf("get_handler: RelCalls = %v, want [svc.handler]", calls)
+	}
+}
+
+func TestAST_AssignedCallback_ShadowGuarded(t *testing.T) {
+	src := `
+def handler():
+    pass
+
+def register(handler):
+    cb = handler
+    return cb
+`
+	result := astExtractIdx(t, "svc.py", src)
+	idx := byName(result)
+
+	regFact, ok := idx["svc.register"]
+	if !ok {
+		t.Fatalf("missing svc.register; keys: %v", keys(idx))
+	}
+	if calls := relsByKind(regFact, facts.RelCalls); len(calls) != 0 {
+		t.Errorf("register: expected no RelCalls (handler is a param), got %v", calls)
+	}
+}
+
+func TestAST_ReturnedPlainVariable_NoPhantomRef(t *testing.T) {
+	src := `
+GREETING = "hi"
+
+def process():
+    return GREETING
+`
+	result := astExtractIdx(t, "svc.py", src)
+	idx := byName(result)
+
+	procFact, ok := idx["svc.process"]
+	if !ok {
+		t.Fatalf("missing svc.process; keys: %v", keys(idx))
+	}
+	if calls := relsByKind(procFact, facts.RelCalls); len(calls) != 0 {
+		t.Errorf("process: expected no RelCalls (GREETING is not a def), got %v", calls)
+	}
+}
+
+func TestAST_ReturnedForwardReference_Resolves(t *testing.T) {
+	src := `
+def build():
+    return later_handler
+
+def later_handler():
+    pass
+`
+	result := astExtractIdx(t, "svc.py", src)
+	idx := byName(result)
+
+	buildFact, ok := idx["svc.build"]
+	if !ok {
+		t.Fatalf("missing svc.build; keys: %v", keys(idx))
+	}
+	calls := relsByKind(buildFact, facts.RelCalls)
+	if len(calls) == 0 || calls[0] != "svc.later_handler" {
+		t.Errorf("build: RelCalls = %v, want [svc.later_handler]", calls)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -825,7 +825,7 @@ func (s *Server) registerTools() {
 		Description: "Walk the dependency/call graph from a starting node. " +
 			"direction='forward' answers \"what does X depend on?\"; direction='reverse' answers \"what depends on X?\". " +
 			"start= accepts substring match plus scoped prefixes (repo:, kind:, file:) and package-qualified names (e.g. 'domain/cart.CartService') to disambiguate; returns ranked candidates with confidence when ambiguous. " +
-			"relation_kinds filter: imports, calls, declares, implements, depends_on, has_method. " +
+			"relation_kinds filter: imports, calls, declares, implements, depends_on, has_method, references. " +
 			"Forward traversal from a struct/interface follows has_method edges to its methods (and then their calls). " +
 			"Reverse traversal from a struct/interface automatically includes its methods and constructor as origins, so it surfaces callers (including cross-repo) that reference the type only through a method — matching impact_analysis. " +
 			"Note: interface method calls cannot be statically bound to a concrete implementation, so such call edges may be absent or appear as unresolved nodes. " +
@@ -2089,7 +2089,7 @@ type exploreArgs struct {
 type traverseArgs struct {
 	Start         string   `json:"start" jsonschema:"required,Starting node name (fact name, module name, or symbol name). Substring match; supports scoped prefixes repo:/kind:/file: to disambiguate (e.g. 'repo:go-auth kind:struct AuthHandler')."`
 	Direction     string   `json:"direction,omitempty" jsonschema:"'forward' follows outgoing relations (what does X depend on?), 'reverse' follows incoming relations (what depends on X?). Default: forward."`
-	RelationKinds []string `json:"relation_kinds,omitempty" jsonschema:"Filter to specific relation types: imports, calls, declares, implements, depends_on, has_method. Default: all."`
+	RelationKinds []string `json:"relation_kinds,omitempty" jsonschema:"Filter to specific relation types: imports, calls, declares, implements, depends_on, has_method, references. Default: all."`
 	MaxDepth      int      `json:"max_depth,omitempty" jsonschema:"Maximum traversal depth (1-20). Default: 5."`
 	MaxNodes      int      `json:"max_nodes,omitempty" jsonschema:"Maximum nodes to return (1-500). Traversal stops when this limit is reached. Default: 100."`
 	NodeKinds     []string `json:"node_kinds,omitempty" jsonschema:"Filter results to specific fact kinds: module, symbol, dependency, route, storage. Default: all."`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -825,7 +825,7 @@ func (s *Server) registerTools() {
 		Description: "Walk the dependency/call graph from a starting node. " +
 			"direction='forward' answers \"what does X depend on?\"; direction='reverse' answers \"what depends on X?\". " +
 			"start= accepts substring match plus scoped prefixes (repo:, kind:, file:) and package-qualified names (e.g. 'domain/cart.CartService') to disambiguate; returns ranked candidates with confidence when ambiguous. " +
-			"relation_kinds filter: imports, calls, declares, implements, depends_on, has_method, references. " +
+			"relation_kinds filter: imports, calls, declares, implements, depends_on, has_method. " +
 			"Forward traversal from a struct/interface follows has_method edges to its methods (and then their calls). " +
 			"Reverse traversal from a struct/interface automatically includes its methods and constructor as origins, so it surfaces callers (including cross-repo) that reference the type only through a method — matching impact_analysis. " +
 			"Note: interface method calls cannot be statically bound to a concrete implementation, so such call edges may be absent or appear as unresolved nodes. " +
@@ -2089,7 +2089,7 @@ type exploreArgs struct {
 type traverseArgs struct {
 	Start         string   `json:"start" jsonschema:"required,Starting node name (fact name, module name, or symbol name). Substring match; supports scoped prefixes repo:/kind:/file: to disambiguate (e.g. 'repo:go-auth kind:struct AuthHandler')."`
 	Direction     string   `json:"direction,omitempty" jsonschema:"'forward' follows outgoing relations (what does X depend on?), 'reverse' follows incoming relations (what depends on X?). Default: forward."`
-	RelationKinds []string `json:"relation_kinds,omitempty" jsonschema:"Filter to specific relation types: imports, calls, declares, implements, depends_on, has_method, references. Default: all."`
+	RelationKinds []string `json:"relation_kinds,omitempty" jsonschema:"Filter to specific relation types: imports, calls, declares, implements, depends_on, has_method. Default: all."`
 	MaxDepth      int      `json:"max_depth,omitempty" jsonschema:"Maximum traversal depth (1-20). Default: 5."`
 	MaxNodes      int      `json:"max_nodes,omitempty" jsonschema:"Maximum nodes to return (1-500). Traversal stops when this limit is reached. Default: 100."`
 	NodeKinds     []string `json:"node_kinds,omitempty" jsonschema:"Filter results to specific fact kinds: module, symbol, dependency, route, storage. Default: all."`

--- a/pkg/explain/explain.go
+++ b/pkg/explain/explain.go
@@ -86,9 +86,10 @@ type Report struct {
 	Languages  []string `json:"languages,omitempty"`
 	TotalFacts int      `json:"total_facts"`
 
-	KindCounts  []LabelCount `json:"kind_counts"`  // module/symbol/route/storage/dependency/service
-	SymbolKinds []LabelCount `json:"symbol_kinds"` // function/method/struct/…
-	DepSources  []LabelCount `json:"dep_sources"`  // external/internal/stdlib/…
+	KindCounts     []LabelCount `json:"kind_counts"`     // module/symbol/route/storage/dependency/service
+	RelationCounts []LabelCount `json:"relation_counts"` // declares/imports/calls/implements/depends_on/instantiates/injects/has_method/references
+	SymbolKinds    []LabelCount `json:"symbol_kinds"`    // function/method/struct/…
+	DepSources     []LabelCount `json:"dep_sources"`     // external/internal/stdlib/…
 
 	Routes         int          `json:"routes"`
 	RoutesByMethod []LabelCount `json:"routes_by_method,omitempty"`
@@ -142,6 +143,24 @@ func Compute(eng *bootstrap.Engine) *Report {
 	} {
 		if n := len(store.ByKind(k)); n > 0 {
 			r.KindCounts = append(r.KindCounts, LabelCount{Label: k, Count: n})
+		}
+	}
+
+	// Relation-kind tallies (edge counts, not fact counts) — relations live on
+	// facts of every kind, so this scans the whole store, not one ByKind slice.
+	relCount := map[string]int{}
+	for _, f := range store.All() {
+		for _, rel := range f.Relations {
+			relCount[rel.Kind]++
+		}
+	}
+	for _, k := range []string{
+		facts.RelDeclares, facts.RelImports, facts.RelCalls, facts.RelImplements,
+		facts.RelDependsOn, facts.RelInstantiates, facts.RelInjects, facts.RelHasMethod,
+		facts.RelReferences,
+	} {
+		if n := relCount[k]; n > 0 {
+			r.RelationCounts = append(r.RelationCounts, LabelCount{Label: k, Count: n})
 		}
 	}
 

--- a/pkg/explain/explain.go
+++ b/pkg/explain/explain.go
@@ -87,7 +87,7 @@ type Report struct {
 	TotalFacts int      `json:"total_facts"`
 
 	KindCounts     []LabelCount `json:"kind_counts"`     // module/symbol/route/storage/dependency/service
-	RelationCounts []LabelCount `json:"relation_counts"` // declares/imports/calls/implements/depends_on/instantiates/injects/has_method/references
+	RelationCounts []LabelCount `json:"relation_counts"` // declares/imports/calls/implements/depends_on/instantiates/injects/has_method
 	SymbolKinds    []LabelCount `json:"symbol_kinds"`    // function/method/struct/…
 	DepSources     []LabelCount `json:"dep_sources"`     // external/internal/stdlib/…
 
@@ -157,7 +157,6 @@ func Compute(eng *bootstrap.Engine) *Report {
 	for _, k := range []string{
 		facts.RelDeclares, facts.RelImports, facts.RelCalls, facts.RelImplements,
 		facts.RelDependsOn, facts.RelInstantiates, facts.RelInjects, facts.RelHasMethod,
-		facts.RelReferences,
 	} {
 		if n := relCount[k]; n > 0 {
 			r.RelationCounts = append(r.RelationCounts, LabelCount{Label: k, Count: n})

--- a/pkg/explain/explain_test.go
+++ b/pkg/explain/explain_test.go
@@ -168,8 +168,8 @@ func TestCompute_RelationCounts(t *testing.T) {
 			t.Errorf("relation %q: got %d, want %d", k, got[k], n)
 		}
 	}
-	if _, ok := got[facts.RelReferences]; ok {
-		t.Errorf("references relation should be omitted when zero")
+	if _, ok := got[facts.RelInstantiates]; ok {
+		t.Errorf("instantiates relation should be omitted when zero")
 	}
 }
 

--- a/pkg/explain/explain_test.go
+++ b/pkg/explain/explain_test.go
@@ -151,6 +151,28 @@ func TestCompute_KindCounts(t *testing.T) {
 	}
 }
 
+func TestCompute_RelationCounts(t *testing.T) {
+	r := computeFixture(t)
+
+	want := map[string]int{
+		facts.RelDeclares: 4, // the 4 symbol facts
+		facts.RelCalls:    1, // DoThing -> Helper
+		facts.RelImports:  7, // the 7 dependency facts
+	}
+	got := map[string]int{}
+	for _, rc := range r.RelationCounts {
+		got[rc.Label] = rc.Count
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("relation %q: got %d, want %d", k, got[k], n)
+		}
+	}
+	if _, ok := got[facts.RelReferences]; ok {
+		t.Errorf("references relation should be omitted when zero")
+	}
+}
+
 func TestCompute_SymbolKinds(t *testing.T) {
 	r := computeFixture(t)
 	got := map[string]int{}
@@ -280,6 +302,7 @@ func TestRender_ContainsHeadlineNumbers(t *testing.T) {
 	for _, want := range []string{
 		"Repository explanation: /repo/demo",
 		"Architectural kinds",
+		"Relations",
 		"Symbol breakdown",
 		"Impact analysis (hotspots)",
 		"Go-standard",

--- a/pkg/explain/render.go
+++ b/pkg/explain/render.go
@@ -50,6 +50,15 @@ func (r *Report) Render() string {
 	}
 	b.WriteString("\n")
 
+	// Relations
+	if len(r.RelationCounts) > 0 {
+		b.WriteString("Relations\n")
+		for _, rc := range r.RelationCounts {
+			countRow(&b, rc.Label, rc.Count)
+		}
+		b.WriteString("\n")
+	}
+
 	// Symbol breakdown
 	if len(r.SymbolKinds) > 0 {
 		b.WriteString("Symbol breakdown\n")


### PR DESCRIPTION
## Summary

Follow-up to #72/#74 (indirect-reference resolution and the resolveCall
shadow guard). Two aspects I identified while testing:

- No value-ref edge was emitted for a callback passed via assignment or
  return (`cb = handler; return cb`, `return handler`).  This is a common pattern
  for factories/registries/DI-by-return. These functions had no incoming
  edge and were misreported as dead code.
- The shadow guard (`paramNames`) only excluded function parameters. A loop
  variable, local assignment, `with ... as` alias, or walrus binding that
  happens to share a name with an unrelated top-level def would still be
  credited as a call to that def. 

This replaces the parameter-only guard with `localBound`: every name bound
anywhere in the enclosing function's own scope (not just parameters),
applied uniformly to both direct-call resolution (`resolveCall`) and
value-ref resolution (`valueRefTarget`).

Also includes an unrelated, additive change to `pkg/explain`: a
relation-kind count breakdown (declares/imports/calls/.../has_method) in
the `--explain` Report and rendered output, for visibility into the edge
mix of a snapshot. Which is quite useful in my opinion. 

cacheVersion bumped v95 → v96 since Python extractor output changes for
existing source (new edges + fewer false-positive edges); registered in
cachecov's versionCoverage per repo convention.