### PR TITLE
fix(explainers): resolve module-graph edge targets to the enclosing m…

### DIFF
--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -199,10 +199,19 @@ func BuildModuleGraphExcluding(store *facts.Store, excludeKinds ...string) map[s
 				target = ResolveRelativeImport(sourceModule, target)
 			}
 
-			// A target is included only if it names a known internal module. This gate is
-			// authoritative; we deliberately do NOT pre-filter with IsExternalImport, which
-			// misclassifies single-segment internal modules (top-level "cmd", "config") as
-			// external and would drop real edges before this check.
+			// Resolve the target up to its enclosing module too. Extractors emit
+			// import targets at differing granularity — a bare module dir (Go/Rails),
+			// a module dir + symbol name (Kotlin/Java `import a.b.C` -> "a/b/C"), or a
+			// file stem (TypeScript) — so an exact module-name match drops every
+			// class-/file-suffixed target and silently loses those edges (e.g. all
+			// Kotlin-sourced cycles). Walking up mirrors package_metrics and the source
+			// resolution above; it is a no-op where the target is already a module.
+			target = nearestModule(target, moduleNames, testModules)
+
+			// A target is included only if it names a known internal PRODUCTION module.
+			// This gate is authoritative; we deliberately do NOT pre-filter with
+			// IsExternalImport, which misclassifies single-segment internal modules
+			// (top-level "cmd", "config") as external and would drop real edges here.
 			if moduleNames[target] {
 				graph[sourceModule] = append(graph[sourceModule], target)
 			}

--- a/internal/explainers/common/common_test.go
+++ b/internal/explainers/common/common_test.go
@@ -156,6 +156,40 @@ func TestBuildModuleGraph_NestedFileResolvesToModule(t *testing.T) {
 	}
 }
 
+// TestBuildModuleGraph_ClassSuffixedTargetResolves pins the fix for import
+// targets that carry a trailing symbol segment (Kotlin/Java `import a.b.C` is
+// emitted as target "a/b/C", where the module is "a/b"). A mutual pair of such
+// imports must still form a cycle — an exact module-name match would drop both.
+func TestBuildModuleGraph_ClassSuffixedTargetResolves(t *testing.T) {
+	s := facts.NewStore()
+	for _, m := range []string{"app/model", "app/common"} {
+		s.Add(facts.Fact{Kind: facts.KindModule, Name: m})
+	}
+	// model imports a class in common; common imports a class in model.
+	s.Add(facts.Fact{
+		Kind:      facts.KindDependency,
+		File:      "app/model/User.kt",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "app/common/Pagination"}},
+	})
+	s.Add(facts.Fact{
+		Kind:      facts.KindDependency,
+		File:      "app/common/FlowUtils.kt",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "app/model/GidUtil"}},
+	})
+
+	graph := BuildModuleGraph(s)
+
+	if edges := graph["app/model"]; len(edges) != 1 || edges[0] != "app/common" {
+		t.Errorf("app/model edges = %v, want [app/common]", edges)
+	}
+	if edges := graph["app/common"]; len(edges) != 1 || edges[0] != "app/model" {
+		t.Errorf("app/common edges = %v, want [app/model]", edges)
+	}
+	if got := sccKey(StronglyConnectedComponents(graph)); got != "app/common,app/model" {
+		t.Errorf("SCC = %q, want the model<->common cycle", got)
+	}
+}
+
 func TestSymbolModule(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/explainers/layers/layers.go
+++ b/internal/explainers/layers/layers.go
@@ -428,11 +428,14 @@ func (e *LayerExplainer) detectViolations(store *facts.Store, pattern *archPatte
 	var violations []violation
 
 	for _, dep := range store.ByKind(facts.KindDependency) {
-		sourceModule := common.FileDir(dep.File)
-		sourceLayer, sourceOK := pattern.Modules[sourceModule]
+		// Resolve the importing file's directory up to its nearest classified module,
+		// so a file nested below the module root (Swift/Xcode) still attributes to a
+		// layer instead of being dropped.
+		sourceModule, sourceOK := resolveLayerModule(common.FileDir(dep.File), pattern.Modules)
 		if !sourceOK {
 			continue
 		}
+		sourceLayer := pattern.Modules[sourceModule]
 
 		for _, rel := range dep.Relations {
 			if rel.Kind != facts.RelImports {
@@ -444,10 +447,18 @@ func (e *LayerExplainer) detectViolations(store *facts.Store, pattern *archPatte
 				target = common.ResolveRelativeImport(sourceModule, target)
 			}
 
-			targetLayer, targetOK := pattern.Modules[target]
+			// Resolve the target up to its enclosing classified module. Import targets
+			// carry differing granularity across extractors — a module dir + symbol
+			// name (Kotlin/Java `import a.b.C` -> "a/b/C") or a file stem (TypeScript) —
+			// so an exact module lookup silently drops every class-/file-suffixed
+			// target (which was hiding all Kotlin-sourced layer violations). Mirrors
+			// package_metrics' resolveToModule; a no-op for bare-module-dir targets.
+			targetModule, targetOK := resolveLayerModule(target, pattern.Modules)
 			if !targetOK {
 				continue
 			}
+			targetLayer := pattern.Modules[targetModule]
+			target = targetModule
 
 			sourceDef := pattern.Layers[sourceLayer]
 			targetDef := pattern.Layers[targetLayer]
@@ -499,6 +510,26 @@ func (e *LayerExplainer) detectViolations(store *facts.Store, pattern *archPatte
 	}
 
 	return insights
+}
+
+// resolveLayerModule walks path up its directory segments until it names a
+// classified module (a key in modules), returning that module and true. If no
+// ancestor is classified it returns false. This absorbs the granularity
+// differences in extractor import targets (bare module dir, module dir + symbol
+// name, or file stem) and in nested source layouts, so a layer violation is not
+// missed just because the raw endpoint carried a trailing symbol/file segment.
+func resolveLayerModule(path string, modules map[string]string) (string, bool) {
+	cur := path
+	for {
+		if _, ok := modules[cur]; ok {
+			return cur, true
+		}
+		i := strings.LastIndex(cur, "/")
+		if i < 0 {
+			return "", false
+		}
+		cur = cur[:i]
+	}
 }
 
 // matchesLayer checks if a module path contains any of the given patterns.

--- a/internal/explainers/layers/layers_test.go
+++ b/internal/explainers/layers/layers_test.go
@@ -413,6 +413,34 @@ func TestDetectViolations_InnerImportsOuter(t *testing.T) {
 	}
 }
 
+// TestDetectViolations_ResolvesNestedSourceAndSuffixedTarget pins the fix for
+// endpoint granularity: the source file sits BELOW its module directory
+// (Swift/Xcode nesting) and the import target carries a trailing symbol name
+// (Kotlin/Java `import a.b.C` -> "a/b/C"). Both must resolve up to their modules
+// or the inner→outer violation is silently dropped (which was hiding every
+// Kotlin-sourced layer violation).
+func TestDetectViolations_ResolvesNestedSourceAndSuffixedTarget(t *testing.T) {
+	s := facts.NewStore()
+	for _, m := range []string{"domain/entity", "presentation/views", "adapter/rest", "application/svc"} {
+		s.Add(facts.Fact{Kind: facts.KindModule, Name: m})
+	}
+	s.Add(facts.Fact{
+		Kind: facts.KindDependency,
+		File: "domain/entity/nested/Thing.kt", // FileDir = domain/entity/nested (not a module)
+		Relations: []facts.Relation{
+			{Kind: facts.RelImports, Target: "presentation/views/HomeView"}, // module dir + class name
+		},
+	})
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if got := countViolations(insights); got != 1 {
+		t.Fatalf("want 1 violation (domain nested -> presentation class-suffixed), got %d", got)
+	}
+}
+
 func TestDetectViolations_OuterImportsInner(t *testing.T) {
 	store := makeStore(
 		[]string{"domain/entity", "presentation/views", "adapter/rest", "application/svc"},


### PR DESCRIPTION
…odule

Complements the edge-source fix: BuildModuleGraph and the layers explainer matched an import edge's TARGET against an exact module name, but extractors emit targets at differing granularity — a bare module dir (Go/Ruby), a module dir plus the imported symbol name (Kotlin/Java `import a.b.C` -> "a/b/C"), or a file stem (TypeScript). An exact match therefore dropped every class- or file-suffixed target, silently losing those edges: on a Kotlin codebase this hid all Kotlin-sourced layer violations and dependency cycles (only edges whose target happened to be a bare package dir survived), while package_metrics, which resolves via resolveToModule, reported the same edges correctly.

Walk the target up to its nearest enclosing module in both BuildModuleGraph (cycles, dependency-depth) and the layers explainer's detectViolations; also resolve the layers source directory up, matching the earlier source fix so a file nested below its module root still attributes to a layer. All resolution is a no-op where the endpoint is already a module dir, so existing behavior and goldens are unchanged; it only recovers edges that were previously dropped.

Add regression tests: a cycle formed from class-suffixed mutual imports, and a layer violation from a nested source importing a class-suffixed target.