### PR TITLE
Share the ** -capable glob matcher through pkg/facts

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -524,107 +523,17 @@ func (e *Engine) matchesTestGlob(relPath string) bool {
 	return matchAnyGlob(filepath.ToSlash(relPath), e.cfg.TestGlobs)
 }
 
-// matchAnyGlob reports whether a forward-slash path matches any of the patterns.
-// It is the single matcher behind both the ignore list and the test globs, so a
-// file the two lists disagree about cannot exist: an ignored file that stops being
-// a test necessarily stops being ignored.
+// matchAnyGlob and matchGlob are thin aliases onto the shared matcher, which now
+// lives in internal/facts alongside the other path predicates (IsTestPath) so that
+// out-of-module consumers can reach it through pkg/facts. The enterprise performance
+// analyzer's ENOLA_PERF_EXCLUDE globs documented `**` support that path.Match cannot
+// give them; rather than grow a second glob implementation, it uses this one.
 func matchAnyGlob(relPath string, patterns []string) bool {
-	_, ok := matchGlob(relPath, patterns)
-	return ok
+	return facts.MatchAnyGlob(relPath, patterns)
 }
 
-// matchGlob returns the first pattern that matches relPath. The receipt records it
-// beside the skipped path, so "why is this file missing from the graph?" is a
-// lookup rather than an investigation. Supported forms:
-//
-//	vendor/**                 anchored directory prefix
-//	**/build/**               a directory named "build" at any depth
-//	**/*_test.go              a basename glob at any depth
-//	**/spec/**/*_spec.rb      a basename glob under a directory named "spec"
-//
-// The last form is the only one that constrains directory and filename together;
-// see matchDirScopedGlob for why the Ruby test globs need it.
 func matchGlob(relPath string, patterns []string) (string, bool) {
-	for _, pattern := range patterns {
-		// "<prefix>/**/<fileglob>". Handled first and exclusively: the branches
-		// below would match such a pattern only when exactly one directory sits
-		// between prefix and file, which is an artifact of filepath.Match reading
-		// "**" as "*", not a rule anyone intended.
-		if i := strings.Index(pattern, "/**/"); i >= 0 {
-			prefix, fileGlob := pattern[:i], pattern[i+len("/**/"):]
-			if !strings.Contains(fileGlob, "/") {
-				if matchDirScopedGlob(relPath, prefix, fileGlob) {
-					return pattern, true
-				}
-				continue
-			}
-		}
-		if strings.HasPrefix(pattern, "**/") && strings.HasSuffix(pattern, "/**") {
-			seg := strings.TrimSuffix(strings.TrimPrefix(pattern, "**/"), "/**")
-			if seg != "" && !strings.Contains(seg, "/") {
-				for _, part := range strings.Split(relPath, "/") {
-					if part == seg {
-						return pattern, true
-					}
-				}
-			}
-		}
-		if strings.HasSuffix(pattern, "/**") {
-			dirPrefix := strings.TrimSuffix(pattern, "/**")
-			if relPath == dirPrefix || strings.HasPrefix(relPath, dirPrefix+"/") {
-				return pattern, true
-			}
-		}
-		if m, err := filepath.Match(pattern, relPath); err == nil && m {
-			return pattern, true
-		}
-		if strings.HasPrefix(pattern, "**/") {
-			sub := strings.TrimPrefix(pattern, "**/")
-			if m, err := filepath.Match(sub, filepath.Base(relPath)); err == nil && m {
-				return pattern, true
-			}
-			if m, err := filepath.Match(sub, relPath); err == nil && m {
-				return pattern, true
-			}
-		}
-	}
-	return "", false
-}
-
-// matchDirScopedGlob reports whether relPath's basename matches fileGlob AND
-// prefix names one of its ancestor directories ("**/<seg>" for a segment at any
-// depth, otherwise an anchored literal path).
-//
-// A filename alone cannot classify a Ruby test. `lib/foo_test.rb` is one and
-// `app/jobs/cache_warmup_ab_test.rb` is a production A/B-test job, yet both end in
-// the token `test`; matching on the suffix deleted the latter from the graph
-// entirely. Ruby settles it by convention — RSpec requires spec/, Minitest defaults
-// to test/ — so the directory segment is the signal, and this predicate lets a
-// single pattern demand both halves.
-//
-// Because every element of dirSegs is by construction an ancestor of the basename,
-// segment equality alone places the file under the directory: no depth bookkeeping,
-// and "spec/user_spec.rb" (zero intervening directories) falls out for free.
-func matchDirScopedGlob(relPath, prefix, fileGlob string) bool {
-	segs := strings.Split(relPath, "/")
-	if len(segs) < 2 {
-		return false // no directory component, so no prefix can name an ancestor
-	}
-	dirSegs, base := segs[:len(segs)-1], segs[len(segs)-1]
-
-	if m, err := filepath.Match(fileGlob, base); err != nil || !m {
-		return false
-	}
-	if seg, ok := strings.CutPrefix(prefix, "**/"); ok {
-		if seg == "" || strings.Contains(seg, "/") {
-			return false
-		}
-		return slices.Contains(dirSegs, seg)
-	}
-	if prefix == "**" {
-		return true // any directory
-	}
-	return strings.HasPrefix(relPath, prefix+"/")
+	return facts.MatchGlob(relPath, patterns)
 }
 
 // isIgnored checks whether a path matches any ignore pattern. isDir is unused: the

--- a/internal/facts/pathglob.go
+++ b/internal/facts/pathglob.go
@@ -1,0 +1,110 @@
+package facts
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// matchAnyGlob reports whether a forward-slash path matches any of the patterns.
+// It is the single matcher behind both the ignore list and the test globs, so a
+// file the two lists disagree about cannot exist: an ignored file that stops being
+// a test necessarily stops being ignored.
+func MatchAnyGlob(relPath string, patterns []string) bool {
+	_, ok := MatchGlob(relPath, patterns)
+	return ok
+}
+
+// matchGlob returns the first pattern that matches relPath. The receipt records it
+// beside the skipped path, so "why is this file missing from the graph?" is a
+// lookup rather than an investigation. Supported forms:
+//
+//	vendor/**                 anchored directory prefix
+//	**/build/**               a directory named "build" at any depth
+//	**/*_test.go              a basename glob at any depth
+//	**/spec/**/*_spec.rb      a basename glob under a directory named "spec"
+//
+// The last form is the only one that constrains directory and filename together;
+// see matchDirScopedGlob for why the Ruby test globs need it.
+func MatchGlob(relPath string, patterns []string) (string, bool) {
+	for _, pattern := range patterns {
+		// "<prefix>/**/<fileglob>". Handled first and exclusively: the branches
+		// below would match such a pattern only when exactly one directory sits
+		// between prefix and file, which is an artifact of filepath.Match reading
+		// "**" as "*", not a rule anyone intended.
+		if i := strings.Index(pattern, "/**/"); i >= 0 {
+			prefix, fileGlob := pattern[:i], pattern[i+len("/**/"):]
+			if !strings.Contains(fileGlob, "/") {
+				if matchDirScopedGlob(relPath, prefix, fileGlob) {
+					return pattern, true
+				}
+				continue
+			}
+		}
+		if strings.HasPrefix(pattern, "**/") && strings.HasSuffix(pattern, "/**") {
+			seg := strings.TrimSuffix(strings.TrimPrefix(pattern, "**/"), "/**")
+			if seg != "" && !strings.Contains(seg, "/") {
+				for _, part := range strings.Split(relPath, "/") {
+					if part == seg {
+						return pattern, true
+					}
+				}
+			}
+		}
+		if strings.HasSuffix(pattern, "/**") {
+			dirPrefix := strings.TrimSuffix(pattern, "/**")
+			if relPath == dirPrefix || strings.HasPrefix(relPath, dirPrefix+"/") {
+				return pattern, true
+			}
+		}
+		if m, err := filepath.Match(pattern, relPath); err == nil && m {
+			return pattern, true
+		}
+		if strings.HasPrefix(pattern, "**/") {
+			sub := strings.TrimPrefix(pattern, "**/")
+			if m, err := filepath.Match(sub, filepath.Base(relPath)); err == nil && m {
+				return pattern, true
+			}
+			if m, err := filepath.Match(sub, relPath); err == nil && m {
+				return pattern, true
+			}
+		}
+	}
+	return "", false
+}
+
+// matchDirScopedGlob reports whether relPath's basename matches fileGlob AND
+// prefix names one of its ancestor directories ("**/<seg>" for a segment at any
+// depth, otherwise an anchored literal path).
+//
+// A filename alone cannot classify a Ruby test. `lib/foo_test.rb` is one and
+// `app/jobs/cache_warmup_ab_test.rb` is a production A/B-test job, yet both end in
+// the token `test`; matching on the suffix deleted the latter from the graph
+// entirely. Ruby settles it by convention — RSpec requires spec/, Minitest defaults
+// to test/ — so the directory segment is the signal, and this predicate lets a
+// single pattern demand both halves.
+//
+// Because every element of dirSegs is by construction an ancestor of the basename,
+// segment equality alone places the file under the directory: no depth bookkeeping,
+// and "spec/user_spec.rb" (zero intervening directories) falls out for free.
+func matchDirScopedGlob(relPath, prefix, fileGlob string) bool {
+	segs := strings.Split(relPath, "/")
+	if len(segs) < 2 {
+		return false // no directory component, so no prefix can name an ancestor
+	}
+	dirSegs, base := segs[:len(segs)-1], segs[len(segs)-1]
+
+	if m, err := filepath.Match(fileGlob, base); err != nil || !m {
+		return false
+	}
+	if seg, ok := strings.CutPrefix(prefix, "**/"); ok {
+		if seg == "" || strings.Contains(seg, "/") {
+			return false
+		}
+		return slices.Contains(dirSegs, seg)
+	}
+	if prefix == "**" {
+		return true // any directory
+	}
+	return strings.HasPrefix(relPath, prefix+"/")
+}

--- a/pkg/facts/facts.go
+++ b/pkg/facts/facts.go
@@ -83,6 +83,27 @@ func ModuleRoleForPath(dir string) string { return internal.ModuleRoleForPath(di
 // directory and not the filename.
 func IsTestPath(p string) bool { return internal.IsTestPath(p) }
 
+// MatchGlob reports which of the patterns matches a forward-slash relative path, and
+// MatchAnyGlob whether any does. Unlike path.Match / filepath.Match, these understand
+// `**`:
+//
+//	vendor/**                 anchored directory prefix
+//	**/build/**               a directory named "build" at any depth
+//	**/*_test.go              a basename glob at any depth
+//	**/spec/**/*_spec.rb      a basename glob under a directory named "spec"
+//
+// Re-exported so out-of-module consumers share the engine's matcher instead of
+// reaching for path.Match — which silently reads `**` as `*` and cannot cross a `/`,
+// so every documented `**` pattern quietly matches nothing.
+func MatchGlob(relPath string, patterns []string) (string, bool) {
+	return internal.MatchGlob(relPath, patterns)
+}
+
+// MatchAnyGlob reports whether relPath matches any of the patterns. See MatchGlob.
+func MatchAnyGlob(relPath string, patterns []string) bool {
+	return internal.MatchAnyGlob(relPath, patterns)
+}
+
 // CanonicalSymbols collapses #if/#else conditional-compilation duplicates in a
 // symbol-fact slice, keeping non-conditional overloads intact. Re-exported so
 // out-of-module consumers that count symbols (package-metrics) apply the same rule


### PR DESCRIPTION
The engine has had a matcher that understands ** since the ignore globs were directory-scoped — vendor/**, **/build/**, **/*_test.go, prefix/**/fileglob — and its own comment names the bug it exists to avoid: filepath.Match reads ** as *, which cannot cross a /.

It was unexported and in internal/, so the enterprise performance analyzer could not reach it and grew a second, weaker implementation on path.Match. That one silently matched nothing for every ** pattern its own docs advertised.

Move matchGlob/matchAnyGlob/matchDirScopedGlob to internal/facts, beside the other shared path predicates (IsTestPath), and re-export MatchGlob / MatchAnyGlob from pkg/facts. internal/engine keeps thin aliases, so its call sites and both its existing glob test files are untouched.

Pure code move: no behaviour change, no facts emitted, no cacheVersion bump. TestGolden passing unchanged is the proof — if a golden moved, the move altered what the walker ignores.