### PR TITLE
fix(server): distinguish "cross-repo explainer did not run" from "fou…

### DIFF
--- a/internal/renderers/llmcontext/llm.go
+++ b/internal/renderers/llmcontext/llm.go
@@ -653,6 +653,14 @@ func (r *LLMContextRenderer) renderExtractionQuality(snapshot *facts.Snapshot) s
 		sb.WriteString("\n_These are extraction limits, not code defects — verify against source, and consider whether an extractor, detection, or ignore glob needs improving._\n")
 	}
 
+	// A single-repo snapshot has no service nodes (Coverage is nil), so the cross-repo
+	// linker never ran and the Cross-Repo Dependencies section below renders empty —
+	// byte-identical to a fully-resolved cluster's. State the difference here so its
+	// silence is not read as "no unused routes / no coverage gaps".
+	if m.Coverage == nil {
+		sb.WriteString("- Cross-repo analysis: not run (single-repo snapshot — append client/backend repos to enable unused-routes and coverage)\n")
+	}
+
 	sb.WriteString("\n")
 	return sb.String()
 }

--- a/internal/renderers/llmcontext/llm_test.go
+++ b/internal/renderers/llmcontext/llm_test.go
@@ -350,6 +350,33 @@ func TestExtractionQuality_SingleRepoNoCoverage(t *testing.T) {
 	}
 }
 
+// GAP-LK-04: a real single-repo snapshot (files parsed, but Coverage nil because
+// there are no service nodes) renders the section and must state that the cross-repo
+// linker did not run — otherwise renderCrossRepo's empty section reads identically
+// to a fully-resolved cluster's.
+func TestExtractionQuality_SingleRepoNotesCrossRepoNotRun(t *testing.T) {
+	snapshot := makeSnapshot(nil, nil)
+	snapshot.Meta.FilesSeen = 1920
+	snapshot.Meta.FilesParsed = 1595
+	snapshot.Meta.Coverage = nil // single-repo: no service nodes
+	content := string(mustRender(t, snapshot))
+
+	if !strings.Contains(content, "## Extraction Quality") {
+		t.Fatalf("section should render when files were seen:\n%s", content)
+	}
+	if !strings.Contains(content, "Cross-repo analysis: not run") {
+		t.Errorf("single-repo snapshot must state the cross-repo linker did not run:\n%s", content)
+	}
+}
+
+// The multi-repo shape (Coverage non-nil) must NOT carry the single-repo note.
+func TestExtractionQuality_MultiRepoOmitsCrossRepoNotRun(t *testing.T) {
+	content := renderWithCoverage(t, &facts.CoverageSummary{ServicesTotal: 4})
+	if strings.Contains(content, "Cross-repo analysis: not run") {
+		t.Errorf("multi-repo snapshot must not claim cross-repo analysis did not run:\n%s", content)
+	}
+}
+
 // bigRepoMapSnapshot returns a snapshot whose Repository Map alone overruns any
 // small token budget — the shape of a real multi-repo cluster.
 func bigRepoMapSnapshot(modules int, cov *facts.CoverageSummary) *facts.Snapshot {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -248,6 +248,75 @@ func filterInsights(insights []facts.Insight, explainer, repo string, minConfide
 	return out
 }
 
+// crossRepoExplainer reports whether name identifies an explainer whose findings
+// depend on KindService nodes — the cross-repo "graph of graphs" the linker builds
+// only for a multi-repo (append-mode) snapshot. On a single-repo snapshot these
+// explainers return nothing not because the code is clean but because they could
+// not run; the response must say which. Keep in sync with crossrepo.ComputeLinks,
+// which returns nil below two repos.
+func crossRepoExplainer(name string) bool {
+	switch name {
+	case "unused-routes", "coverage", "crossrepo":
+		return true
+	}
+	return false
+}
+
+// producingExplainers returns the sorted, de-duplicated set of explainer names
+// that actually produced at least one insight in snap, read from the Insight.Source
+// the engine stamps. Unlike SnapshotMeta.Explainers — the ran-without-error set,
+// which includes explainers gated out to zero insights — this lists only the
+// genuine sources, so it never implies an insight came from an explainer that
+// produced none.
+func producingExplainers(snap *facts.Snapshot) []string {
+	seen := map[string]struct{}{}
+	for _, in := range snap.Insights {
+		if in.Source != "" {
+			seen[in.Source] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// noMatchInsightsMessage builds the query_insights response for the case where no
+// insight matched the filter. It separates three situations the old single string
+// conflated: nothing was produced at all; a cross-repo explainer could not run
+// because the snapshot is single-repo (no KindService nodes); and a genuine
+// no-match. The middle wording mirrors coverage_report's, so the two surfaces read
+// the same for the same underlying cause.
+func noMatchInsightsMessage(explainer, repo string, minConfidence float64, snap *facts.Snapshot, store *facts.Store) string {
+	if len(snap.Insights) == 0 {
+		return "No insights were produced for this snapshot."
+	}
+	if crossRepoExplainer(explainer) && len(store.ByKind(facts.KindService)) == 0 {
+		return fmt.Sprintf(
+			"Explainer %q did not run: it needs a multi-repo (append-mode) snapshot. "+
+				"Snapshot the backend, then each client with append=true.", explainer)
+	}
+	return fmt.Sprintf(
+		"No insights matched (explainer=%q, repo=%q, min_confidence=%.2f). The snapshot has %d insight(s) produced by: %v. "+
+			"Call query_insights without filters to list them.",
+		explainer, repo, minConfidence, len(snap.Insights), producingExplainers(snap))
+}
+
+// singleRepoServiceHint returns an append-mode hint (and true) when a
+// query_facts(kind=service) call returned nothing because the snapshot is
+// single-repo — service nodes exist only in multi-repo (append-mode) snapshots, so
+// a bare marshalled null here reads like an absence of edges rather than an absence
+// of the whole cross-repo graph. Mirrors coverage_report's wording.
+func singleRepoServiceHint(kind string, resultCount int, store *facts.Store) (string, bool) {
+	if kind == facts.KindService && resultCount == 0 && len(store.RepoLabels()) <= 1 {
+		return "No service nodes found: query_facts(kind=\"service\") needs a multi-repo (append-mode) snapshot. " +
+			"Snapshot the backend, then each client with append=true.", true
+	}
+	return "", false
+}
+
 // pathInRepo reports whether a repo-prefixed evidence path (e.g.
 // "golf/internal/x.go") belongs to repo (given lowercased). Matching is on the
 // first path segment, so "golf" does not match "golf-ui/..." or
@@ -598,6 +667,13 @@ func (s *Server) registerTools() {
 			extra, extraTotal := store.QueryAdvanced(opts)
 			results = append(results, extra...)
 			total += extraTotal
+		}
+
+		// A query_facts(kind=service) that comes back empty on a single-repo snapshot
+		// means the cross-repo graph was never built, not that this service is a leaf.
+		// Say so, mirroring coverage_report, instead of returning a bare null.
+		if hint, ok := singleRepoServiceHint(args.Kind, len(results), store); ok {
+			return textResult(hint), nil, nil
 		}
 
 		// Non-JSON output modes: return text instead of JSON.
@@ -1094,12 +1170,7 @@ func (s *Server) registerTools() {
 		}
 		matched := filterInsights(snap.Insights, args.Explainer, args.Repo, args.MinConfidence, len(repos) > 1)
 		if len(matched) == 0 {
-			if len(snap.Insights) == 0 {
-				return textResult("No insights were produced for this snapshot."), nil, nil
-			}
-			return textResult(fmt.Sprintf(
-				"No insights matched (explainer=%q, repo=%q, min_confidence=%.2f). The snapshot has %d insight(s) from these explainers: %v. Call query_insights without filters to list them.",
-				args.Explainer, args.Repo, args.MinConfidence, len(snap.Insights), snap.Meta.Explainers)), nil, nil
+			return textResult(noMatchInsightsMessage(args.Explainer, args.Repo, args.MinConfidence, snap, s.eng.Store())), nil, nil
 		}
 
 		switch resolveOutputMode(args.OutputMode, modeSummary) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1989,3 +1989,85 @@ func TestReadEdgeCoverage_JSONRoundTripShape(t *testing.T) {
 		t.Errorf("readEdgeCoverage = %+v, want detected 4 resolved 1 unresolved 3", cov)
 	}
 }
+
+// --- GAP-LK-04: cross-repo explainers must not degrade silently ---
+
+func TestCrossRepoExplainer(t *testing.T) {
+	for _, name := range []string{"unused-routes", "coverage", "crossrepo"} {
+		if !crossRepoExplainer(name) {
+			t.Errorf("crossRepoExplainer(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"god-class", "cycles", "hotspots", ""} {
+		if crossRepoExplainer(name) {
+			t.Errorf("crossRepoExplainer(%q) = true, want false", name)
+		}
+	}
+}
+
+// A cross-repo explainer on a single-repo store (no KindService facts) could not
+// run at all — its response must say so, not read like a clean "nothing found".
+func TestNoMatchInsightsMessage_CrossRepoDidNotRun(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(facts.Fact{Kind: facts.KindRoute, Name: "GET /x", Props: map[string]any{"role": "server"}})
+	snap := &facts.Snapshot{Insights: []facts.Insight{{Title: "gc", Source: "god-class"}}}
+
+	msg := noMatchInsightsMessage("unused-routes", "", 0, snap, store)
+	if !strings.Contains(msg, "did not run") || !strings.Contains(msg, "append=true") {
+		t.Errorf("expected a did-not-run/append hint, got: %q", msg)
+	}
+	if strings.Contains(msg, "No insights matched") {
+		t.Errorf("a gated-out cross-repo explainer must not read as a clean no-match: %q", msg)
+	}
+}
+
+// With a KindService fact the linker ran, so a no-match is genuine. The message
+// must also list only the explainers that actually produced insights (from
+// Insight.Source), not the ran-without-error set — the old misattribution.
+func TestNoMatchInsightsMessage_RanFoundNothing(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(facts.Fact{Kind: facts.KindService, Name: "svc", Repo: "svc"})
+	snap := &facts.Snapshot{Insights: []facts.Insight{{Title: "gc", Source: "god-class"}}}
+
+	msg := noMatchInsightsMessage("unused-routes", "", 0, snap, store)
+	if !strings.Contains(msg, "No insights matched") {
+		t.Errorf("with services present the explainer ran; expected a genuine no-match: %q", msg)
+	}
+	// The source list names only explainers that produced an insight. unused-routes
+	// produced none, so it must not appear as a source (it still legitimately echoes
+	// in the explainer=... filter, so assert on the "produced by:" list specifically).
+	if !strings.Contains(msg, "produced by: [god-class]") {
+		t.Errorf("source list should be exactly the producing explainers: %q", msg)
+	}
+}
+
+func TestNoMatchInsightsMessage_NoInsightsAtAll(t *testing.T) {
+	msg := noMatchInsightsMessage("cycles", "", 0, &facts.Snapshot{}, facts.NewStore())
+	if !strings.Contains(msg, "No insights were produced") {
+		t.Errorf("empty snapshot should report no insights produced: %q", msg)
+	}
+}
+
+func TestSingleRepoServiceHint(t *testing.T) {
+	single := facts.NewStore()
+	single.Add(facts.Fact{Kind: facts.KindRoute, Name: "GET /x"}) // no Repo label -> single-repo
+
+	multi := facts.NewStore()
+	multi.Add(
+		facts.Fact{Kind: facts.KindService, Name: "a", Repo: "a"},
+		facts.Fact{Kind: facts.KindService, Name: "b", Repo: "b"},
+	)
+
+	if _, ok := singleRepoServiceHint(facts.KindService, 0, single); !ok {
+		t.Error("single-repo empty service query should return an append-mode hint")
+	}
+	if _, ok := singleRepoServiceHint(facts.KindService, 0, multi); ok {
+		t.Error("multi-repo store must not return the single-repo service hint")
+	}
+	if _, ok := singleRepoServiceHint(facts.KindSymbol, 0, single); ok {
+		t.Error("hint is only for kind=service")
+	}
+	if _, ok := singleRepoServiceHint(facts.KindService, 3, single); ok {
+		t.Error("hint must not fire when results are non-empty")
+	}
+}


### PR DESCRIPTION
…nd nothing"

query_insights, query_facts(kind=service), and the llm_context renderer all reported the absence of a cross-repo analysis identically to a clean result. On a single-repo snapshot the linker never builds service nodes (ComputeLinks returns nil below two repos), so unused-routes/coverage/crossrepo return no insights — but the response read "No insights matched", indistinguishable from a fully-resolved multi-repo snapshot with nothing to report. The message also misattributed: it listed Meta.Explainers (the ran-without-error set), naming gated-out explainers as sources of insights they produced none of.

- query_insights: route the no-match case through noMatchInsightsMessage, which separates no-insights-at-all, a cross-repo explainer that could not run (crossRepoExplainer + no KindService facts) → "did not run: needs a multi-repo (append-mode) snapshot", and a genuine no-match. Derive the listed sources from Insight.Source (producingExplainers) instead of Meta.Explainers.
- query_facts(kind=service): return an append-mode hint on an empty single-repo result instead of a bare null, mirroring coverage_report.
- llm_context: renderExtractionQuality states "Cross-repo analysis: not run (single-repo snapshot ...)" when Coverage is nil.

Read-path only; facts.jsonl and insights.json are byte-identical, so no cacheVersion bump and no golden regeneration. Adds server + llmcontext tests.