### PR TITLE
Add facts.IsTestPath and gate god-class/hotspots on it

### DIFF
--- a/internal/explainers/godclass/godclass.go
+++ b/internal/explainers/godclass/godclass.go
@@ -99,6 +99,24 @@ func (e *GodClassExplainer) Explain(ctx context.Context, store *facts.Store) ([]
 		if common.IsRubyFrameworkBaseSymbol(s.Name, s.File) {
 			continue
 		}
+		// A test-support symbol is supposed to have high fan-in: an XCTest assertion
+		// helper called by every test case is doing its job, not concentrating change
+		// risk. ArchitecturalReverse above only drops reference-only KINDS, which
+		// covers the languages whose test files are config-ignored and re-enter as
+		// test_ref nodes (Ruby/Go/TS). Where test files are indexed as ordinary
+		// symbols — Swift, Kotlin/Java, Python, C/C++ — they arrive here as plain
+		// symbol facts, so they need a path gate as well (GAP-XL-15, the half
+		// fixed/40 could not reach).
+		//
+		// Gate the CANDIDATE only. The fan-in count and the outlier distribution
+		// above both stay whole: a test caller is still a caller, and editing a
+		// symbol that 400 tests depend on really does ripple to 400 places. Dropping
+		// test-sourced EDGES instead was prototyped against the corpus and rewrites
+		// the production report rather than de-noising it — on python/superset it
+		// collapses the threshold from 17.23 to 4.82 and churns 40 hotspot findings.
+		if facts.IsTestPath(s.File) {
+			continue
+		}
 		n := fanIn[s.Name]
 		if n < minFanIn || float64(n) <= threshold {
 			continue

--- a/internal/explainers/godclass/godclass_test.go
+++ b/internal/explainers/godclass/godclass_test.go
@@ -340,3 +340,94 @@ func TestConfidenceMath(t *testing.T) {
 		}
 	}
 }
+
+// TestExplain_TestSupportSymbolExcluded pins the fix for the case where a repo's
+// tests are indexed as ordinary symbol facts — every Swift/Xcode repo, every
+// Gradle repo with an androidTest source set, every Python repo with a tests/
+// tree. An XCTest assertion helper is SUPPOSED to have a thousand callers, so
+// ranking it as the repo's #1 god class is noise that outranks (and, given the
+// maxInsights cap, evicts) real production findings.
+//
+// facts.ArchitecturalReverse only drops reference-only KINDS (test_ref/file_ref),
+// which is how the Ruby/Go/TS case is handled — their test files are ignored by
+// config and re-enter only as test_ref nodes. A Swift symbol under Tests/ is an
+// ordinary symbol fact and passes straight through, so the path gate is needed too.
+//
+// The production hub must still be reported with its fan-in INTACT: the gate is on
+// the candidate, not on the edges. Excluding test callers from the count instead
+// was measured against the corpus and rewrites the production report — on
+// python/superset it collapses the outlier threshold from 17.23 to 4.82.
+func TestExplain_TestSupportSymbolExcluded(t *testing.T) {
+	s := facts.NewStore()
+	// A test helper with high fan-in from other test files.
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "Tests/Testability/Sources.Assert",
+		File: "Tests/Testability/Sources/Assert.swift"})
+	// A production hub with high fan-in, some of it from tests.
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "Sources/Core.APIService",
+		File: "Sources/Core/APIService.swift"})
+	for i := 0; i < 12; i++ {
+		s.Add(facts.Fact{
+			Kind: facts.KindSymbol,
+			Name: fmt.Sprintf("Tests/CoreTests.SpecCase%d", i),
+			File: fmt.Sprintf("Tests/CoreTests/SpecCase%d.swift", i),
+			Relations: []facts.Relation{
+				{Kind: facts.RelCalls, Target: "Tests/Testability/Sources.Assert"},
+				{Kind: facts.RelCalls, Target: "Sources/Core.APIService"},
+			},
+		})
+	}
+	s.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	for _, in := range insights {
+		if strings.Contains(in.Title, "Assert") {
+			t.Errorf("test-support symbol reported as god class: %q", in.Title)
+		}
+	}
+	var sawAPI bool
+	for _, in := range insights {
+		if strings.Contains(in.Title, "APIService") {
+			sawAPI = true
+			// Fan-in must be the FULL count (12), not the production-only count.
+			if !strings.Contains(in.Title, "(12 dependents)") {
+				t.Errorf("production hub fan-in was altered by the test gate: %q", in.Title)
+			}
+		}
+	}
+	if !sawAPI {
+		t.Errorf("production hub should still be reported")
+	}
+}
+
+// TestExplain_ProductionABTestNotExcluded is the fixed/28 guard. A production
+// feature named like a test ("KindnessReminderABTest.swift") must stay in the
+// report — the test gate keys off the directory, never the filename.
+func TestExplain_ProductionABTestNotExcluded(t *testing.T) {
+	s := makeStore("Sources/Foundation.KindnessReminderABTest", manyCallers(12), nil)
+	// Re-file the hub onto its real production path.
+	s2 := facts.NewStore()
+	for _, f := range s.All() {
+		if f.Name == "Sources/Foundation.KindnessReminderABTest" {
+			f.File = "Sources/NebenanFoundation/Components/KindnessReminderABTest/KindnessReminderABTest.swift"
+		}
+		s2.Add(f)
+	}
+	s2.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s2)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	var saw bool
+	for _, in := range insights {
+		if strings.Contains(in.Title, "KindnessReminderABTest") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("production A/B-test feature was wrongly gated out as test code")
+	}
+}

--- a/internal/explainers/hotspots/hotspots.go
+++ b/internal/explainers/hotspots/hotspots.go
@@ -98,6 +98,14 @@ func (e *HotspotExplainer) Explain(ctx context.Context, store *facts.Store) ([]f
 		if common.IsRubyFrameworkBaseSymbol(s.Name, s.File) {
 			continue
 		}
+		// Test-support code is not production architecture. See the god-class
+		// explainer for the full rationale: ArchitecturalReverse drops reference-only
+		// KINDS, but a Swift/Kotlin/Python test file is indexed as an ordinary symbol
+		// fact, so it needs a path gate too (GAP-XL-15). Candidate-only: the score and
+		// the outlier distribution stay whole.
+		if facts.IsTestPath(s.File) {
+			continue
+		}
 		in := len(reverse[s.Name])
 		out := len(forward[s.Name])
 		if in < minDegree || out < minDegree {

--- a/internal/explainers/hotspots/hotspots_test.go
+++ b/internal/explainers/hotspots/hotspots_test.go
@@ -297,3 +297,67 @@ func TestExplain_OrderedByScore(t *testing.T) {
 		}())
 	}
 }
+
+// TestExplain_TestSupportSymbolExcluded is the hotspots half of the same gate the
+// god-class explainer carries. See godclass_test.go for the full rationale: a
+// symbol under a test tree is an ordinary symbol fact (not a test_ref), so
+// ArchitecturalReverse cannot see it, and an XCTest helper with 1371 callers was
+// being ranked as the repo's most central symbol.
+//
+// The production hotspot must keep its fan-in intact — the gate is on the
+// candidate, not on the edges.
+func TestExplain_TestSupportSymbolExcluded(t *testing.T) {
+	s := facts.NewStore()
+	// Test helper: high fan-in AND high fan-out, so it clears both degree floors.
+	helperCalls := make([]facts.Relation, 0, 4)
+	for i := 0; i < 4; i++ {
+		tgt := fmt.Sprintf("Tests/Testability.Helper%d", i)
+		helperCalls = append(helperCalls, facts.Relation{Kind: facts.RelCalls, Target: tgt})
+		s.Add(facts.Fact{Kind: facts.KindSymbol, Name: tgt, File: "Tests/Testability/Sources/H.swift"})
+	}
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "Tests/Testability/Sources.Assert",
+		File: "Tests/Testability/Sources/Assert.swift", Relations: helperCalls})
+
+	// Production hotspot: high fan-in and fan-out.
+	prodCalls := make([]facts.Relation, 0, 4)
+	for i := 0; i < 4; i++ {
+		tgt := fmt.Sprintf("Sources/Core.Dep%d", i)
+		prodCalls = append(prodCalls, facts.Relation{Kind: facts.RelCalls, Target: tgt})
+		s.Add(facts.Fact{Kind: facts.KindSymbol, Name: tgt, File: "Sources/Core/Dep.swift"})
+	}
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "Sources/Core.APIService",
+		File: "Sources/Core/APIService.swift", Relations: prodCalls})
+
+	for i := 0; i < 12; i++ {
+		s.Add(facts.Fact{
+			Kind: facts.KindSymbol,
+			Name: fmt.Sprintf("Tests/CoreTests.SpecCase%d", i),
+			File: fmt.Sprintf("Tests/CoreTests/SpecCase%d.swift", i),
+			Relations: []facts.Relation{
+				{Kind: facts.RelCalls, Target: "Tests/Testability/Sources.Assert"},
+				{Kind: facts.RelCalls, Target: "Sources/Core.APIService"},
+			},
+		})
+	}
+	s.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	var sawAPI bool
+	for _, in := range insights {
+		if strings.Contains(in.Title, "Assert") {
+			t.Errorf("test-support symbol reported as hotspot: %q", in.Title)
+		}
+		if strings.Contains(in.Title, "APIService") {
+			sawAPI = true
+			if !strings.Contains(in.Title, "fan-in 12") {
+				t.Errorf("production hotspot fan-in was altered by the test gate: %q", in.Title)
+			}
+		}
+	}
+	if !sawAPI {
+		t.Errorf("production hotspot should still be reported")
+	}
+}

--- a/internal/facts/testpath.go
+++ b/internal/facts/testpath.go
@@ -1,0 +1,122 @@
+package facts
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// testSegments are path segments that mark a test or test-support tree: test
+// sources, and the mock/fixture/helper packages that exist only to serve them.
+// Membership is an exact, case-sensitive segment match.
+//
+// These carry the weight of the predicate. Every language enola supports puts its
+// tests in a tool-enforced directory — an Xcode test target (Tests/, Mocks/), a
+// Gradle source set (src/test/, src/androidTest/, and the KMP per-target trees),
+// a pytest/rspec tree, a Jest __tests__/ — so the directory is the reliable signal
+// and the filename is not. See IsTestPath for why that distinction matters.
+var testSegments = map[string]bool{
+	"test": true, "tests": true, "testing": true,
+	"testutil": true, "testutils": true, "testdata": true,
+	"mock": true, "mocks": true,
+	"fixture": true, "fixtures": true,
+	"spec": true, "specs": true,
+	// Xcode names a test target's tree `Tests` and its mock tree `Mocks`; Jest and
+	// Next.js colocate specs in `__tests__`. The match is case-sensitive, so the
+	// lowercase entries above do not cover them.
+	"__tests__": true,
+	"Tests":     true, "Mocks": true,
+	// Gradle instrumented tests and the Kotlin-Multiplatform per-target test trees.
+	// The plain `test` segment above already covers local JVM unit tests.
+	"androidTest": true, "commonTest": true, "jvmTest": true,
+	"iosTest": true, "nativeTest": true,
+	// Python shared test-support trees.
+	"tests_common": true, "test_utils": true,
+}
+
+// testFileSuffixes are the filename conventions safe enough to trust on their own,
+// for the languages whose tests are genuinely colocated with production source:
+// Go's `_test.go` (reserved by the compiler — a production file cannot be named
+// this), pytest's `*_test.py`, RSpec's `*_spec.rb`, and the dotted Jest/Vitest
+// forms, which really do appear outside a test tree (`cypress/e2e/explore/
+// chart.test.js` on python/superset is one).
+//
+// Several sibling conventions are deliberately ABSENT. The criterion is empirical:
+// a filename rule is dropped when, measured across the corpus, the files it
+// uniquely claims — the ones no directory segment already covers — are ALL
+// production code. Each of these was:
+//
+//   - Swift `Tests.swift`/`Test.swift` and Kotlin `Test.kt`/`Tests.kt`/`Spec.kt`.
+//     On nan/nebenan-iOS they matched 402 files, 393 already covered by a segment,
+//     and all 9 of the remainder were production A/B-test features
+//     (`KindnessReminderABTest.swift`, `Tracking+ShortenNameABTest.swift`, …). On
+//     nan/nebenan-android-app: 261 matched, 260 already covered, the 1 remainder a
+//     production model (`api/…/model/ABTest.kt`). Neither SPM nor Gradle will build
+//     a test from a production target, so the real tests are always in the test
+//     tree and these rules had no true positives to contribute.
+//   - Ruby `_test.rb`. Across the whole corpus it uniquely claimed exactly one
+//     file: `app/jobs/hood_message/finish_kindness_reminder_ab_test.rb` — the
+//     production ActiveJob that the identically-shaped `**/*_test.rb` ignore glob
+//     once deleted from the graph outright, and which is why that glob is now
+//     directory-scoped. Minitest files live in `test/`, which the segments claim.
+//   - pytest's `test_*.py` PREFIX. It uniquely claimed three files on
+//     python/superset and all three were production commands that *test a database
+//     connection*: `superset/cli/test_db.py`, `superset/cli/test_loaders.py`,
+//     `superset/commands/database/test_connection.py`.
+//
+// The rule that survives is: a name that merely LOOKS like a test is production.
+// Erring this way costs at worst a false negative (a stray colocated test rated as
+// production, which shows up as noise); erring the other way silently removes
+// production code from the analysis, which is strictly worse and much harder to
+// notice. It is the same reason ModuleRoleForPath matches whole '-'/'_' tokens
+// rather than substrings.
+//
+// Residual risk, recorded honestly: `_test.py` and `_spec.rb` have the same
+// theoretical collision as `_test.rb` (a production `feature_ab_test.py`), but
+// unlike `_test.rb` no such file exists on the corpus, and dropping them would
+// re-introduce false-positive orphans for colocated pytest suites. If one ever
+// turns up, they go the way of `_test.rb`.
+var testFileSuffixes = []string{
+	"_test.go",
+	"_test.py",
+	"_spec.rb",
+	".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx",
+	".test.js", ".test.jsx", ".spec.js", ".spec.jsx",
+}
+
+// IsTestPath reports whether a repo-relative path is test or test-support code.
+//
+// This is the single definition. The dead-code detector (which must not offer an
+// XCTest helper as a deletion candidate), the performance analyzer (whose findings
+// on test code are not actionable) and the god-class/hotspots explainers (which
+// must not rank a test assertion helper as the repo's most central symbol) all
+// classify through here. They previously carried three separate copies that had
+// drifted apart in both directions, and a fourth consumer had no path check at all.
+//
+// Conservative by construction: an exact directory-segment match, or a filename
+// convention that a tool enforces. A name that merely *looks* like a test —
+// `ABTest.swift`, `test_job.rb`, `contest/`, `latest/` — is production code and
+// stays in the graph.
+func IsTestPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	p = filepath.ToSlash(p)
+	for _, seg := range strings.Split(p, "/") {
+		if testSegments[seg] {
+			return true
+		}
+	}
+	base := p
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, suf := range testFileSuffixes {
+		if strings.HasSuffix(base, suf) {
+			return true
+		}
+	}
+	// conftest.py is pytest's plugin/config file: the name is exact and reserved by
+	// the runner, so unlike the `test_*.py` discovery prefix it cannot collide with
+	// a production module.
+	return base == "conftest.py"
+}

--- a/internal/facts/testpath_test.go
+++ b/internal/facts/testpath_test.go
@@ -1,0 +1,88 @@
+package facts
+
+import "testing"
+
+func TestIsTestPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Directory segments — the primary signal. Test trees are tool-enforced
+		// (Xcode targets, Gradle source sets, pytest/rspec convention).
+		{"swift xcode test target", "Tests/Testability/Sources/Assert.swift", true},
+		{"swift xcode mock target", "Mocks/APIStub.swift", true},
+		{"gradle unit test source set", "app/src/test/java/de/nebenan/app/FooTest.kt", true},
+		{"gradle instrumented source set", "app/src/androidTest/java/de/nebenan/app/EspressoMocks.kt", true},
+		{"kmp per-target test tree", "shared/src/commonTest/kotlin/Foo.kt", true},
+		{"jest colocated", "src/components/__tests__/Button.tsx", true},
+		{"rspec tree", "spec/models/user_spec.rb", true},
+		{"go testdata", "internal/engine/testdata/repos/x/main.go", true},
+		{"test-support package", "internal/testutil/helpers.go", true},
+		{"fixtures tree", "src/dashboard/fixtures/mockNativeFilters.ts", true},
+		{"python shared test support", "tests_common/pytest_plugins.py", true},
+
+		// Filename conventions — ONLY the tool-enforced ones. A compiler or runner
+		// keys off each of these, so production code cannot adopt one by accident.
+		{"go test file", "internal/engine/cache_test.go", true},
+		{"go test file colocated", "pkg/a/a_ext_test.go", true},
+		{"pytest conftest", "superset/conftest.py", true},
+		{"jest dotted suffix", "src/utils/format.test.ts", true},
+		{"vitest dotted spec", "src/utils/format.spec.tsx", true},
+		// Genuinely outside any test segment on python/superset — the one case the
+		// dotted rule uniquely earns.
+		{"cypress e2e outside a test tree", "superset-frontend/cypress-base/cypress/e2e/explore/chart.test.js", true},
+
+		// Colocated conventions that are safe on their own.
+		{"rspec suffix", "app/models/user_spec.rb", true},
+		{"pytest suffix colocated", "pkg/foo_test.py", true},
+
+		// Real Ruby/Swift/Kotlin tests are claimed by their DIRECTORY, not by their
+		// filename — their basename rules were dropped as pure false-positive
+		// generators. These still classify, via the segment rules.
+		{"rspec in spec tree", "spec/models/user_spec.rb", true},
+		{"minitest in test tree", "test/models/user_test.rb", true},
+		{"pytest prefix in tests tree", "tests/unit/test_date_parser.py", true},
+		{"swift test in test target", "Tests/CoreKitTests/CoreKitTests.swift", true},
+		{"kotlin test in source set", "app/src/test/java/de/nebenan/FooTest.kt", true},
+
+		// --- Production code that MUST NOT be classified as test ---
+		//
+		// Every one of these is a real corpus file that a filename-suffix rule
+		// wrongly claimed. This is the fixed/28 defect class: a name that merely
+		// LOOKS like a test. Suppressing production code from the analysis is
+		// silent, so the predicate errs toward keeping it.
+		{"swift production A/B feature", "Sources/NebenanFoundation/Components/KindnessReminderABTest/KindnessReminderABTest.swift", false},
+		{"swift production feature ending in Test", "Sources/NebenanFoundation/Components/PersonalisedFeedTest/PersonalisedFeedTest.swift", false},
+		{"swift production tracking ext", "Sources/NebenanFoundation/Components/Tracking/Tracking+ShortenNameABTest.swift", false},
+		{"swift production ending in Tests", "Sources/NebenanFoundation/Components/Settings/Settings.ABUserTests.swift", false},
+		{"kotlin production model ending in Test", "api/src/main/java/de/nebenan/app/api/model/ABTest.kt", false},
+		{"ruby production job named test_job", "app/jobs/test_job.rb", false},
+		{"ruby production job named test_fail_job", "app/jobs/test_fail_job.rb", false},
+		// The fixed/28 file itself: it genuinely ends in `_test.rb`, which is why a
+		// bare suffix rule can never be safe for Ruby.
+		{"ruby production ab-test job (fixed/28)", "app/jobs/hood_message/finish_kindness_reminder_ab_test.rb", false},
+		// Production CLI/commands on python/superset that "test a DB connection".
+		{"python production cli test_db", "superset/cli/test_db.py", false},
+		{"python production test_connection command", "superset/commands/database/test_connection.py", false},
+
+		// The v60 hardening cases from ModuleRoleForPath: a genuine single-token
+		// name must never misfire.
+		{"latest is not a test dir", "app/services/latest/fetcher.rb", false},
+		{"contest is not a test dir", "app/models/contest/entry.rb", false},
+		{"abtest is not a test dir", "app/features/abtest/toggle.rb", false},
+		{"protest is not a test dir", "src/protest/handler.go", false},
+
+		// Ordinary production paths.
+		{"plain source", "Sources/NebenanCore/APIService.swift", false},
+		{"plain go", "internal/facts/graph.go", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTestPath(tt.path); got != tt.want {
+				t.Errorf("IsTestPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/facts/facts.go
+++ b/pkg/facts/facts.go
@@ -75,6 +75,14 @@ const (
 // extractors instead of re-implementing the heuristic.
 func ModuleRoleForPath(dir string) string { return internal.ModuleRoleForPath(dir) }
 
+// IsTestPath reports whether a repo-relative path is test or test-support code.
+// Re-exported so out-of-module consumers (the enterprise dead-code and performance
+// analyzers) share one definition with the OSS explainers instead of each carrying
+// its own copy — they previously carried three, which drifted in both directions.
+// See internal/facts for the full contract, in particular why it trusts the
+// directory and not the filename.
+func IsTestPath(p string) bool { return internal.IsTestPath(p) }
+
 // CanonicalSymbols collapses #if/#else conditional-compilation duplicates in a
 // symbol-fact slice, keeping non-conditional overloads intact. Re-exported so
 // out-of-module consumers that count symbols (package-metrics) apply the same rule


### PR DESCRIPTION
god-class and hotspots rank symbols by fan-in with no notion of a test path, so on a repo with an in-repo test target the top finding is test scaffolding — an XCTest assertion helper with 1371 dependents, which is what an assertion helper is for. ArchitecturalReverse() drops reference-only KINDS (test_ref/file_ref), which is blind to Swift, Kotlin/Java, Python and C/C++, where test files are ordinary symbol facts.

Add facts.IsTestPath as the one definition, re-exported via pkg/facts so the out-of-module analyzers share it instead of each keeping a copy.

Gate the candidate, not the edges: dropping test-sourced edges from the fan-in index rewrites the report rather than de-noising it (the outlier threshold collapses, real god classes disappear). A test caller is still a caller; what is noise is reporting the helper itself.

Trust the directory, not the filename. Measured per rule, the Swift/Kotlin basename suffixes, Ruby's _test.rb and pytest's test_*.py prefix uniquely matched nothing but production code — A/B-test features, a production ActiveJob, commands that test a DB connection.

Explainer read-path only: no facts emitted, so no cacheVersion bump and no golden regeneration. TestGolden passes unchanged.