### PR TITLE
BuildModuleGraph derived a dependency edge's source module from

### DIFF
--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -31,6 +31,26 @@ func FileDir(file string) string {
 	return strings.Join(parts[:len(parts)-1], "/")
 }
 
+// nearestModule walks dir up its path until it reaches a known production or test
+// module, and returns that module name. If nothing encloses dir it is returned
+// unchanged — so the result is identical to a raw FileDir wherever the file's
+// directory is itself the module (Go packages, Rails/TS directory-modules), and
+// only differs for nested layouts (Swift/Xcode targets) where the module lives
+// above the file's leaf directory. Mirrors package_metrics' resolveToModule.
+func nearestModule(dir string, prod, test map[string]bool) string {
+	cur := dir
+	for {
+		if prod[cur] || test[cur] {
+			return cur
+		}
+		i := strings.LastIndex(cur, "/")
+		if i < 0 {
+			return dir
+		}
+		cur = cur[:i]
+	}
+}
+
 // IsExternalImport reports whether an import target points outside the repo
 // (Go stdlib, third-party, or an npm package) rather than at an internal module.
 func IsExternalImport(path string) bool {
@@ -151,7 +171,15 @@ func BuildModuleGraphExcluding(store *facts.Store, excludeKinds ...string) map[s
 
 	deps := store.ByKind(facts.KindDependency)
 	for _, dep := range deps {
-		sourceModule := FileDir(dep.File)
+		// Attribute the edge to the file's nearest ENCLOSING module, not its raw
+		// leaf directory. Where files sit directly in the module directory (Go
+		// packages, Rails/TS directory-modules) these coincide; but in a nested
+		// layout — a Swift/Xcode target `Sources/Foo` with files under
+		// `Sources/Foo/Bar/…` — the leaf dir `Sources/Foo/Bar` is not a module, so a
+		// raw-FileDir source node never matched a module-name target and no cycle or
+		// edge could form (which silently zeroed cycle detection on such projects).
+		// Resolving up keeps this graph consistent with package_metrics.
+		sourceModule := nearestModule(FileDir(dep.File), moduleNames, testModules)
 		if testModules[sourceModule] {
 			continue // edge out of a test bundle — not production architecture
 		}

--- a/internal/explainers/common/common_test.go
+++ b/internal/explainers/common/common_test.go
@@ -115,6 +115,47 @@ func TestBuildModuleGraph(t *testing.T) {
 	}
 }
 
+// TestBuildModuleGraph_NestedFileResolvesToModule pins the fix for nested module
+// layouts (e.g. a Swift/Xcode target Sources/Foo with files under Sources/Foo/Bar/…):
+// a dependency whose File sits BELOW the module root must attribute to the module,
+// not the leaf directory — otherwise the source node never matches a module-name
+// target and a real cycle (Foo <-> Bar) is silently missed.
+func TestBuildModuleGraph_NestedFileResolvesToModule(t *testing.T) {
+	s := facts.NewStore()
+	for _, m := range []string{"Sources/Foo", "Sources/Bar"} {
+		s.Add(facts.Fact{Kind: facts.KindModule, Name: m})
+	}
+	// Foo imports Bar (from a file nested under Sources/Foo/Sub) and Bar imports Foo
+	// (from a file nested under Sources/Bar/Deeper/Nested) — a 2-module cycle.
+	s.Add(facts.Fact{
+		Kind:      facts.KindDependency,
+		File:      "Sources/Foo/Sub/Thing.swift",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "Sources/Bar"}},
+	})
+	s.Add(facts.Fact{
+		Kind:      facts.KindDependency,
+		File:      "Sources/Bar/Deeper/Nested/Other.swift",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "Sources/Foo"}},
+	})
+
+	graph := BuildModuleGraph(s)
+
+	if edges := graph["Sources/Foo"]; len(edges) != 1 || edges[0] != "Sources/Bar" {
+		t.Errorf("Sources/Foo edges = %v, want [Sources/Bar]", edges)
+	}
+	if edges := graph["Sources/Bar"]; len(edges) != 1 || edges[0] != "Sources/Foo" {
+		t.Errorf("Sources/Bar edges = %v, want [Sources/Foo]", edges)
+	}
+	// The leaf directories must NOT appear as their own graph nodes.
+	if _, ok := graph["Sources/Foo/Sub"]; ok {
+		t.Error("leaf dir Sources/Foo/Sub leaked as a graph node")
+	}
+	// And the two modules form a strongly-connected component (a real cycle).
+	if got := sccKey(StronglyConnectedComponents(graph)); got != "Sources/Bar,Sources/Foo" {
+		t.Errorf("SCC = %q, want the Foo<->Bar cycle", got)
+	}
+}
+
 func TestSymbolModule(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
FileDir(dep.File) — the file's leaf directory. In nested module layouts, where source files live below the module root (e.g. an Xcode/SPM target with files under Sources/<Target>/<Sub>/), the leaf directory is not a module, so source nodes never matched module-name targets and no strongly-connected component could form. This silently zeroed cycle detection — and skewed dependency-depth — on such projects, while package_metrics, which resolves via resolveToModule, was unaffected.

Add a nearestModule helper that walks a file's directory up to its enclosing production/test module, and use it for the edge source. It is a no-op where the file directory is already the module (Go packages, directory-based Ruby and TypeScript modules) and only changes nested layouts, so existing behavior and goldens are unaffected.

Add a regression test asserting a two-module cycle forms from files nested below their module roots.