### PR TITLE
Add mcputil.Scoped so a summary cannot count the unfiltered set

### DIFF
--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -135,3 +135,66 @@ func TestRenderQuerySummary_SurfacesUnmatchedFlag(t *testing.T) {
 		t.Errorf("summary should surface the unmatched_by_clients flag count; got:\n%s", out)
 	}
 }
+
+// TestRenderInsightsSummary_HeadlineReflectsTheFilter composes the filter with the
+// summary, which no test in either repo did before. It pins the invariant that the
+// enterprise analyze_performance tool violated (bug new/56): a tool that filters its
+// results and then summarizes must count the FILTERED set, not the corpus. There,
+// the summary was built before the filter ran, so package="androidTest" printed the
+// repo-wide total (61 findings) above an empty table — a real number, and the answer
+// to a question the caller never asked.
+//
+// query_insights is correct by construction — renderInsightsSummary is handed only
+// the matched slice and does not have snap.Insights in scope, so it cannot count the
+// wrong thing. This test is what keeps that true.
+func TestRenderInsightsSummary_HeadlineReflectsTheFilter(t *testing.T) {
+	all := sampleInsights() // 3 insights: unused-routes, cycles, god-class
+
+	tests := []struct {
+		name         string
+		explainer    string
+		minConf      float64
+		wantHeadline string
+		wantAbsent   string
+	}{
+		{"unfiltered", "", 0, "Found **3** insight(s)", ""},
+		{"by explainer", "cycles", 0, "Found **1** insight(s)", "unused-routes"},
+		{"by confidence", "", 0.8, "Found **1** insight(s)", "god-class"},
+		{"explainer with no matches", "layers", 0, "Found **0** insight(s)", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := filterInsights(all, tt.explainer, "", tt.minConf, false)
+			out := renderInsightsSummary(matched)
+
+			if !strings.Contains(out, tt.wantHeadline) {
+				t.Errorf("headline does not reflect the filter: want %q in\n%s", tt.wantHeadline, out)
+			}
+			// The by-explainer tally must be over the filtered set too — a breakdown
+			// computed over the corpus is the same defect one line lower.
+			if tt.wantAbsent != "" && strings.Contains(out, tt.wantAbsent) {
+				t.Errorf("filtered-out explainer %q leaked into the summary:\n%s", tt.wantAbsent, out)
+			}
+		})
+	}
+}
+
+// TestRenderQuerySummary_HeadlineIsTheFilteredTotal pins the same invariant for
+// query_facts, whose headline takes `total` as an argument — so unlike
+// query_insights it *could* be handed the wrong number. store.QueryAdvanced returns
+// the post-filter match count; this asserts the renderer reports that, and not the
+// size of the store.
+func TestRenderQuerySummary_HeadlineIsTheFilteredTotal(t *testing.T) {
+	results := []facts.Fact{
+		{Kind: facts.KindRoute, Name: "GET /a", File: "a.go"},
+		{Kind: facts.KindRoute, Name: "GET /b", File: "b.go"},
+	}
+	// The filtered total is 2, even though the store holds far more.
+	out := renderQuerySummary(results, len(results))
+	if !strings.Contains(out, "Found **2** matching facts.") {
+		t.Errorf("headline must be the filtered total, got:\n%s", out)
+	}
+	if strings.Contains(out, "Found **500**") || strings.Contains(out, "Found **0**") {
+		t.Errorf("headline reported something other than the filtered total:\n%s", out)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3300,8 +3300,13 @@ func (s *Server) renderTraverseSummary(store *facts.Store, resp traverseResponse
 		sb.WriteString("\n")
 	}
 
-	fmt.Fprintf(&sb, "_Stats: %d nodes, %d edges, max depth %d. Use output_mode=compact for the per-depth node list, output_mode=full for the raw graph._\n",
-		resp.Stats.NodesVisited, len(resp.Edges), resp.Stats.MaxDepthReached)
+	// NodesVisited counts every node the walk PASSED THROUGH, including those a
+	// node_kinds filter excluded from the result (graph.go traverses through them to
+	// reach their neighbours). Printing it as a bare "N nodes" put an unfiltered
+	// number beside a filtered list — node_kinds=["route"] could report "used by 2
+	// nodes" above "Stats: 431 nodes". Label the two counts for what they are.
+	fmt.Fprintf(&sb, "_Stats: %d nodes matched, %d walked, %d edges, max depth %d. Use output_mode=compact for the per-depth node list, output_mode=full for the raw graph._\n",
+		reached, resp.Stats.NodesVisited, len(resp.Edges), resp.Stats.MaxDepthReached)
 	return sb.String()
 }
 

--- a/pkg/mcputil/scoped.go
+++ b/pkg/mcputil/scoped.go
@@ -1,0 +1,78 @@
+package mcputil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Scoped pairs a filtered result set with the SIZE of the population it was drawn
+// from — never with the population itself.
+//
+// It exists to make one class of bug unrepresentable. A tool that filters its
+// results and then renders a summary has two sets in scope, and the summary must be
+// computed from the filtered one. `analyze_performance` computed it from the other:
+// its summary struct was built before the filter ran and rendered beside the
+// filtered list, so `package="androidTest"` printed "Performance: 61 findings" —
+// the repo-wide total — above an empty table. Nothing in the output revealed it, and
+// the number was wrong in the most convincing possible way: it was a real number,
+// just the answer to a question the caller had not asked.
+//
+// The OSS server avoids this by construction rather than by care: renderInsightsSummary
+// receives only the matched slice and does not have the unfiltered corpus in scope, so
+// it *cannot* count the wrong thing. Scoped generalizes that invariant. Population is
+// an int, not a slice, so a renderer holding a Scoped has nothing to range over but
+// the filtered set.
+//
+// Use it for any tool surface where a filter and a summary meet.
+type Scoped[T any] struct {
+	// Items is the filtered set — the only collection a renderer may count.
+	Items []T
+	// Population is the size of the unfiltered set, carried for context so a zero
+	// result can say what it was drawn from. It is deliberately a count, not the
+	// data.
+	Population int
+	// Filter describes the filter in the caller's own terms, e.g. `package="x"`.
+	// Empty means no filter was applied.
+	Filter string
+}
+
+// Scope pairs a filtered set with the size of its population.
+func Scope[T any](population int, filtered []T, filter string) Scoped[T] {
+	return Scoped[T]{Items: filtered, Population: population, Filter: filter}
+}
+
+// Filtered reports whether a filter was applied.
+func (s Scoped[T]) Filtered() bool { return s.Filter != "" }
+
+// Headline renders the count sentence, naming the filter when there was one.
+//
+//	unfiltered → "61 findings."
+//	filtered   → `0 findings under package="androidTest" (of 61 repo-wide).`
+//
+// The filtered form always states the population, because a bare "0 findings" is
+// indistinguishable from a filter that silently matched nothing — which is the
+// second half of the same defect: analyze_performance's `package=` matched against
+// the symbol NAME, so on a Rails repo (whose symbol names carry no path) it returned
+// zero for every real package, forever.
+func (s Scoped[T]) Headline(noun string) string {
+	if !s.Filtered() {
+		return fmt.Sprintf("%d %s.", len(s.Items), noun)
+	}
+	return fmt.Sprintf("%d %s under %s (of %d repo-wide).", len(s.Items), noun, s.Filter, s.Population)
+}
+
+// DescribeFilters renders a set of name=value filter pairs into the form Headline
+// expects, skipping empties, so every tool describes its filters the same way.
+func DescribeFilters(pairs ...string) string {
+	if len(pairs)%2 != 0 {
+		panic("mcputil.DescribeFilters: odd number of arguments; want name, value pairs")
+	}
+	var parts []string
+	for i := 0; i < len(pairs); i += 2 {
+		if pairs[i+1] == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%q", pairs[i], pairs[i+1]))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/mcputil/scoped_test.go
+++ b/pkg/mcputil/scoped_test.go
@@ -1,0 +1,79 @@
+package mcputil
+
+import "testing"
+
+func TestScope_HeadlineNamesTheFilter(t *testing.T) {
+	population := []int{1, 2, 3, 4, 5, 6}
+
+	tests := []struct {
+		name     string
+		filtered []int
+		filter   string
+		want     string
+	}{
+		// Unfiltered: the population IS the result, so there is nothing to qualify.
+		{
+			name:     "unfiltered",
+			filtered: population,
+			filter:   "",
+			want:     "6 findings.",
+		},
+		// Filtered and non-empty: the caller must be able to see that a filter was
+		// applied, and how big the set it was drawn from is.
+		{
+			name:     "filtered",
+			filtered: []int{1, 2},
+			filter:   `package="androidTest"`,
+			want:     `2 findings under package="androidTest" (of 6 repo-wide).`,
+		},
+		// The case this type exists for. A bare "0 findings." is indistinguishable
+		// from a broken filter; naming the filter and the population makes the zero
+		// legible. Reporting the POPULATION count here — which is what
+		// analyze_performance did — is the defect: it said "61 findings" beside an
+		// empty table.
+		{
+			name:     "filtered to empty",
+			filtered: nil,
+			filter:   `package="androidTest"`,
+			want:     `0 findings under package="androidTest" (of 6 repo-wide).`,
+		},
+		{
+			name:     "unfiltered and empty",
+			filtered: nil,
+			filter:   "",
+			want:     "0 findings.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Scope(len(population), tt.filtered, tt.filter)
+			if got := s.Headline("findings"); got != tt.want {
+				t.Errorf("Headline() = %q, want %q", got, tt.want)
+			}
+			if len(s.Items) != len(tt.filtered) {
+				t.Errorf("Items = %d, want %d", len(s.Items), len(tt.filtered))
+			}
+		})
+	}
+}
+
+// TestScope_ItemsAreTheOnlyCountableSet is the invariant, stated as a test: a
+// renderer holding a Scoped can only count the filtered set. Population is an int,
+// not a slice, so there is no unfiltered corpus to accidentally range over — which
+// is exactly how analyze_performance came to report repo-wide totals beside a
+// filtered list.
+func TestScope_ItemsAreTheOnlyCountableSet(t *testing.T) {
+	s := Scope(100, []string{"a", "b"}, `repo="x"`)
+	if len(s.Items) != 2 {
+		t.Fatalf("Items = %d, want 2", len(s.Items))
+	}
+	if s.Population != 100 {
+		t.Errorf("Population = %d, want 100", s.Population)
+	}
+	if !s.Filtered() {
+		t.Errorf("Filtered() = false, want true")
+	}
+	if Scope(2, []string{"a", "b"}, "").Filtered() {
+		t.Errorf("Filtered() = true for an unfiltered scope")
+	}
+}


### PR DESCRIPTION
A tool that filters its results and then summarizes has two collections in scope, and exactly one is the answer. Nothing stopped a renderer counting the other, and enola-enterprise's analyze_performance did: package="androidTest" printed the repo-wide total above an empty table.

The OSS tools never had this bug, but by shape rather than by care — their renderers are handed only the filtered slice and cannot see the corpus. Scoped[T] makes that shape portable: it carries the filtered set plus the SIZE of its population (an int, not a slice), so a renderer has nothing to range over but the answer. Headline() names the filter and states the population, because a bare "0 findings." is indistinguishable from a filter that silently matched nothing.

Also: traverse's _Stats: N nodes_ printed NodesVisited, the pre-filter walk count, so node_kinds=["route"] could report "used by 2 nodes" above "Stats: 431 nodes". Now "N matched, M walked".

Add the filter-to-headline assertion for query_facts and query_insights. It existed nowhere in either repo — the OSS tools were correct with nothing holding them there.

No facts emitted: no cacheVersion bump, no golden regeneration.