### PR TITLE
Exclude test modules in the languages that emit no module_role

### DIFF
--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -90,6 +90,34 @@ func BuildModuleGraph(store *facts.Store) map[string][]string {
 	return BuildModuleGraphExcluding(store)
 }
 
+// isTestModule reports whether a module is test scaffolding rather than production
+// architecture, and must therefore be kept out of the coupling graph the cycles and
+// dependency-depth explainers read.
+//
+// The extractor's `module_role` prop is AUTHORITATIVE where it exists: it comes from
+// a build file, not a guess — an SPM/Xcode target type, a Gradle source set. A module
+// the extractor tagged `production` stays in the graph even if its path looks like a
+// test tree, because the build system is right and the path is not. nan/nebenan-android-app
+// ships a real package called `app/src/main/java/…/ui/base/testing`; Gradle says
+// `src/main`, so it is production, and no path heuristic gets to overrule that.
+//
+// But only java, kotlin, ruby and swift emit the prop at all. Go, Python, TypeScript,
+// PHP and C/C++ emit NONE — and the exclusion used to key on the prop alone, so their
+// test trees walked straight into the graph. On python/superset that meant ALL TEN
+// dependency-depth findings were test modules (`tests/unit_tests/dao (depth 11)`, …)
+// and 2 of the 10 cycles ran through them: an explainer whose entire output was test
+// scaffolding. Where the prop is absent, fall back to the path.
+func isTestModule(m facts.Fact) bool {
+	switch role, _ := m.Props[facts.PropModuleRole].(string); role {
+	case facts.ModuleRoleTest:
+		return true
+	case facts.ModuleRoleProduction, facts.ModuleRoleTooling:
+		return false // authoritative: the build file said so
+	}
+	// No usable signal (absent, "", or "unknown") — the five untagged languages.
+	return facts.IsTestPath(m.Name)
+}
+
 // BuildModuleGraphExcluding is BuildModuleGraph with the ability to drop synthetic
 // coupling edges by their Props["coupling_kind"] (see facts.Coupling* constants).
 // A dependency fact whose coupling_kind is in excludeKinds contributes no edge.
@@ -111,7 +139,7 @@ func BuildModuleGraphExcluding(store *facts.Store, excludeKinds ...string) map[s
 	moduleNames := make(map[string]bool)
 	testModules := make(map[string]bool)
 	for _, m := range modules {
-		if role, _ := m.Props[facts.PropModuleRole].(string); role == facts.ModuleRoleTest {
+		if isTestModule(m) {
 			testModules[m.Name] = true
 			continue
 		}

--- a/internal/explainers/common/common_test.go
+++ b/internal/explainers/common/common_test.go
@@ -277,3 +277,58 @@ func TestBuildModuleGraph_ExternalStillDropped(t *testing.T) {
 		t.Errorf("handlers edges = %v, want none (fmt/react are not modules)", edges)
 	}
 }
+
+// TestBuildModuleGraph_UntaggedTestModuleExcluded pins the real defect behind
+// new/55. The test-module exclusion above keys on the module_role prop — which only
+// java, kotlin, ruby and swift emit. Go, Python, TypeScript, PHP and C/C++ emit no
+// module_role at all, so their test trees walked straight into the cycles and
+// dependency-depth graphs: on python/superset, 10 of the 10 dependency-depth findings
+// were test modules, and 2 of the 10 cycles ran through them.
+//
+// Where the prop is absent, fall back to the path.
+func TestBuildModuleGraph_UntaggedTestModuleExcluded(t *testing.T) {
+	s := facts.NewStore()
+	// Python/TS/Go: no module_role prop at all.
+	s.Add(facts.Fact{Kind: facts.KindModule, Name: "superset/dao"})
+	s.Add(facts.Fact{Kind: facts.KindModule, Name: "tests/unit_tests/dao"})
+	s.Add(facts.Fact{Kind: facts.KindDependency, File: "tests/unit_tests/dao/f.py",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "superset/dao"}}})
+	s.Add(facts.Fact{Kind: facts.KindDependency, File: "superset/dao/f.py",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "tests/unit_tests/dao"}}})
+
+	graph := BuildModuleGraph(s)
+	if _, ok := graph["tests/unit_tests/dao"]; ok {
+		t.Error("an untagged test module must not be a graph node")
+	}
+	if len(graph["superset/dao"]) != 0 {
+		t.Errorf("edge to an untagged test module should be dropped, got %v", graph["superset/dao"])
+	}
+}
+
+// TestBuildModuleGraph_AuthoritativeRoleWins is the anti-regression guard, and the
+// reason new/55's own prescribed fix was refuted. nan/nebenan-android-app has a
+// production package literally named `app/src/main/java/.../ui/base/testing`. Gradle
+// says src/main, so the extractor tags it module_role=production — an AUTHORITATIVE
+// signal. The path heuristic must never override it, or a real production package is
+// silently dropped from the architecture graph for having "testing" in its name.
+//
+// This is why the fallback is a fallback and not a union: the report proposed
+// widening ModuleRoleForPath itself, which would have suppressed this package.
+func TestBuildModuleGraph_AuthoritativeRoleWins(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{Kind: facts.KindModule, Name: "app/src/main/java/de/nebenan/app/ui/base/testing",
+		Props: map[string]any{facts.PropModuleRole: facts.ModuleRoleProduction}})
+	s.Add(facts.Fact{Kind: facts.KindModule, Name: "app/src/main/java/de/nebenan/app/ui",
+		Props: map[string]any{facts.PropModuleRole: facts.ModuleRoleProduction}})
+	s.Add(facts.Fact{Kind: facts.KindDependency, File: "app/src/main/java/de/nebenan/app/ui/f.kt",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "app/src/main/java/de/nebenan/app/ui/base/testing"}}})
+
+	graph := BuildModuleGraph(s)
+	if _, ok := graph["app/src/main/java/de/nebenan/app/ui/base/testing"]; !ok {
+		t.Error("a module the extractor authoritatively tagged production must stay in the graph, " +
+			"even though its path contains a test segment")
+	}
+	if len(graph["app/src/main/java/de/nebenan/app/ui"]) != 1 {
+		t.Error("the edge into it must survive")
+	}
+}

--- a/internal/explainers/surface/surface.go
+++ b/internal/explainers/surface/surface.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/enola-labs/enola/internal/explainers/common"
 	"github.com/enola-labs/enola/internal/facts"
+	"github.com/enola-labs/enola/pkg/mcputil"
 )
 
 const (
@@ -38,17 +38,8 @@ const (
 	maxEvidence = 8
 )
 
-// excludedSegments are path segments whose modules are skipped: mocks, test
-// helpers, fixtures, and generated code naturally export everything and aren't
-// hand-maintained public APIs.
-var excludedSegments = map[string]bool{
-	"mock": true, "mocks": true,
-	"test": true, "tests": true, "testing": true,
-	"testutil": true, "testutils": true, "testdata": true,
-	"fixture": true, "fixtures": true,
-	"spec": true, "specs": true,
-	"generated": true,
-}
+// (The old excludedSegments map lived here. It has been replaced by the shared
+// facts.IsTestPath — see excludedModule.)
 
 // SurfaceExplainer detects modules with an oversized exported surface.
 type SurfaceExplainer struct{}
@@ -174,13 +165,17 @@ func (e *SurfaceExplainer) Explain(ctx context.Context, store *facts.Store) ([]f
 	return insights, nil
 }
 
-// excludedModule reports whether any path segment of the module is a mock/test/
-// generated marker.
+// excludedModule reports whether a module is test scaffolding or generated output:
+// both naturally export everything and are not hand-maintained public APIs.
+//
+// It used to carry its own segment list, lowercasing the module path to match it.
+// That covered `Tests/` (via `tests`) but not `androidTest` — which lowercases to
+// `androidtest` — nor `__tests__` nor the Kotlin-Multiplatform trees, so
+// nan/nebenan-android-app reported "Large public surface:
+// app/src/androidTest/java/…/ui/signup/compose" as a finding. Both questions now have
+// exactly one owner each: facts.IsTestPath and mcputil.IsGeneratedPath. Note
+// IsTestPath is case-SENSITIVE and carries the real-world spellings (`Tests`,
+// `Mocks`, `androidTest`, `__tests__`), so the lowercasing is gone with the list.
 func excludedModule(mod string) bool {
-	for _, seg := range strings.Split(strings.ToLower(mod), "/") {
-		if excludedSegments[seg] {
-			return true
-		}
-	}
-	return false
+	return facts.IsTestPath(mod) || mcputil.IsGeneratedPath(mod)
 }

--- a/internal/explainers/surface/surface_test.go
+++ b/internal/explainers/surface/surface_test.go
@@ -273,3 +273,46 @@ func TestExplain_MissingVisibilityIgnored(t *testing.T) {
 		t.Errorf("expected 0 insights when visibility is unknown, got %d", len(insights))
 	}
 }
+
+// TestExplain_GradleAndJestTestModulesExcluded pins the surface half of new/55.
+// excludedSegments lowercases the module path, so `Tests/` already matched its
+// `tests` entry — but `androidTest` lowercases to `androidtest`, which is not in the
+// set, and neither are `__tests__` or the Kotlin-Multiplatform trees. On
+// nan/nebenan-android-app that produced a real finding: "Large public surface:
+// app/src/androidTest/java/de/nebenan/app/ui/signup/compose". An instrumented-test
+// source set is not a hand-maintained public API.
+func TestExplain_GradleAndJestTestModulesExcluded(t *testing.T) {
+	s := facts.NewStore()
+	addModuleSymbols(s, "app/src/androidTest/java/de/nebenan/app/ui/signup/compose", 30, 30)
+	addModuleSymbols(s, "src/components/__tests__", 30, 30)
+	addModuleSymbols(s, "shared/src/commonTest/kotlin", 30, 30)
+	addModuleSymbols(s, "Tests/Testability/Sources", 30, 30)
+	addModuleSymbols(s, "app/Mocks", 30, 30)
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 0 {
+		for _, in := range insights {
+			t.Errorf("test-source module reported as a public surface: %q", in.Title)
+		}
+	}
+}
+
+// TestExplain_ProductionModuleNamedLikeATestKept is the fixed/28 guard, at the
+// module level. A production package whose name merely CONTAINS a test-ish token —
+// `contest`, `latest`, an A/B-test feature — must still be analyzed. Suppressing a
+// real module is silent; reporting one is not.
+func TestExplain_ProductionModuleNamedLikeATestKept(t *testing.T) {
+	s := facts.NewStore()
+	addModuleSymbols(s, "app/features/contest", 30, 30)
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Errorf("a production module named 'contest' must not be excluded, got %d insights", len(insights))
+	}
+}


### PR DESCRIPTION
cycles and dependency-depth drop test modules from the coupling graph by checking role == ModuleRoleTest. Only java, kotlin, ruby and swift emit that prop. Go, Python, TypeScript, PHP and C/C++ emit none, so their test trees walked straight into the graph: on a large Python codebase, all ten dependency-depth findings were test modules and two of ten cycles ran through them — an explainer whose entire output was test scaffolding.

Fall back to facts.IsTestPath where the prop is absent. The extractor's prop stays AUTHORITATIVE where it exists: it comes from a build file, not a guess — an SPM/Xcode target type, a Gradle source set. A module tagged production stays in the graph even if its path looks like a test tree. One repo ships a real package called .../ui/base/testing under src/main; Gradle is right and the path is not, and that is pinned by a test.

exported-surface had the same gap from the other side: it lowercased the module path to match a lowercase segment list, which caught Tests/ but not androidTest (-> androidtest), __tests__, or the Kotlin-Multiplatform trees — so an instrumented-test source set was reported as a large public API. It now delegates to facts.IsTestPath for test paths and mcputil.IsGeneratedPath for generated ones; both questions have one owner.

facts.ModuleRoleForPath is deliberately unchanged. Widening it would override the build file, and it emits a cached fact prop — leaving it alone is what keeps facts.jsonl byte-identical. No cacheVersion bump, no golden regeneration; TestGolden passing unchanged is the proof.