### PR TITLE
fix(diff): pair colliding facts positionally instead of last-write-wins

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -116,28 +116,28 @@ func Compute(baseline, current *facts.Snapshot) *SnapshotDiff {
 	baseFacts := snapFacts(baseline)
 	curFacts := snapFacts(current)
 
-	baseByKey := make(map[string]facts.Fact, len(baseFacts))
-	for _, f := range baseFacts {
-		baseByKey[factKey(f)] = f
-	}
-	curByKey := make(map[string]facts.Fact, len(curFacts))
-	for _, f := range curFacts {
-		curByKey[factKey(f)] = f
-	}
+	baseByKey := groupByKey(baseFacts)
+	curByKey := groupByKey(curFacts)
 
-	for k, cf := range curByKey {
-		bf, ok := baseByKey[k]
-		if !ok {
-			d.FactsAdded = append(d.FactsAdded, cf)
-			continue
-		}
-		if propsChanged(bf, cf) {
-			d.FactsChanged = append(d.FactsChanged, FactChange{Before: bf, After: cf})
+	for k, curGroup := range curByKey {
+		baseGroup := baseByKey[k]
+		// Pair member i of the baseline group with member i of the current group.
+		// Both groups are ordered by intraGroupOrder, so the pairing is stable
+		// across the on-disk baseline and the in-memory current snapshot.
+		for i, cf := range curGroup {
+			if i >= len(baseGroup) {
+				d.FactsAdded = append(d.FactsAdded, cf)
+				continue
+			}
+			if propsChanged(baseGroup[i], cf) {
+				d.FactsChanged = append(d.FactsChanged, FactChange{Before: baseGroup[i], After: cf})
+			}
 		}
 	}
-	for k, bf := range baseByKey {
-		if _, ok := curByKey[k]; !ok {
-			d.FactsRemoved = append(d.FactsRemoved, bf)
+	for k, baseGroup := range baseByKey {
+		curGroup := curByKey[k]
+		for i := len(curGroup); i < len(baseGroup); i++ {
+			d.FactsRemoved = append(d.FactsRemoved, baseGroup[i])
 		}
 	}
 
@@ -398,12 +398,69 @@ func factKey(f facts.Fact) string {
 	return f.Kind + "\x00" + f.Repo + "\x00" + f.File + "\x00" + f.Name + "\x00" + factDiscriminator(f)
 }
 
+// groupByKey buckets facts by factKey, preserving every member rather than
+// letting the last one win.
+//
+// factKey is NOT unique even with a discriminator, and no prop can make it so:
+// Swift declares the same class twice under mutually exclusive #if/#else
+// branches, overloaded methods share a name and symbol_kind, and a dependency
+// fact's name already embeds its import target, so two imports of one target in
+// one file are identical in name, props AND relations. Such facts differ only
+// by line. Keying them into a map[string]Fact silently dropped all but one, so
+// a deletion produced no diff entry and — because the on-disk baseline and the
+// in-memory current iterate facts in different orders — the surviving
+// representative differed between the two sides, reporting a "changed" fact
+// between byte-identical fact sets.
+//
+// Each bucket is sorted by intraGroupOrder so the two sides pair positionally.
+func groupByKey(fs []facts.Fact) map[string][]facts.Fact {
+	groups := make(map[string][]facts.Fact, len(fs))
+	for _, f := range fs {
+		k := factKey(f)
+		groups[k] = append(groups[k], f)
+	}
+	for _, g := range groups {
+		if len(g) > 1 {
+			sort.Slice(g, func(i, j int) bool { return intraGroupOrder(g[i]) < intraGroupOrder(g[j]) })
+		}
+	}
+	return groups
+}
+
+// intraGroupOrder totally orders facts that share a factKey. Line comes first
+// because it is the only field that reliably separates them and it is stable
+// under the edits that matter: an insertion above the group shifts every member
+// equally, preserving their relative order, so the pairing does not churn.
+//
+// This is the ONLY place line participates in matching, and only WITHIN a group
+// that already shares an identity. It never enters factKey, so a lone fact that
+// merely moves is still unchanged — see TestCompute_LineShiftIsNotAChange.
+func intraGroupOrder(f facts.Fact) string {
+	return fmt.Sprintf("%09d\x00%s\x00%s", f.Line, propsJSON(f.Props), relationsJSON(f.Relations))
+}
+
+// relationsJSON renders relations order-stably for use as a tiebreak.
+func relationsJSON(rs []facts.Relation) string {
+	if len(rs) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(rs)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 // factDiscriminator returns the props that distinguish facts which legitimately
 // share (kind, repo, file, name). It is kind-specific because only a few kinds
 // have multiple facts per name; for the rest the fully-qualified name is unique.
 // It deliberately uses identity-bearing props (a route's method, a storage
 // reference's operation), not mutable ones, so a genuine attribute change still
 // surfaces as "changed" rather than remove+add.
+//
+// It is no longer load-bearing for correctness — groupByKey handles collisions
+// it cannot separate — but it still improves pairing: a route's GET and DELETE
+// facts match up by method rather than by position.
 func factDiscriminator(f facts.Fact) string {
 	switch f.Kind {
 	case facts.KindRoute:
@@ -413,6 +470,13 @@ func factDiscriminator(f facts.Fact) string {
 	default:
 		return ""
 	}
+}
+
+// factSortKey totally orders facts for deterministic output. It extends factKey
+// with intraGroupOrder so that facts sharing an identity still have a stable
+// relative order in the rendered diff.
+func factSortKey(f facts.Fact) string {
+	return factKey(f) + "\x00" + intraGroupOrder(f)
 }
 
 // propString returns the named prop as a string, or "" if absent.
@@ -554,11 +618,17 @@ func insightMatches(in facts.Insight, focusLC string) bool {
 }
 
 // sortAll orders every collection by its stable key so output is deterministic.
+//
+// Facts are ordered by factSortKey, not factKey: colliding facts share a factKey,
+// and the collections are built by ranging over a map, so factKey alone would
+// leave their relative order to sort.Slice and to Go's randomized map iteration.
 func (d *SnapshotDiff) sortAll() {
-	sort.Slice(d.FactsAdded, func(i, j int) bool { return factKey(d.FactsAdded[i]) < factKey(d.FactsAdded[j]) })
-	sort.Slice(d.FactsRemoved, func(i, j int) bool { return factKey(d.FactsRemoved[i]) < factKey(d.FactsRemoved[j]) })
+	sort.Slice(d.FactsAdded, func(i, j int) bool { return factSortKey(d.FactsAdded[i]) < factSortKey(d.FactsAdded[j]) })
+	sort.Slice(d.FactsRemoved, func(i, j int) bool {
+		return factSortKey(d.FactsRemoved[i]) < factSortKey(d.FactsRemoved[j])
+	})
 	sort.Slice(d.FactsChanged, func(i, j int) bool {
-		return factKey(d.FactsChanged[i].After) < factKey(d.FactsChanged[j].After)
+		return factSortKey(d.FactsChanged[i].After) < factSortKey(d.FactsChanged[j].After)
 	})
 	sort.Slice(d.EdgesAdded, func(i, j int) bool { return edgeKey(d.EdgesAdded[i]) < edgeKey(d.EdgesAdded[j]) })
 	sort.Slice(d.EdgesRemoved, func(i, j int) bool { return edgeKey(d.EdgesRemoved[i]) < edgeKey(d.EdgesRemoved[j]) })

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -264,6 +264,117 @@ func TestCompute_NoChurnFromCollidingRouteMethods(t *testing.T) {
 	}
 }
 
+// classSym builds a symbol fact for a class whose only distinguishing prop is
+// its signature — the shape of a Swift type declared twice under mutually
+// exclusive #if/#else branches. symbol_kind is "class" on both, so no prop
+// discriminates them and only positional pairing can tell them apart.
+func classSym(name, file, signature string, line int) facts.Fact {
+	return facts.Fact{Kind: facts.KindSymbol, Name: name, File: file, Line: line, Repo: "r",
+		Props: map[string]any{"symbol_kind": facts.SymbolClass, "signature": signature}}
+}
+
+// depFact builds a dependency fact. Real dependency names embed the import
+// target ("pkg -> react"), so two imports of the same target in one file are
+// identical in name, props and relations — they differ only by line.
+func depFact(from, target, file string, line int) facts.Fact {
+	return facts.Fact{Kind: facts.KindDependency, Name: from + " -> " + target, File: file, Line: line, Repo: "r",
+		Props:     map[string]any{"source": "external"},
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: target}}}
+}
+
+// TestCompute_NoChurnFromCollidingSymbols is the regression guard for the
+// phantom diff observed on my-golf-journal-ios: ArchitectureFitnessGateTests is
+// declared twice in one file (#if/#else), so two symbol facts share
+// (kind, repo, file, name) and differ only in line and signature. The on-disk
+// baseline and the in-memory current iterate them in different orders, so
+// last-write-wins picks a different representative on each side and the diff
+// reports "changed" between byte-identical fact sets.
+func TestCompute_NoChurnFromCollidingSymbols(t *testing.T) {
+	macOS := classSym("Tests.ArchitectureFitnessGateTests", "Tests/A.swift", "func testFull() throws", 5)
+	iOS := classSym("Tests.ArchitectureFitnessGateTests", "Tests/A.swift", "func testSkipped() throws", 101)
+
+	// Same facts, different iteration order — as disk and memory produce them.
+	d := Compute(snap([]facts.Fact{macOS, iOS}, nil), snap([]facts.Fact{iOS, macOS}, nil))
+	if !d.Empty() {
+		t.Fatalf("colliding symbols churned the diff: %+v", d)
+	}
+}
+
+// TestCompute_CollidingSymbolRemovalIsDetected pins the silent-drop half of the
+// bug: with last-write-wins, one of two colliding facts never reaches the map,
+// so deleting it produces no diff entry at all.
+func TestCompute_CollidingSymbolRemovalIsDetected(t *testing.T) {
+	macOS := classSym("Tests.Gate", "Tests/A.swift", "func testFull() throws", 5)
+	iOS := classSym("Tests.Gate", "Tests/A.swift", "func testSkipped() throws", 101)
+
+	d := Compute(snap([]facts.Fact{macOS, iOS}, nil), snap([]facts.Fact{macOS}, nil))
+	if len(d.FactsRemoved) != 1 {
+		t.Fatalf("expected exactly 1 removed fact, got %d: %+v", len(d.FactsRemoved), d.FactsRemoved)
+	}
+	if got := d.FactsRemoved[0].Line; got != 101 {
+		t.Fatalf("expected the line-101 declaration removed, got line %d", got)
+	}
+	if len(d.FactsAdded) != 0 || len(d.FactsChanged) != 0 {
+		t.Fatalf("removal must not churn: added=%+v changed=%+v", d.FactsAdded, d.FactsChanged)
+	}
+}
+
+// TestCompute_CollidingSymbolPropsChangeIsAChange asserts a real edit to one of
+// two colliding facts still surfaces — the fix must not silence the diff.
+func TestCompute_CollidingSymbolPropsChangeIsAChange(t *testing.T) {
+	a := classSym("Tests.Gate", "Tests/A.swift", "func testFull() throws", 5)
+	b := classSym("Tests.Gate", "Tests/A.swift", "func testSkipped() throws", 101)
+	bEdited := classSym("Tests.Gate", "Tests/A.swift", "func testSkipped() async throws", 101)
+
+	d := Compute(snap([]facts.Fact{a, b}, nil), snap([]facts.Fact{a, bEdited}, nil))
+	if len(d.FactsChanged) != 1 {
+		t.Fatalf("expected exactly 1 changed fact, got %d: %+v", len(d.FactsChanged), d.FactsChanged)
+	}
+	if len(d.FactsAdded) != 0 || len(d.FactsRemoved) != 0 {
+		t.Fatalf("props change must not become add+remove: added=%+v removed=%+v", d.FactsAdded, d.FactsRemoved)
+	}
+	if got := d.FactsChanged[0].After.Line; got != 101 {
+		t.Fatalf("wrong member paired: expected line 101, got %d", got)
+	}
+}
+
+// TestCompute_NoChurnFromCollidingDependencies covers the kind the original bug
+// report named. A dependency fact's name already embeds its import target, so
+// two imports of the same target in one file are identical in name, props AND
+// relations — discriminating on Relations[0].Target cannot separate them.
+func TestCompute_NoChurnFromCollidingDependencies(t *testing.T) {
+	first := depFact("src/app/hub", "react", "src/app/hub/page.tsx", 3)
+	second := depFact("src/app/hub", "react", "src/app/hub/page.tsx", 5)
+
+	d := Compute(snap([]facts.Fact{first, second}, nil), snap([]facts.Fact{second, first}, nil))
+	if !d.Empty() {
+		t.Fatalf("colliding dependencies churned the diff: %+v", d)
+	}
+
+	// And dropping one must be visible.
+	d2 := Compute(snap([]facts.Fact{first, second}, nil), snap([]facts.Fact{first}, nil))
+	if len(d2.FactsRemoved) != 1 {
+		t.Fatalf("expected 1 removed dependency, got %d: %+v", len(d2.FactsRemoved), d2.FactsRemoved)
+	}
+}
+
+// TestCompute_CollidingFactsAreDeterministic guards the output ordering: once
+// colliding facts both survive, factKey alone no longer totally orders them.
+func TestCompute_CollidingFactsAreDeterministic(t *testing.T) {
+	base := snap(nil, nil)
+	cur := snap([]facts.Fact{
+		classSym("Tests.Gate", "Tests/A.swift", "func b() throws", 101),
+		classSym("Tests.Gate", "Tests/A.swift", "func a() throws", 5),
+	}, nil)
+
+	want := Compute(base, cur).RenderCompact()
+	for i := 0; i < 50; i++ {
+		if got := Compute(base, cur).RenderCompact(); got != want {
+			t.Fatalf("nondeterministic output on run %d:\n--- want ---\n%s\n--- got ---\n%s", i, want, got)
+		}
+	}
+}
+
 func TestRenderSummary_EmptyIsExplicit(t *testing.T) {
 	d := Compute(snap(nil, nil), snap(nil, nil))
 	out := d.RenderSummary()


### PR DESCRIPTION
factKey is not unique and no prop can make it so: Swift declares the same class twice under mutually exclusive #if/#else branches, overloaded methods share a name and symbol_kind, and a dependency fact's name already embeds its import target, so two imports of one target in one file are identical in name, props and relations. Such facts differ only by line, and line may not enter identity (diff.go:388, TestCompute_LineShiftIsNotAChange).

Keying them into a map[string]Fact silently dropped all but one. Two symptoms:

  - Deleting a dropped fact produced no diff entry at all. 172 facts across three corpus repos were absent from the diff's map entirely.
  - The on-disk baseline and the in-memory current iterate facts in different orders, so the surviving representative differed between the two sides and diff_snapshot reported a changed fact between byte-identical fact sets.

groupByKey now buckets facts into map[string][]Fact, sorts each bucket by intraGroupOrder (line, propsJSON, relationsJSON), and pairs the two sides positionally. Line is used only as an ordinal within a group that already shares an identity; it never enters factKey, so a lone fact that merely moves is still unchanged.

sortAll orders by factSortKey rather than factKey. Once colliding facts both survive, factKey no longer totally orders them, and the collections are built by ranging over a map -- sort.Slice would have left their order to Go's randomized map iteration, breaking the package's byte-identical-output promise.

The KindRoute/KindStorage discriminators are kept. They are no longer load-bearing for correctness but still pair a route's GET and DELETE facts by method rather than by position.

No cacheVersion bump: internal/diff emits no facts. Verified -- facts.jsonl hashed identically before and after.