### PR TITLE
fix(explainers): exclude RelInstantiates from god-class and hotspot f…

### DIFF
--- a/internal/explainers/godclass/godclass.go
+++ b/internal/explainers/godclass/godclass.go
@@ -101,8 +101,8 @@ func (e *GodClassExplainer) Explain(ctx context.Context, store *facts.Store) ([]
 		}
 		// A test-support symbol is supposed to have high fan-in: an XCTest assertion
 		// helper called by every test case is doing its job, not concentrating change
-		// risk. ArchitecturalReverse above only drops reference-only KINDS, which
-		// covers the languages whose test files are config-ignored and re-enter as
+		// risk. ArchitecturalReverse above drops reference-only KINDS (and
+		// RelInstantiates edges), which covers the languages whose test files are config-ignored and re-enter as
 		// test_ref nodes (Ruby/Go/TS). Where test files are indexed as ordinary
 		// symbols — Swift, Kotlin/Java, Python, C/C++ — they arrive here as plain
 		// symbol facts, so they need a path gate as well (GAP-XL-15, the half

--- a/internal/explainers/godclass/godclass_test.go
+++ b/internal/explainers/godclass/godclass_test.go
@@ -431,3 +431,35 @@ func TestExplain_ProductionABTestNotExcluded(t *testing.T) {
 		t.Errorf("production A/B-test feature was wrongly gated out as test code")
 	}
 }
+
+// A ubiquitous DATA struct constructed at many sites (RelInstantiates fan-in
+// only) is not a god class — those edges must be excluded from fan-in.
+func TestExplain_ExcludesInstantiateFanIn(t *testing.T) {
+	s := facts.NewStore()
+	const hub = "facts.Fact"
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: hub, File: "facts/fact.go",
+		Props: map[string]any{"symbol_kind": facts.SymbolStruct}})
+	// 12 sources that only CONSTRUCT the struct — must NOT count as fan-in.
+	for i := 0; i < 12; i++ {
+		s.Add(facts.Fact{
+			Kind: facts.KindSymbol, Name: fmt.Sprintf("pkg/c%d.build", i),
+			File:      fmt.Sprintf("pkg/c%d.go", i),
+			Relations: []facts.Relation{{Kind: facts.RelInstantiates, Target: hub}},
+		})
+	}
+	// Low-fan-in noise so the outlier threshold is meaningful.
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "leaf.A", File: "leaf/a.go"})
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "leaf.B", File: "leaf/b.go"})
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "leaf.C", File: "leaf/c.go"})
+	s.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	for _, ins := range insights {
+		if strings.Contains(ins.Title, hub) {
+			t.Errorf("data struct with only instantiate fan-in must not be a god-class; got %q", ins.Title)
+		}
+	}
+}

--- a/internal/explainers/hotspots/hotspots.go
+++ b/internal/explainers/hotspots/hotspots.go
@@ -100,7 +100,7 @@ func (e *HotspotExplainer) Explain(ctx context.Context, store *facts.Store) ([]f
 		}
 		// Test-support code is not production architecture. See the god-class
 		// explainer for the full rationale: ArchitecturalReverse drops reference-only
-		// KINDS, but a Swift/Kotlin/Python test file is indexed as an ordinary symbol
+		// KINDS (and RelInstantiates edges), but a Swift/Kotlin/Python test file is indexed as an ordinary symbol
 		// fact, so it needs a path gate too (GAP-XL-15). Candidate-only: the score and
 		// the outlier distribution stay whole.
 		if facts.IsTestPath(s.File) {

--- a/internal/explainers/hotspots/hotspots_test.go
+++ b/internal/explainers/hotspots/hotspots_test.go
@@ -361,3 +361,34 @@ func TestExplain_TestSupportSymbolExcluded(t *testing.T) {
 		t.Errorf("production hotspot should still be reported")
 	}
 }
+
+// A ubiquitous DATA struct constructed at many sites (RelInstantiates fan-in
+// only, no calls) is not a call-graph hotspot — instantiate edges are excluded
+// from fan-in, so its score drops below threshold.
+func TestExplain_ExcludesInstantiateFanIn(t *testing.T) {
+	s := facts.NewStore()
+	const hub = "facts.Fact"
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: hub, File: "facts/fact.go",
+		Props: map[string]any{"symbol_kind": facts.SymbolStruct}})
+	for i := 0; i < 12; i++ {
+		s.Add(facts.Fact{
+			Kind: facts.KindSymbol, Name: fmt.Sprintf("pkg/c%d.build", i),
+			File:      fmt.Sprintf("pkg/c%d.go", i),
+			Relations: []facts.Relation{{Kind: facts.RelInstantiates, Target: hub}},
+		})
+	}
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "leaf.A", File: "leaf/a.go"})
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "leaf.B", File: "leaf/b.go"})
+	s.Add(facts.Fact{Kind: facts.KindSymbol, Name: "leaf.C", File: "leaf/c.go"})
+	s.BuildGraph()
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	for _, ins := range insights {
+		if strings.Contains(ins.Title, hub) {
+			t.Errorf("data struct with only instantiate fan-in must not be a hotspot; got %q", ins.Title)
+		}
+	}
+}

--- a/internal/facts/graph.go
+++ b/internal/facts/graph.go
@@ -731,13 +731,14 @@ func isReferenceOnlyKind(kind string) bool {
 	return kind == KindTestRef || kind == KindFileRef || kind == KindRoute
 }
 
-// ArchitecturalReverse returns a reverse adjacency map restricted to edges whose
-// SOURCE fact is part of the architectural coupling graph — i.e. excluding
-// reference-only kinds (test_ref/file_ref). The outlier explainers (god-class,
-// hotspots) use this instead of Reverse() so their fan-in/centrality and the
-// distribution they threshold over count only real symbol coupling. orphans,
-// impact_analysis, traverse and find_path keep using the unfiltered Reverse()
-// index — they intentionally surface those references. (GAP-XL-15)
+// ArchitecturalReverse returns a reverse adjacency map restricted to edges that
+// represent architectural coupling — excluding reference-only SOURCE kinds
+// (test_ref/file_ref/route) and RelInstantiates edges (struct construction /
+// field-type usage). The outlier explainers (god-class, hotspots) use this
+// instead of Reverse() so their fan-in/centrality and the distribution they
+// threshold over count only real symbol coupling. orphans, impact_analysis,
+// traverse and find_path keep using the unfiltered Reverse() index — they
+// intentionally surface those references. (GAP-XL-15)
 func (g *Graph) ArchitecturalReverse() map[string][]Edge {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -745,6 +746,14 @@ func (g *Graph) ArchitecturalReverse() map[string][]Edge {
 	for target, edges := range g.reverse {
 		kept := make([]Edge, 0, len(edges))
 		for _, e := range edges {
+			// RelInstantiates keeps ubiquitous DATA structs out of the dead-code
+			// report, but it is not change-risk coupling: a data struct built at many
+			// sites is not a god class or a call-graph hotspot. Exclude it from fan-in
+			// / centrality (and the outlier distribution). Traversal, impact_analysis,
+			// find_path and orphans read the raw Reverse() index and still see it.
+			if e.RelKind == RelInstantiates {
+				continue
+			}
 			// In a reverse edge, e.Target holds the SOURCE fact name.
 			if idx, ok := g.factIdx[e.Target]; ok && idx < len(g.facts) &&
 				isReferenceOnlyKind(g.facts[idx].Kind) {

--- a/internal/facts/graph_test.go
+++ b/internal/facts/graph_test.go
@@ -1024,3 +1024,45 @@ func TestArchitecturalReverse_ExcludesRouteSources(t *testing.T) {
 		t.Error("Reverse() lost the handled_by edge — impact_analysis and perf depend on it")
 	}
 }
+
+// ArchitecturalReverse must drop RelInstantiates edges (a data struct built at
+// many sites is not architectural coupling), while Reverse keeps them and
+// Forward keeps the constructing side — so traversal/impact/orphans are
+// unaffected and the god-class/hotspots fan-in is corrected.
+func TestArchitecturalReverse_ExcludesInstantiate(t *testing.T) {
+	s := NewStore()
+	s.Add(Fact{Kind: KindSymbol, Name: "pkg.Data", File: "pkg/data.go"})
+	s.Add(Fact{Kind: KindSymbol, Name: "pkg.build", File: "pkg/build.go",
+		Relations: []Relation{{Kind: RelInstantiates, Target: "pkg.Data"}}})
+	s.Add(Fact{Kind: KindSymbol, Name: "pkg.call", File: "pkg/call.go",
+		Relations: []Relation{{Kind: RelCalls, Target: "pkg.Data"}}})
+	s.BuildGraph()
+	g := s.Graph()
+
+	countSrc := func(m map[string][]Edge, target, src string) bool {
+		for _, e := range m[target] {
+			if e.Target == src {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Raw Reverse keeps both the instantiate and the call source.
+	rev := g.Reverse()
+	if !countSrc(rev, "pkg.Data", "pkg.build") || !countSrc(rev, "pkg.Data", "pkg.call") {
+		t.Errorf("Reverse should keep both instantiate and call sources; got %v", rev["pkg.Data"])
+	}
+	// ArchitecturalReverse drops the instantiate source, keeps the call source.
+	arch := g.ArchitecturalReverse()
+	if countSrc(arch, "pkg.Data", "pkg.build") {
+		t.Errorf("ArchitecturalReverse must exclude the RelInstantiates source; got %v", arch["pkg.Data"])
+	}
+	if !countSrc(arch, "pkg.Data", "pkg.call") {
+		t.Errorf("ArchitecturalReverse must keep the RelCalls source; got %v", arch["pkg.Data"])
+	}
+	// Forward keeps the constructing side (fan-out is unaffected).
+	if !countSrc(g.Forward(), "pkg.build", "pkg.Data") {
+		t.Errorf("Forward must keep the instantiate edge; got %v", g.Forward()["pkg.build"])
+	}
+}


### PR DESCRIPTION
…an-in

Struct-construction / field-type usage edges (RelInstantiates) keep ubiquitous data structs out of the dead-code report, but they are not change-risk coupling: a data struct built at many sites is not a god class or a call-graph hotspot. After those edges were added, ubiquitous data types surfaced as false-positive high-fan-in findings.

Filter RelInstantiates out of Graph.ArchitecturalReverse — the shared fan-in helper used only by the god-class and hotspots explainers, which already drops reference-only source kinds. Traversal, impact_analysis, find_path and the dead-code detector read the raw Reverse() index and still see instantiate edges; hotspot fan-out (Forward()) is unchanged, so the constructing side is unaffected. Explainer-only change: no new facts, no cacheVersion bump, no golden regen.