### PR TITLE
fix(engine): make snapshot state safe for concurrent tool calls

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/enola-labs/enola/internal/config"
@@ -27,16 +28,35 @@ import (
 	"github.com/enola-labs/enola/pkg/plugin"
 )
 
+// snapshotBundle is the immutable, reader-visible snapshot state. GenerateSnapshot
+// builds a brand-new store off to the side and publishes a fresh bundle in a single
+// atomic swap; once published, none of its fields are ever mutated again. Readers
+// (Store/Snapshot/RepoPaths/ResolveFactFile) Load the current bundle lock-free and
+// use it for as long as they like — a concurrent regeneration builds a different
+// store and swaps the pointer, leaving the bundle an in-flight reader holds intact.
+type snapshotBundle struct {
+	store     *facts.Store      // immutable once published
+	snapshot  *facts.Snapshot   // may be nil (no snapshot generated yet)
+	repoPaths map[string]string // repo label -> absolute path; immutable once published, may be nil
+}
+
 // Engine orchestrates the snapshot generation pipeline.
 type Engine struct {
-	mu         sync.Mutex // serializes GenerateSnapshot calls
+	mu         sync.Mutex // serializes GenerateSnapshot calls and guards the build-scratch store
 	cfg        *config.Config
 	extractors *extractors.Registry
 	explainers *explainers.Registry
 	renderers  *renderers.Registry
-	store      *facts.Store
-	snapshot   *facts.Snapshot
-	repoPaths  map[string]string // repo label -> absolute path (populated in append mode)
+
+	// store is BUILD SCRATCH: it is reassigned to a fresh store at the top of each
+	// GenerateSnapshot and read only by the pipeline helpers, all under mu. It is
+	// NOT the reader-visible store — that lives in `current` and is only swapped in
+	// atomically once the build is complete. Never expose e.store to readers.
+	store *facts.Store
+
+	// current holds the published, immutable {store, snapshot, repoPaths} bundle.
+	// Readers Load it lock-free; GenerateSnapshot Stores a new bundle to publish.
+	current atomic.Pointer[snapshotBundle]
 
 	// persistCache controls whether the per-extractor cache is written back to
 	// disk after a snapshot. The read path is always active when caching is
@@ -47,14 +67,20 @@ type Engine struct {
 // New creates a new Engine with the given config.
 // Extractors, explainers, and renderers must be registered after creation.
 func New(cfg *config.Config) (*Engine, error) {
-	return &Engine{
+	// The build-scratch store and the initial published store are the same empty
+	// store, so AutoLoadSnapshot (which mutates Store() in place before serving)
+	// and the first generate both start from a consistent, non-nil bundle.
+	st := facts.NewStore()
+	e := &Engine{
 		cfg:          cfg,
 		extractors:   extractors.NewRegistry(),
 		explainers:   explainers.NewRegistry(),
 		renderers:    renderers.NewRegistry(),
-		store:        facts.NewStore(),
+		store:        st,
 		persistCache: true,
-	}, nil
+	}
+	e.current.Store(&snapshotBundle{store: st})
+	return e, nil
 }
 
 // SetPersistCache controls whether the per-extractor cache is written to disk
@@ -77,14 +103,17 @@ func (e *Engine) RegisterRenderer(rnd renderers.Renderer) {
 	e.renderers.Register(rnd)
 }
 
-// Store returns the fact store.
+// Store returns the published fact store. The returned store is immutable for as
+// long as the caller uses it: a concurrent regeneration builds a different store
+// and swaps the published bundle, so it never mutates the store handed out here.
 func (e *Engine) Store() *facts.Store {
-	return e.store
+	return e.current.Load().store
 }
 
-// Snapshot returns the last generated snapshot, or nil.
+// Snapshot returns the last published snapshot, or nil. Lock-free: the returned
+// snapshot is immutable once published.
 func (e *Engine) Snapshot() *facts.Snapshot {
-	return e.snapshot
+	return e.current.Load().snapshot
 }
 
 // Config returns the engine config.
@@ -92,23 +121,29 @@ func (e *Engine) Config() *config.Config {
 	return e.cfg
 }
 
-// SetRepoPaths sets the repo label -> absolute path mapping (used in tests).
+// SetRepoPaths sets the repo label -> absolute path mapping (used in tests). It
+// republishes the bundle preserving the current store and snapshot.
 func (e *Engine) SetRepoPaths(paths map[string]string) {
-	e.repoPaths = paths
+	b := e.current.Load()
+	e.current.Store(&snapshotBundle{store: b.store, snapshot: b.snapshot, repoPaths: paths})
 }
 
-// SetSnapshot sets the snapshot (used in tests).
+// SetSnapshot sets the snapshot (used in tests, and by AutoLoadSnapshot at
+// startup). It republishes the bundle preserving the current store and repoPaths.
 func (e *Engine) SetSnapshot(snap *facts.Snapshot) {
-	e.snapshot = snap
+	b := e.current.Load()
+	e.current.Store(&snapshotBundle{store: b.store, snapshot: snap, repoPaths: b.repoPaths})
 }
 
-// RepoPaths returns the repo label -> absolute path mapping (populated in append mode).
+// RepoPaths returns a copy of the repo label -> absolute path mapping (populated in
+// append mode). Lock-free bundle load; the copy lets callers retain it safely.
 func (e *Engine) RepoPaths() map[string]string {
-	if e.repoPaths == nil {
+	b := e.current.Load()
+	if b.repoPaths == nil {
 		return nil
 	}
-	cp := make(map[string]string, len(e.repoPaths))
-	for k, v := range e.repoPaths {
+	cp := make(map[string]string, len(b.repoPaths))
+	for k, v := range b.repoPaths {
 		cp[k] = v
 	}
 	return cp
@@ -119,18 +154,21 @@ func (e *Engine) RepoPaths() map[string]string {
 // corresponding repo root. In single-repo mode it falls back to the snapshot's
 // RepoPath.
 func (e *Engine) ResolveFactFile(f *facts.Fact) string {
+	// Load the bundle once so repoPaths and snapshot are read as a consistent pair.
+	b := e.current.Load()
+
 	// Multi-repo: if the fact has a Repo label that maps to a known path,
 	// strip the repo prefix from f.File and join with the absolute root.
-	if f.Repo != "" && e.repoPaths != nil {
-		if absRoot, ok := e.repoPaths[f.Repo]; ok {
+	if f.Repo != "" && b.repoPaths != nil {
+		if absRoot, ok := b.repoPaths[f.Repo]; ok {
 			rel := strings.TrimPrefix(f.File, f.Repo+"/")
 			return filepath.Join(absRoot, rel)
 		}
 	}
 
 	// Single-repo fallback.
-	if e.snapshot != nil {
-		return filepath.Join(e.snapshot.Meta.RepoPath, f.File)
+	if b.snapshot != nil {
+		return filepath.Join(b.snapshot.Meta.RepoPath, f.File)
 	}
 	return f.File
 }
@@ -155,30 +193,49 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 
 	repoLabel := filepath.Base(absRepo)
 
+	// Build into a BRAND-NEW store off to the side. The currently-published bundle
+	// (prev) is never mutated, so any in-flight reader keeps iterating a consistent,
+	// frozen snapshot while we regenerate. We publish the new store atomically at the
+	// end (see e.current.Store below), which is the single linearization point.
+	prev := e.current.Load()
+	work := facts.NewStore()
+	var workRepoPaths map[string]string
+
 	if appendMode {
-		// Track repo label -> absolute path for multi-repo resolution.
-		if e.repoPaths == nil {
-			e.repoPaths = make(map[string]string)
+		// Carry prior repos forward. All() returns an independent COPY, so mutating
+		// `work` (TagUntagged/TagRange/SetRepoRange) can never touch prev.store, which
+		// stays published and readable until we swap. This is the transient ~1x
+		// fact-set memory cost of lock-free reads in append mode.
+		workRepoPaths = make(map[string]string, len(prev.repoPaths)+1)
+		for k, v := range prev.repoPaths {
+			workRepoPaths[k] = v
 		}
-		e.repoPaths[repoLabel] = absRepo
+		if prev.store != nil {
+			work.Add(prev.store.All()...)
+		}
+
+		// Track repo label -> absolute path for multi-repo resolution.
+		workRepoPaths[repoLabel] = absRepo
 
 		// Retroactively tag facts from a prior single-repo snapshot so they
 		// are filterable by repo alongside the newly appended facts.
-		if e.snapshot != nil && e.store.Count() > 0 {
-			prevLabel := filepath.Base(e.snapshot.Meta.RepoPath)
-			if _, alreadyTracked := e.repoPaths[prevLabel]; !alreadyTracked {
-				tagged := e.store.TagUntagged(prevLabel, prevLabel+"/")
+		if prev.snapshot != nil && work.Count() > 0 {
+			prevLabel := filepath.Base(prev.snapshot.Meta.RepoPath)
+			if _, alreadyTracked := workRepoPaths[prevLabel]; !alreadyTracked {
+				tagged := work.TagUntagged(prevLabel, prevLabel+"/")
 				if tagged > 0 {
-					e.repoPaths[prevLabel] = e.snapshot.Meta.RepoPath
+					workRepoPaths[prevLabel] = prev.snapshot.Meta.RepoPath
 					log.Printf("[engine] retroactively tagged %d existing facts with repo label %q", tagged, prevLabel)
 				}
 			}
 		}
-	} else {
-		// Clear previous state (default single-repo behaviour).
-		e.store.Clear()
-		e.repoPaths = nil
 	}
+	// Non-append: `work` stays empty and workRepoPaths stays nil — the prior bundle
+	// is left intact for in-flight readers until the swap (no in-place Clear()).
+
+	// Point the build-scratch store at `work` so the pipeline helpers (which read
+	// e.store under e.mu) operate on the new store with no signature changes.
+	e.store = work
 
 	// Per-stage timing breakdown (logged at the end). Snapshotting is
 	// extraction-dominated, so this makes it obvious where time goes.
@@ -325,11 +382,12 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 			HeuristicInsights: countHeuristicInsights(allInsights),
 			Coverage:          coverageSummary(e.store),
 		},
-		// FactsRef aliases the store's slice rather than copying it: this snapshot
-		// is the live one (e.snapshot) and its Facts are only ever read (renderers,
-		// diff, query_insights), so a second full copy of every fact would just
-		// double steady-state RSS for a large repo. Baselines, which must stay
-		// immutable as the store regenerates, still use the copying All().
+		// FactsRef aliases the store's slice rather than copying it. This is safe:
+		// `work` is published (below) and then NEVER mutated again — the next
+		// regeneration builds a different store — so a reader iterating snapshot.Facts
+		// iterates a frozen backing array. Copying every fact would just double
+		// steady-state RSS for a large repo. Baselines, which must stay immutable as
+		// the store regenerates, still use the copying All().
 		Facts:    e.store.FactsRef(),
 		Insights: allInsights,
 	}
@@ -344,7 +402,9 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 	snapshot.Meta.Renderers = usedRenderers
 	log.Printf("[engine] produced %d artifacts using %d renderers", len(snapshot.Artifacts), len(usedRenderers))
 
-	e.snapshot = snapshot
+	// Publish atomically. This single Store() is the linearization point: before it
+	// readers see the prior bundle, after it the new one — never a half-built store.
+	e.current.Store(&snapshotBundle{store: work, snapshot: snapshot, repoPaths: workRepoPaths})
 	log.Printf("[engine] snapshot generated in %s", duration)
 	log.Printf("[engine] timings: walk=%s hash=%s extract=%s link=%s graph=%s explain=%s render=%s",
 		tWalk.Round(time.Millisecond), tHash.Round(time.Millisecond), tExtract.Round(time.Millisecond),
@@ -713,7 +773,11 @@ func (e *Engine) runRenderers(ctx context.Context, snapshot *facts.Snapshot) ([]
 // WriteArtifacts writes all snapshot artifacts to the output directory,
 // including facts.jsonl, insights.json, and snapshot.meta.json.
 func (e *Engine) WriteArtifacts(repoPath string) error {
-	if e.snapshot == nil {
+	// Load the published bundle once and read only from it. The bundle is immutable,
+	// so serializing facts/insights/meta here is race-free even if another generate
+	// publishes a newer bundle meanwhile.
+	b := e.current.Load()
+	if b.snapshot == nil {
 		return fmt.Errorf("no snapshot generated")
 	}
 
@@ -735,7 +799,7 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	outputHashes := make(map[string]string)
 
 	// Write renderer artifacts (e.g. llm_context.md)
-	for _, a := range e.snapshot.Artifacts {
+	for _, a := range b.snapshot.Artifacts {
 		path := filepath.Join(outDir, a.Name)
 		if err := os.WriteFile(path, a.Content, 0o644); err != nil {
 			return fmt.Errorf("writing %s: %w", a.Name, err)
@@ -746,7 +810,7 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 
 	// Write facts.jsonl (serialize to a buffer first so we can hash the exact bytes)
 	var factsBuf bytes.Buffer
-	if err := e.store.WriteJSONL(&factsBuf); err != nil {
+	if err := b.store.WriteJSONL(&factsBuf); err != nil {
 		return fmt.Errorf("serializing facts.jsonl: %w", err)
 	}
 	factsPath := filepath.Join(outDir, "facts.jsonl")
@@ -757,7 +821,7 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	log.Printf("[engine] wrote %s", factsPath)
 
 	// Write insights.json
-	insightsJSON, err := json.MarshalIndent(e.snapshot.Insights, "", "  ")
+	insightsJSON, err := json.MarshalIndent(b.snapshot.Insights, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling insights: %w", err)
 	}
@@ -768,11 +832,14 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	outputHashes["insights.json"] = hashBytes(insightsJSON)
 	log.Printf("[engine] wrote %s (%d bytes)", insightsPath, len(insightsJSON))
 
-	// Record the output hashes on the snapshot meta before serializing it.
-	e.snapshot.Meta.OutputHashes = outputHashes
+	// Record the output hashes on a COPY of the meta rather than mutating the
+	// published (shared, immutable) snapshot in place. SnapshotMeta is a value type,
+	// so this copy shares its slices but overrides only OutputHashes.
+	meta := b.snapshot.Meta
+	meta.OutputHashes = outputHashes
 
 	// Write snapshot.meta.json (the internal superset, incl. per-file hashes)
-	metaJSON, err := json.MarshalIndent(e.snapshot.Meta, "", "  ")
+	metaJSON, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling meta: %w", err)
 	}
@@ -783,7 +850,7 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	log.Printf("[engine] wrote %s (%d bytes)", metaPath, len(metaJSON))
 
 	// Write receipt.json (the compact provenance + quality manifest)
-	receiptJSON, err := json.MarshalIndent(e.snapshot.Meta.Receipt(), "", "  ")
+	receiptJSON, err := json.MarshalIndent(meta.Receipt(), "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling receipt: %w", err)
 	}
@@ -792,6 +859,18 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 		return fmt.Errorf("writing receipt.json: %w", err)
 	}
 	log.Printf("[engine] wrote %s (%d bytes)", receiptPath, len(receiptJSON))
+
+	// Republish so in-memory receipt tools (snapshot_receipt/compare_receipts) reflect
+	// the output hashes, WITHOUT mutating the snapshot we just read. Only publish if
+	// the bundle hasn't been superseded by a concurrent generate in the meantime —
+	// generate-vs-generate is serialized (e.mu) and the server serializes the whole
+	// generate handler (genMu), so under normal use this always succeeds; the guard
+	// just avoids clobbering a newer snapshot in any unexpected interleaving.
+	if e.current.Load() == b {
+		snapCopy := *b.snapshot
+		snapCopy.Meta = meta
+		e.current.CompareAndSwap(b, &snapshotBundle{store: b.store, snapshot: &snapCopy, repoPaths: b.repoPaths})
+	}
 
 	return nil
 }
@@ -804,25 +883,26 @@ func hashBytes(b []byte) string {
 
 // GetArtifact returns the content of a named artifact, or the generated JSONL/JSON files.
 func (e *Engine) GetArtifact(name string) ([]byte, error) {
-	if e.snapshot == nil {
+	b := e.current.Load()
+	if b.snapshot == nil {
 		return nil, fmt.Errorf("no snapshot generated")
 	}
 
 	switch name {
 	case "facts.jsonl":
 		var buf bytes.Buffer
-		if err := e.store.WriteJSONL(&buf); err != nil {
+		if err := b.store.WriteJSONL(&buf); err != nil {
 			return nil, err
 		}
 		return buf.Bytes(), nil
 	case "insights.json":
-		return json.MarshalIndent(e.snapshot.Insights, "", "  ")
+		return json.MarshalIndent(b.snapshot.Insights, "", "  ")
 	case "snapshot.meta.json":
-		return json.MarshalIndent(e.snapshot.Meta, "", "  ")
+		return json.MarshalIndent(b.snapshot.Meta, "", "  ")
 	case "receipt.json":
-		return json.MarshalIndent(e.snapshot.Meta.Receipt(), "", "  ")
+		return json.MarshalIndent(b.snapshot.Meta.Receipt(), "", "  ")
 	default:
-		for _, a := range e.snapshot.Artifacts {
+		for _, a := range b.snapshot.Artifacts {
 			if a.Name == name {
 				return a.Content, nil
 			}

--- a/internal/engine/engine_race_test.go
+++ b/internal/engine/engine_race_test.go
@@ -1,0 +1,147 @@
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enola-labs/enola/internal/facts"
+	"github.com/enola-labs/enola/pkg/bootstrap"
+)
+
+// TestEngineConcurrentGenerateAndRead exercises the shared engine under the same
+// concurrency the MCP go-sdk produces (tool handlers dispatched on their own
+// goroutines, unserialized). It hammers a single *engine.Engine with overlapping
+// generate_snapshot writers and lock-free reader tools and must be race-clean under
+// `go test -race`.
+//
+// It proves the atomic snapshot-swap: readers never observe a torn/half-built store,
+// the `snapshot`/`repoPaths` fields never race a concurrent regeneration, and
+// snapshot.Facts (which aliases the store's backing slice) is safe to iterate while
+// another repo is being regenerated because a published store is never mutated again.
+func TestEngineConcurrentGenerateAndRead(t *testing.T) {
+	repoA := copyTree(t, "testdata/repos/go_sample", t.TempDir())
+	repoB := copyTree(t, "testdata/repos/python_sample", t.TempDir())
+
+	eng, _, err := bootstrap.NewEngine(bootstrap.Options{
+		ConfigPath: "no-such-config.yaml", // falls back to defaults
+	})
+	if err != nil {
+		t.Fatalf("bootstrap.NewEngine: %v", err)
+	}
+	// Don't persist the extractor cache: keeps the fixtures' .enola dirs untouched and
+	// avoids on-disk cache churn between the rapid regenerations below.
+	eng.SetPersistCache(false)
+
+	ctx := context.Background()
+
+	// Seed an initial published snapshot so readers have something from the start.
+	if _, err := eng.GenerateSnapshot(ctx, repoA, false); err != nil {
+		t.Fatalf("initial GenerateSnapshot: %v", err)
+	}
+
+	const duration = 2 * time.Second
+	deadline := time.Now().Add(duration)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 64)
+	fail := func(format string, args ...any) {
+		select {
+		case errCh <- fmt.Errorf(format, args...):
+		default:
+		}
+	}
+
+	// Writers: overlapping regenerations. e.mu serializes generate-vs-generate, but
+	// these run concurrently with all readers. Alternate a fresh single-repo snapshot
+	// of A with an append of B, so repoPaths and the store both grow and reset.
+	for w := 0; w < 3; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; time.Now().Before(deadline); i++ {
+				appendMode := (i+id)%2 == 1
+				repo := repoA
+				if appendMode {
+					repo = repoB
+				}
+				if _, err := eng.GenerateSnapshot(ctx, repo, appendMode); err != nil {
+					fail("writer %d: GenerateSnapshot(append=%v): %v", id, appendMode, err)
+					return
+				}
+			}
+		}(w)
+	}
+
+	// Readers: lock-free accessors, plus the FactsRef-aliasing hot path.
+	for r := 0; r < 12; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				st := eng.Store()
+				_ = st.Count()
+				_ = st.ByKind(facts.KindSymbol)
+				_ = st.Query("", "", "", "")
+
+				// The crux: a published snapshot's FactCount must always equal the
+				// length of its aliased Facts slice. A torn publish (or a store
+				// mutated out from under the alias) would break this invariant or
+				// trip the race detector.
+				if snap := eng.Snapshot(); snap != nil {
+					n := 0
+					for range snap.Facts {
+						n++
+					}
+					if snap.Meta.FactCount != n {
+						fail("torn snapshot: FactCount=%d but len(Facts)=%d", snap.Meta.FactCount, n)
+						return
+					}
+					if len(snap.Facts) > 0 {
+						f := snap.Facts[0]
+						_ = eng.ResolveFactFile(&f)
+					}
+				}
+				_ = eng.RepoPaths()
+			}
+		}()
+	}
+
+	// Artifact reader: exercises WriteArtifacts's sibling in-memory read path (bundle
+	// load + store/snapshot serialization) concurrently with regeneration.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			if _, err := eng.GetArtifact("facts.jsonl"); err != nil {
+				fail("GetArtifact(facts.jsonl): %v", err)
+				return
+			}
+			if _, err := eng.GetArtifact("receipt.json"); err != nil {
+				fail("GetArtifact(receipt.json): %v", err)
+				return
+			}
+		}
+	}()
+
+	// A single WriteArtifacts driver (sequential to itself, so no on-disk write race)
+	// running concurrently with generates, to cover the immutable-republish CAS path.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			if err := eng.WriteArtifacts(repoA); err != nil {
+				fail("WriteArtifacts: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -37,15 +37,16 @@ func globalReceiptPath() (string, error) {
 // per repo via gitInfo (nil for non-git dirs) and fact counts come from the store's
 // byRepo index. AddedAt/CommitChangedAt are left to the merge step; InGraphFor is
 // derived at write time. Entries are sorted by Label for stable output.
-func (e *Engine) repoEntries() []facts.GraphRepoEntry {
-	// label -> absolute path for every repo in the graph.
-	repos := e.RepoPaths()
+func (e *Engine) repoEntries(b *snapshotBundle) []facts.GraphRepoEntry {
+	// label -> absolute path for every repo in the graph, read from the passed
+	// bundle so all counts come from one consistent published snapshot.
+	repos := b.repoPaths
 	if len(repos) == 0 {
-		// Single-repo graph: RepoPaths() is nil until a repo is appended.
-		if e.snapshot == nil || e.snapshot.Meta.RepoPath == "" {
+		// Single-repo graph: repoPaths is nil until a repo is appended.
+		if b.snapshot == nil || b.snapshot.Meta.RepoPath == "" {
 			return nil
 		}
-		abs := e.snapshot.Meta.RepoPath
+		abs := b.snapshot.Meta.RepoPath
 		repos = map[string]string{filepath.Base(abs): abs}
 	}
 
@@ -55,7 +56,7 @@ func (e *Engine) repoEntries() []facts.GraphRepoEntry {
 			Label:     label,
 			Path:      abs,
 			Git:       gitInfo(abs),
-			FactCount: e.store.CountByRepo(label),
+			FactCount: b.store.CountByRepo(label),
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Label < entries[j].Label })
@@ -83,10 +84,10 @@ func crossRepoEdgeCount(store *facts.Store) int {
 // assembleGraphReceipt builds a GraphReceipt describing the current graph state.
 // Membership timestamps (AddedAt/CommitChangedAt) are set to their first-write
 // defaults here; WriteGlobalReceipt merges forward from any prior receipt.
-func (e *Engine) assembleGraphReceipt(now time.Time) facts.GraphReceipt {
+func (e *Engine) assembleGraphReceipt(b *snapshotBundle, now time.Time) facts.GraphReceipt {
 	nowStr := now.UTC().Format(time.RFC3339)
 
-	entries := e.repoEntries()
+	entries := e.repoEntries(b)
 	for i := range entries {
 		entries[i].AddedAt = nowStr
 		entries[i].InGraphFor = "0s"
@@ -95,15 +96,15 @@ func (e *Engine) assembleGraphReceipt(now time.Time) facts.GraphReceipt {
 	gr := facts.GraphReceipt{
 		GeneratedAt:        nowStr,
 		EnolaVersion:       version.Version,
-		ServiceCount:       len(e.store.ByKind(facts.KindService)),
-		CrossRepoEdgeCount: crossRepoEdgeCount(e.store),
-		Coverage:           coverageSummary(e.store),
+		ServiceCount:       len(b.store.ByKind(facts.KindService)),
+		CrossRepoEdgeCount: crossRepoEdgeCount(b.store),
+		Coverage:           coverageSummary(b.store),
 		Repos:              entries,
 	}
-	if e.snapshot != nil {
-		gr.SnapshotID = e.snapshot.Meta.SnapshotID
-		gr.FactCount = e.snapshot.Meta.FactCount
-		gr.InsightCount = e.snapshot.Meta.InsightCount
+	if b.snapshot != nil {
+		gr.SnapshotID = b.snapshot.Meta.SnapshotID
+		gr.FactCount = b.snapshot.Meta.FactCount
+		gr.InsightCount = b.snapshot.Meta.InsightCount
 	}
 	return gr
 }
@@ -114,7 +115,10 @@ func (e *Engine) assembleGraphReceipt(now time.Time) facts.GraphReceipt {
 // then atomically replaces the file. It never aborts a snapshot: a missing home dir
 // is logged and skipped, and a corrupt prior receipt is treated as no prior state.
 func (e *Engine) WriteGlobalReceipt() error {
-	if e.snapshot == nil {
+	// Load the published bundle once; everything below reads from it, so the receipt
+	// reflects a single consistent snapshot even if a generate republishes meanwhile.
+	b := e.current.Load()
+	if b.snapshot == nil {
 		return fmt.Errorf("no snapshot generated")
 	}
 
@@ -128,7 +132,7 @@ func (e *Engine) WriteGlobalReceipt() error {
 	}
 
 	now := time.Now().UTC()
-	gr := e.assembleGraphReceipt(now)
+	gr := e.assembleGraphReceipt(b, now)
 
 	// Merge forward membership timestamps from the prior receipt, if any. Repos
 	// present in the prior receipt but absent now are simply omitted: the receipt

--- a/internal/engine/global_receipt_test.go
+++ b/internal/engine/global_receipt_test.go
@@ -156,9 +156,9 @@ func TestWriteGlobalReceipt_SingleRepoFallbackAndPersistence(t *testing.T) {
 		facts.Fact{Kind: facts.KindModule, Name: "m1", Repo: "myrepo"},
 		facts.Fact{Kind: facts.KindSymbol, Name: "s1", Repo: "myrepo"},
 	)
-	eng.snapshot = &facts.Snapshot{Meta: facts.SnapshotMeta{
+	eng.SetSnapshot(&facts.Snapshot{Meta: facts.SnapshotMeta{
 		RepoPath: filepath.Join("/tmp", "some", "myrepo"), SnapshotID: "sha256:abc", FactCount: 2, InsightCount: 0,
-	}}
+	}})
 
 	if err := eng.WriteGlobalReceipt(); err != nil {
 		t.Fatalf("WriteGlobalReceipt: %v", err)
@@ -181,7 +181,7 @@ func TestWriteGlobalReceipt_SingleRepoFallbackAndPersistence(t *testing.T) {
 	firstAdded := first.Repos[0].AddedAt
 
 	// Regenerate and rewrite: added_at must be preserved (repo did not re-enter).
-	eng.snapshot.Meta.SnapshotID = "sha256:def"
+	eng.Snapshot().Meta.SnapshotID = "sha256:def"
 	if err := eng.WriteGlobalReceipt(); err != nil {
 		t.Fatalf("WriteGlobalReceipt (2nd): %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/enola-labs/enola/internal/config"
@@ -20,18 +22,34 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// toolCallbackFunc is invoked once per tool call with the tool name and the repo
+// the call operated on. Stored behind an atomic.Pointer so SetToolCallback and the
+// per-call fireToolCallback are race-free regardless of call ordering.
+type toolCallbackFunc func(tool, repo string)
+
 // Server wraps the MCP server and connects it to the snapshot engine.
 type Server struct {
-	mcp          *mcp.Server
-	eng          *engine.Engine
-	cfg          *config.Config
-	startTime    time.Time
-	toolCallback func(tool, repo string)
+	mcp       *mcp.Server
+	eng       *engine.Engine
+	cfg       *config.Config
+	startTime time.Time
+
+	// toolCallback is read on every tool-call goroutine via fireToolCallback and
+	// written by SetToolCallback; the atomic pointer makes that race-free.
+	toolCallback atomic.Pointer[toolCallbackFunc]
+
+	// genMu serializes the entire generate_snapshot handler (the auto-append
+	// heuristic's reads of the current snapshot, GenerateSnapshot, the
+	// snapshotsGenerated flag, and the artifact/receipt writes). Two generates can
+	// no longer interleave and corrupt session state. Read-only tools never take
+	// genMu, so they stay concurrent and lock-free against the published bundle.
+	genMu sync.Mutex
 
 	// snapshotsGenerated records whether generate_snapshot has run at least once
 	// in this session. It distinguishes a user-driven multi-repo session from a
 	// store that was merely pre-populated by AutoLoadSnapshot at startup, so the
-	// auto-append heuristic never fires on top of auto-loaded-only state.
+	// auto-append heuristic never fires on top of auto-loaded-only state. Guarded
+	// by genMu (only read/written inside the locked generate_snapshot handler).
 	snapshotsGenerated bool
 }
 
@@ -67,13 +85,15 @@ func (s *Server) Run(ctx context.Context) error {
 // operated on (the active snapshot's repo, or the target repo for
 // generate_snapshot). It is safe to call before Run().
 func (s *Server) SetToolCallback(cb func(tool, repo string)) {
-	s.toolCallback = cb
+	fn := toolCallbackFunc(cb)
+	s.toolCallback.Store(&fn)
 }
 
-// fireToolCallback invokes the tool callback if set.
+// fireToolCallback invokes the tool callback if set. Safe to call concurrently
+// from multiple tool-call goroutines.
 func (s *Server) fireToolCallback(tool, repo string) {
-	if s.toolCallback != nil {
-		s.toolCallback(tool, repo)
+	if cbp := s.toolCallback.Load(); cbp != nil {
+		(*cbp)(tool, repo)
 	}
 }
 
@@ -484,6 +504,14 @@ func (s *Server) registerTools() {
 		if args.Fresh && args.Append {
 			return errorResult("fresh and append are mutually exclusive: fresh forces a single-repo reset; append adds to the existing store. Pick one."), nil, nil
 		}
+
+		// Serialize the whole write side against any other generate_snapshot: the
+		// auto-append heuristic reads the current snapshot/store, then GenerateSnapshot
+		// rebuilds and publishes, then snapshotsGenerated/WriteArtifacts/WriteGlobalReceipt
+		// run — all of which must be atomic w.r.t. a second concurrent generate. Held
+		// for the rest of the handler. Read-only tools do not take genMu.
+		s.genMu.Lock()
+		defer s.genMu.Unlock()
 
 		// Auto-enable append mode when switching to a different repo while facts
 		// from another repo are already loaded — but only once this session has

--- a/internal/server/server_race_test.go
+++ b/internal/server/server_race_test.go
@@ -1,0 +1,136 @@
+package server_test
+
+// Concurrency stress test driving the real MCP server over the in-memory transport,
+// through the same jsonrpc2.Async dispatch production uses (tool calls run on their
+// own goroutines, unserialized). It fires overlapping generate_snapshot calls
+// interleaved with read-only tools and, to mirror the enterprise wrapper, a
+// long-running read tool registered against the same *mcp.Server. Must be race-clean
+// under `go test -race`.
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/enola-labs/enola/internal/facts"
+	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestServerConcurrentToolCalls(t *testing.T) {
+	ctx := context.Background()
+	eng, cfg := newTestEngine(t)
+
+	srv, err := bootstrap.NewServer(eng, cfg)
+	if err != nil {
+		t.Fatalf("bootstrap.NewServer: %v", err)
+	}
+
+	// Mirror the enterprise wrapper: register an extra long-running read-only tool
+	// against the SAME server + engine, so a heavy reader overlaps generate_snapshot
+	// exactly as find_orphans/analyze_performance do in enola-enterprise.
+	mcp.AddTool(srv.MCP(), &mcp.Tool{
+		Name:        "heavy_scan",
+		Description: "test-only long read over the shared store",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
+		st := eng.Store()
+		_ = st.Count()
+		_ = st.ByKind(facts.KindSymbol)
+		if snap := eng.Snapshot(); snap != nil {
+			n := 0
+			for range snap.Facts {
+				n++
+			}
+			if snap.Meta.FactCount != n {
+				return &mcp.CallToolResult{IsError: true}, nil, nil
+			}
+		}
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	// Wire the server to an in-memory transport and connect a client, driving tool
+	// calls through the real jsonrpc2.Async dispatch.
+	serverT, clientT := mcp.NewInMemoryTransports()
+	if _, err := srv.MCP().Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "enola-race-test", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	repoA := copyTree(t, filepath.Join("..", "engine", "testdata", "repos", "go_sample"), t.TempDir())
+	repoB := copyTree(t, filepath.Join("..", "engine", "testdata", "repos", "python_sample"), t.TempDir())
+
+	// Seed a snapshot so readers have data immediately.
+	if _, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "generate_snapshot", Arguments: map[string]any{"repo_path": repoA, "fresh": true},
+	}); err != nil {
+		t.Fatalf("seed generate_snapshot: %v", err)
+	}
+
+	const duration = 2 * time.Second
+	deadline := time.Now().Add(duration)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 64)
+	report := func(err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case errCh <- err:
+		default:
+		}
+	}
+
+	callLoop := func(name string, args func(i int) map[string]any) {
+		defer wg.Done()
+		for i := 0; time.Now().Before(deadline); i++ {
+			_, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: name, Arguments: args(i)})
+			if err != nil {
+				report(err)
+				return
+			}
+		}
+	}
+
+	// Writers: overlapping generate_snapshot, alternating fresh-A and append-B.
+	for w := 0; w < 2; w++ {
+		wg.Add(1)
+		go callLoop("generate_snapshot", func(i int) map[string]any {
+			if i%2 == 0 {
+				return map[string]any{"repo_path": repoA, "fresh": true}
+			}
+			return map[string]any{"repo_path": repoB, "append": true}
+		})
+	}
+
+	// Readers: OSS read tools + the enterprise-style heavy_scan, all against the
+	// shared store while generates churn it.
+	readers := []struct {
+		name string
+		args func(i int) map[string]any
+	}{
+		{"query_facts", func(i int) map[string]any { return map[string]any{"kind": "symbol"} }},
+		{"coverage_report", func(i int) map[string]any { return map[string]any{} }},
+		{"query_insights", func(i int) map[string]any { return map[string]any{} }},
+		{"heavy_scan", func(i int) map[string]any { return map[string]any{} }},
+	}
+	for _, r := range readers {
+		for c := 0; c < 3; c++ {
+			wg.Add(1)
+			go callLoop(r.name, r.args)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("tool call transport error: %v", err)
+	}
+}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -244,6 +244,11 @@ func NewServer(eng *Engine, cfg *config.Config) (*Server, error) {
 
 // AutoLoadSnapshot loads an existing snapshot from disk if available.
 // This allows queries to work immediately without a generate_snapshot call.
+//
+// It mutates the engine's initially-published (empty) store in place and then
+// republishes it via SetSnapshot. This is safe ONLY because it runs single-threaded
+// at startup, before the MCP server begins serving tool calls — no reader can
+// observe the store mid-load. Callers must keep it strictly before Server.Run.
 func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
 	repoPath, err := filepath.Abs(cfg.Repo)
 	if err != nil {


### PR DESCRIPTION
Tool handlers are dispatched on their own goroutines and are not serialized, so multiple handlers run against the one shared engine at once. GenerateSnapshot mutated the fact store in place (Clear -> Add -> BuildGraph) while readers took no lock, racing the snapshot pointer and repoPaths map; snapshot.Facts also aliases the store's live slice, so a reader could iterate an array being reallocated mid-regeneration.

Publish the snapshot state as an immutable bundle {store, snapshot, repoPaths} behind an atomic.Pointer. GenerateSnapshot now builds a brand-new store off to the side and swaps the pointer once at the end (the single linearization point); read accessors load the bundle lock-free. A published store is never mutated again, so the Facts alias stays valid for in-flight readers. Append mode seeds the new store from a copy of the previous one. WriteArtifacts/GetArtifact/global_receipt read one loaded bundle; WriteArtifacts republishes a copy carrying OutputHashes via CAS instead of mutating the shared snapshot.

Serialize the generate handler with a mutex and make the tool callback atomic to close the remaining unsynchronized session fields.

Add -race stress tests covering overlapping generates against lock-free readers at both the engine and server (in-memory transport) layers.