### PR TITLE
feat(engine): restore full graph on restart; warn on stale snapshots

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -135,6 +135,61 @@ func (e *Engine) SetSnapshot(snap *facts.Snapshot) {
 	e.current.Store(&snapshotBundle{store: b.store, snapshot: snap, repoPaths: b.repoPaths})
 }
 
+// RestoreFromDir rebuilds and publishes the snapshot bundle from a persisted
+// snapshot directory (facts.jsonl plus, when present, insights.json and
+// snapshot.meta.json) WITHOUT re-running any extractor. It is the restart-restore
+// counterpart to GenerateSnapshot: it reads facts into a brand-new store off to the
+// side, builds the graph, then publishes a fresh bundle in one atomic swap — so no
+// reader can ever observe a half-built store.
+//
+// repoPaths is the graph's label -> absolute-path map (one entry for a single-repo
+// graph). When singleRepoLabel is non-empty, any untagged facts are labeled with it
+// (a single-repo facts.jsonl carries no repo label); a multi-repo facts.jsonl is
+// already tagged, so pass an empty singleRepoLabel to preserve the baked-in labels.
+//
+// Missing insights/meta are tolerated (a partial restore still serves facts); a
+// missing facts.jsonl is an error. It MUST run single-threaded at startup, before
+// Server.Run begins serving — like SetSnapshot, it publishes a new bundle.
+func (e *Engine) RestoreFromDir(dir string, repoPaths map[string]string, singleRepoLabel string) error {
+	factsPath := filepath.Join(dir, "facts.jsonl")
+	if _, err := os.Stat(factsPath); err != nil {
+		return fmt.Errorf("no snapshot at %s: %w", dir, err)
+	}
+
+	work := facts.NewStore()
+	if err := work.ReadJSONLFile(factsPath); err != nil {
+		return fmt.Errorf("reading facts from %s: %w", factsPath, err)
+	}
+	if singleRepoLabel != "" {
+		// Tags only facts whose Repo is empty, so a pre-tagged file is left intact.
+		work.SetRepoRange(0, singleRepoLabel)
+	}
+	work.BuildGraph()
+
+	// Default the primary repo path from the dir; snapshot.meta.json (loaded below)
+	// overrides it when present.
+	snap := &facts.Snapshot{Meta: facts.SnapshotMeta{RepoPath: filepath.Dir(dir)}}
+	if data, err := os.ReadFile(filepath.Join(dir, "insights.json")); err == nil {
+		var ins []facts.Insight
+		if err := json.Unmarshal(data, &ins); err == nil {
+			snap.Insights = ins
+		}
+	}
+	if data, err := os.ReadFile(filepath.Join(dir, "snapshot.meta.json")); err == nil {
+		var meta facts.SnapshotMeta
+		if err := json.Unmarshal(data, &meta); err == nil {
+			snap.Meta = meta
+		}
+	}
+	// FactsRef aliases the store's slice (never copied): `work` is published here and
+	// then never mutated again, so a reader iterating snap.Facts sees a frozen array.
+	snap.Facts = work.FactsRef()
+
+	e.current.Store(&snapshotBundle{store: work, snapshot: snap, repoPaths: repoPaths})
+	log.Printf("[engine] restored %d facts, %d insights from %s", work.Count(), len(snap.Insights), dir)
+	return nil
+}
+
 // RepoPaths returns a copy of the repo label -> absolute path mapping (populated in
 // append mode). Lock-free bundle load; the copy lets callers retain it safely.
 func (e *Engine) RepoPaths() map[string]string {

--- a/internal/engine/freshness.go
+++ b/internal/engine/freshness.go
@@ -1,0 +1,92 @@
+package engine
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// RepoChange reports that a repository's code has moved since its snapshot was
+// taken, and why.
+type RepoChange struct {
+	Label  string
+	Reason string // e.g. "commit moved", "uncommitted changes"
+}
+
+// Staleness summarizes whether the loaded graph is out of date. It is ADVISORY
+// only — used to surface a warning banner. Nothing here regenerates a snapshot.
+type Staleness struct {
+	GeneratedAt time.Time     // when the graph was generated (zero if unknown)
+	Age         time.Duration // now - GeneratedAt (zero if GeneratedAt unknown)
+	TooOld      bool          // Age exceeded the checked maxAge
+	Changed     []RepoChange  // repos whose git state moved since the snapshot
+}
+
+// Stale reports whether any staleness signal fired.
+func (s Staleness) Stale() bool { return s.TooOld || len(s.Changed) > 0 }
+
+// Staleness judges the freshness of the loaded graph against maxAge and each repo's
+// CURRENT VCS state, without regenerating anything. A repo counts as changed when
+// its git HEAD has moved since the snapshot, or its working tree is NEWLY dirty
+// (a tree that was already dirty at snapshot time is ignored — that state was
+// captured by the extractors). Age is measured from the graph-wide generated_at in
+// ~/.enola/receipt.json, falling back to the in-memory snapshot meta for a
+// single-repo graph. Repos without git contribute only to the age signal.
+func (e *Engine) Staleness(maxAge time.Duration, now time.Time) Staleness {
+	var st Staleness
+
+	gr, err := LoadGlobalReceipt()
+	if err == nil && gr.GeneratedAt != "" {
+		if t, perr := time.Parse(time.RFC3339, gr.GeneratedAt); perr == nil {
+			st.GeneratedAt = t
+		}
+	}
+	if st.GeneratedAt.IsZero() {
+		// No (or unparseable) global receipt: use the loaded snapshot's own time.
+		if snap := e.Snapshot(); snap != nil && snap.Meta.GeneratedAt != "" {
+			if t, perr := time.Parse(time.RFC3339, snap.Meta.GeneratedAt); perr == nil {
+				st.GeneratedAt = t
+			}
+		}
+	}
+	if !st.GeneratedAt.IsZero() {
+		st.Age = now.Sub(st.GeneratedAt)
+		st.TooOld = st.Age > maxAge
+	}
+
+	for _, r := range e.stalenessEntries(gr, err) {
+		if r.Path == "" || r.Git == nil {
+			continue // non-git or unknown: covered by the age signal only
+		}
+		cur := gitInfo(r.Path)
+		if cur == nil {
+			continue
+		}
+		switch {
+		case cur.Commit != r.Git.Commit:
+			st.Changed = append(st.Changed, RepoChange{Label: r.Label, Reason: "commit moved"})
+		case !r.Git.Dirty && cur.Dirty:
+			st.Changed = append(st.Changed, RepoChange{Label: r.Label, Reason: "uncommitted changes"})
+		}
+	}
+	return st
+}
+
+// stalenessEntries returns the per-repo entries to check: the global receipt's repo
+// list when available, otherwise a single synthetic entry from the in-memory
+// snapshot meta (single-repo / no global receipt).
+func (e *Engine) stalenessEntries(gr *facts.GraphReceipt, grErr error) []facts.GraphRepoEntry {
+	if grErr == nil && gr != nil && len(gr.Repos) > 0 {
+		return gr.Repos
+	}
+	snap := e.Snapshot()
+	if snap == nil || snap.Meta.RepoPath == "" {
+		return nil
+	}
+	return []facts.GraphRepoEntry{{
+		Label: filepath.Base(snap.Meta.RepoPath),
+		Path:  snap.Meta.RepoPath,
+		Git:   snap.Meta.Git,
+	}}
+}

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -31,6 +31,28 @@ func globalReceiptPath() (string, error) {
 	return filepath.Join(home, globalReceiptDirName, globalReceiptFileName), nil
 }
 
+// LoadGlobalReceipt reads and parses ~/.enola/receipt.json — the graph-wide
+// multi-repo registry describing which repositories currently compose the graph
+// and where they live on disk. It is the counterpart to WriteGlobalReceipt and the
+// source of truth a restart uses to reload the whole graph (not just one repo).
+// Returns an error when the home dir is unavailable, the file is missing, or its
+// contents cannot be parsed, so callers can fall back to a single-repo restore.
+func LoadGlobalReceipt() (*facts.GraphReceipt, error) {
+	path, err := globalReceiptPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading global receipt: %w", err)
+	}
+	var gr facts.GraphReceipt
+	if err := json.Unmarshal(data, &gr); err != nil {
+		return nil, fmt.Errorf("parsing global receipt %s: %w", path, err)
+	}
+	return &gr, nil
+}
+
 // repoEntries returns one GraphRepoEntry per repository currently in the graph.
 // In multi-repo (append) mode it iterates RepoPaths(); in single-repo mode it
 // falls back to the sole primary repo from the snapshot meta. Git state is captured

--- a/internal/engine/restore_test.go
+++ b/internal/engine/restore_test.go
@@ -1,0 +1,159 @@
+package engine_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/engine"
+	"github.com/enola-labs/enola/internal/explainers/cycles"
+	"github.com/enola-labs/enola/internal/extractors/goextractor"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// TestRestoreFromDir verifies a restart-style restore rebuilds the full snapshot
+// from disk WITHOUT re-running extractors: facts, insights, and the generated_at
+// timestamp all come back. This is the regression against the old facts-only load
+// that left Meta with only RepoPath (no generated_at, no insights).
+func TestRestoreFromDir(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "go.mod"), "module testmod\n\ngo 1.21\n")
+	// An import cycle so the cycles explainer emits at least one insight to restore.
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nimport \"testmod/pkg/b\"\n\nfunc A() { b.B() }\n")
+	writeFile(t, filepath.Join(repo, "pkg", "b", "b.go"), "package b\n\nimport \"testmod/pkg/a\"\n\nfunc B() { _ = a.A }\n")
+
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.RegisterExtractor(goextractor.New())
+	eng.RegisterExplainer(cycles.New())
+
+	ctx := context.Background()
+	orig, err := eng.GenerateSnapshot(ctx, repo, false)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if err := eng.WriteArtifacts(repo); err != nil {
+		t.Fatalf("write artifacts: %v", err)
+	}
+	if orig.Meta.FactCount == 0 {
+		t.Fatal("precondition: expected some facts")
+	}
+	if len(orig.Insights) == 0 {
+		t.Fatal("precondition: expected the cycle to produce an insight")
+	}
+
+	// Restore into a BRAND-NEW engine (no extractors registered) — proves nothing
+	// is re-extracted, only read from disk.
+	fresh, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	label := filepath.Base(repo)
+	dir := eng.OutputDir(repo)
+	if err := fresh.RestoreFromDir(dir, map[string]string{label: repo}, label); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if got := fresh.Store().Count(); got != orig.Meta.FactCount {
+		t.Errorf("restored fact count = %d, want %d", got, orig.Meta.FactCount)
+	}
+	snap := fresh.Snapshot()
+	if snap == nil {
+		t.Fatal("restored snapshot is nil")
+	}
+	if snap.Meta.GeneratedAt == "" {
+		t.Error("restored Meta.GeneratedAt is empty (regression: timestamp not restored)")
+	}
+	if snap.Meta.GeneratedAt != orig.Meta.GeneratedAt {
+		t.Errorf("restored generated_at = %q, want %q", snap.Meta.GeneratedAt, orig.Meta.GeneratedAt)
+	}
+	if len(snap.Insights) != len(orig.Insights) {
+		t.Errorf("restored insights = %d, want %d", len(snap.Insights), len(orig.Insights))
+	}
+	if snap.Meta.RepoPath == "" {
+		t.Error("restored Meta.RepoPath is empty")
+	}
+}
+
+// TestStaleness_Age checks the age signal in isolation (no git, no global receipt).
+// HOME is redirected to an empty temp dir so LoadGlobalReceipt misses and Staleness
+// falls back to the in-memory snapshot's generated_at.
+func TestStaleness_Age(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	// Older than 24h -> stale.
+	eng.SetSnapshot(&facts.Snapshot{Meta: facts.SnapshotMeta{
+		GeneratedAt: now.Add(-48 * time.Hour).Format(time.RFC3339),
+	}})
+	if st := eng.Staleness(24*time.Hour, now); !st.TooOld || !st.Stale() {
+		t.Errorf("48h-old snapshot: got TooOld=%v Stale=%v, want both true", st.TooOld, st.Stale())
+	}
+
+	// Within 24h -> fresh.
+	eng.SetSnapshot(&facts.Snapshot{Meta: facts.SnapshotMeta{
+		GeneratedAt: now.Add(-1 * time.Hour).Format(time.RFC3339),
+	}})
+	if st := eng.Staleness(24*time.Hour, now); st.TooOld || st.Stale() {
+		t.Errorf("1h-old snapshot: got TooOld=%v Stale=%v, want both false", st.TooOld, st.Stale())
+	}
+}
+
+// TestStaleness_CommitMoved checks the VCS-drift signal: a fresh-by-age snapshot
+// whose recorded commit no longer matches HEAD is flagged as changed.
+func TestStaleness_CommitMoved(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	repo := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "t")
+	writeFile(t, filepath.Join(repo, "f.txt"), "hello\n")
+	git("add", ".")
+	git("commit", "-m", "init")
+
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	eng.SetSnapshot(&facts.Snapshot{Meta: facts.SnapshotMeta{
+		RepoPath:    repo,
+		GeneratedAt: now.Format(time.RFC3339), // fresh by age
+		Git:         &facts.GitInfo{Commit: "0000000000000000000000000000000000000000"},
+	}})
+
+	st := eng.Staleness(24*time.Hour, now)
+	if st.TooOld {
+		t.Errorf("snapshot is fresh by age, TooOld should be false")
+	}
+	if len(st.Changed) != 1 || st.Changed[0].Reason != "commit moved" {
+		t.Errorf("got Changed=%+v, want one 'commit moved'", st.Changed)
+	}
+	if !st.Stale() {
+		t.Error("commit moved should make Stale() true")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,13 @@ type Server struct {
 	// auto-append heuristic never fires on top of auto-loaded-only state. Guarded
 	// by genMu (only read/written inside the locked generate_snapshot handler).
 	snapshotsGenerated bool
+
+	// Freshness-banner cache. freshnessBanner() shells out to git per repo, so the
+	// result is memoized for freshTTL to keep that cost off the hot path of
+	// back-to-back read tools. Guarded by freshMu.
+	freshMu     sync.Mutex
+	freshBanner string
+	freshAt     time.Time
 }
 
 // New creates a new MCP server wired to the given engine.
@@ -73,6 +80,11 @@ func New(eng *engine.Engine, cfg *config.Config) (*Server, error) {
 
 	s.mcp = mcpServer
 	s.registerTools()
+
+	// Prepend a freshness warning to tool results when the loaded graph looks
+	// stale. Registered once here so it also covers the license-gated enterprise
+	// tools, which register on this same MCP server after New returns.
+	s.mcp.AddReceivingMiddleware(s.freshnessMiddleware)
 
 	return s, nil
 }
@@ -98,6 +110,85 @@ func (s *Server) SetToolCallback(cb func(tool, repo string)) {
 func (s *Server) fireToolCallback(tool, repo string) {
 	if cbp := s.toolCallback.Load(); cbp != nil {
 		(*cbp)(tool, repo)
+	}
+}
+
+// freshTTL bounds how often the freshness banner recomputes. The banner shells out
+// to git per repo, so caching it for a short window keeps that cost off the hot
+// path of back-to-back read tools without letting the warning go badly stale.
+const freshTTL = 30 * time.Second
+
+// bannerSuppressed lists the tools that must NOT get the freshness banner
+// prepended: generate_snapshot (which just refreshed the graph) and set_baseline (a
+// mutation, not a query). Every other tool result is fair game for the nudge.
+func bannerSuppressed(tool string) bool {
+	return tool == "generate_snapshot" || tool == "set_baseline"
+}
+
+// freshnessMiddleware prepends a staleness warning to successful tool-call results
+// when the loaded graph looks out of date (older than 24h, or a repo's code moved
+// since its snapshot). It is warn-only: it never blocks or regenerates. Registered
+// once, it also covers the enterprise tools that share this MCP server.
+func (s *Server) freshnessMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		result, err := next(ctx, method, req)
+		if err != nil || method != "tools/call" {
+			return result, err
+		}
+		params, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+		if !ok || bannerSuppressed(params.Name) {
+			return result, err
+		}
+		ctr, ok := result.(*mcp.CallToolResult)
+		if !ok || ctr == nil || ctr.IsError {
+			return result, err
+		}
+		banner := s.freshnessBanner()
+		if banner == "" {
+			return result, err
+		}
+		ctr.Content = append([]mcp.Content{&mcp.TextContent{Text: banner + "\n\n"}}, ctr.Content...)
+		return result, err
+	}
+}
+
+// freshnessBanner returns a one-line staleness warning for the loaded graph, or ""
+// when it is fresh. Results are memoized for freshTTL because the underlying check
+// shells out to git per repo.
+func (s *Server) freshnessBanner() string {
+	s.freshMu.Lock()
+	defer s.freshMu.Unlock()
+	if !s.freshAt.IsZero() && time.Since(s.freshAt) < freshTTL {
+		return s.freshBanner
+	}
+
+	st := s.eng.Staleness(24*time.Hour, time.Now())
+	banner := ""
+	if st.Stale() {
+		var parts []string
+		if st.TooOld {
+			parts = append(parts, fmt.Sprintf("graph is %s old", humanizeDuration(st.Age)))
+		}
+		for _, c := range st.Changed {
+			parts = append(parts, fmt.Sprintf("%s (%s)", c.Label, c.Reason))
+		}
+		banner = "⚠️ Snapshot may be stale: " + strings.Join(parts, "; ") + ". Run generate_snapshot to refresh."
+	}
+
+	s.freshBanner = banner
+	s.freshAt = time.Now()
+	return banner
+}
+
+// humanizeDuration renders a coarse, human-friendly age (minutes/hours/days).
+func humanizeDuration(d time.Duration) string {
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
 	}
 }
 

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -68,6 +69,11 @@ func (e *Engine) ActiveRepo() string {
 // SetSnapshot sets the snapshot (used when auto-loading from disk).
 func (e *Engine) SetSnapshot(snap *facts.Snapshot) {
 	e.eng.SetSnapshot(snap)
+}
+
+// RestoreFromDir restores a persisted snapshot into the engine (see engine.RestoreFromDir).
+func (e *Engine) RestoreFromDir(dir string, repoPaths map[string]string, singleRepoLabel string) error {
+	return e.eng.RestoreFromDir(dir, repoPaths, singleRepoLabel)
 }
 
 // SetPersistCache controls whether the per-extractor cache is written to disk.
@@ -242,35 +248,130 @@ func NewServer(eng *Engine, cfg *config.Config) (*Server, error) {
 	return &Server{srv: srv}, nil
 }
 
-// AutoLoadSnapshot loads an existing snapshot from disk if available.
-// This allows queries to work immediately without a generate_snapshot call.
+// AutoLoadSnapshot restores an existing snapshot from disk if available, so queries
+// (and the enterprise tools) work immediately after a restart WITHOUT a
+// generate_snapshot call.
 //
-// It mutates the engine's initially-published (empty) store in place and then
-// republishes it via SetSnapshot. This is safe ONLY because it runs single-threaded
-// at startup, before the MCP server begins serving tool calls — no reader can
-// observe the store mid-load. Callers must keep it strictly before Server.Run.
+// It prefers the graph-wide registry at ~/.enola/receipt.json: that lists every
+// repo currently in the graph and their paths, so a restart restores the WHOLE
+// multi-repo graph — not just cfg.Repo — with no extractor runs. If that is
+// unavailable it falls back to a single-repo restore of cfg.Repo. Either way it
+// restores facts + insights + the snapshot meta (incl. generated_at, which the
+// freshness check needs), unlike the old facts-only load.
+//
+// It publishes a fresh bundle via engine.RestoreFromDir. This is safe ONLY because
+// it runs single-threaded at startup, before the MCP server begins serving tool
+// calls — no reader can observe a half-built store. Callers must keep it strictly
+// before Server.Run.
 func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
+	// Preferred path: reload the full multi-repo graph from the global registry.
+	if gr, err := engine.LoadGlobalReceipt(); err == nil && len(gr.Repos) > 0 {
+		if restoreFromGlobalReceipt(eng, cfg, gr) {
+			return
+		}
+		log.Printf("[bootstrap] global receipt present but multi-repo restore incomplete; falling back to single-repo")
+	}
+
+	// Fallback: single-repo restore of cfg.Repo.
 	repoPath, err := filepath.Abs(cfg.Repo)
 	if err != nil {
 		return
 	}
-
-	factsPath := filepath.Join(repoPath, cfg.Output.Dir, "facts.jsonl")
-	if _, err := os.Stat(factsPath); err != nil {
+	dir := filepath.Join(repoPath, cfg.Output.Dir)
+	if _, err := os.Stat(filepath.Join(dir, "facts.jsonl")); err != nil {
+		return // nothing on disk; start empty
+	}
+	label := filepath.Base(repoPath)
+	if err := eng.RestoreFromDir(dir, map[string]string{label: repoPath}, label); err != nil {
+		log.Printf("[bootstrap] warning: failed to restore snapshot from %s: %v", dir, err)
 		return
 	}
+	log.Printf("[bootstrap] restored single-repo snapshot for %s", label)
+}
 
-	log.Printf("[bootstrap] loading existing snapshot from %s", factsPath)
-	if err := eng.Store().ReadJSONLFile(factsPath); err != nil {
-		log.Printf("[bootstrap] warning: failed to load existing facts: %v", err)
-		return
+// restoreFromGlobalReceipt reloads the complete multi-repo graph named by the
+// global receipt. In append/multi-repo mode WriteArtifacts writes the ENTIRE
+// in-memory store to each repo's .enola, so the most-recently-generated repo dir
+// holds every repo's facts; that dir is loaded once (facts are already tagged with
+// their repo labels). Returns false if it cannot find a complete snapshot dir, so
+// the caller can fall back. repoPaths comes from the receipt so multi-repo file
+// resolution works after restore.
+func restoreFromGlobalReceipt(eng *Engine, cfg *config.Config, gr *facts.GraphReceipt) bool {
+	repoPaths := make(map[string]string, len(gr.Repos))
+	for _, r := range gr.Repos {
+		if r.Path != "" {
+			repoPaths[r.Label] = r.Path
+		}
+	}
+	if len(repoPaths) == 0 {
+		return false
 	}
 
-	repoLabel := filepath.Base(repoPath)
-	eng.Store().SetRepoRange(0, repoLabel)
-	eng.Store().BuildGraph()
-	eng.SetSnapshot(&facts.Snapshot{
-		Meta: facts.SnapshotMeta{RepoPath: repoPath},
-	})
-	log.Printf("[bootstrap] loaded %d facts from existing snapshot", eng.Store().Count())
+	completeDir, ok := newestSnapshotDir(gr.Repos, cfg.Output.Dir)
+	if !ok {
+		return false
+	}
+
+	// Single-repo graph: the file may be untagged, so pass its label; a genuine
+	// multi-repo file is already tagged and SetRepoRange leaves it untouched.
+	singleLabel := ""
+	if len(repoPaths) == 1 {
+		for l := range repoPaths {
+			singleLabel = l
+		}
+	}
+
+	if err := eng.RestoreFromDir(completeDir, repoPaths, singleLabel); err != nil {
+		log.Printf("[bootstrap] warning: multi-repo restore from %s failed: %v", completeDir, err)
+		return false
+	}
+	if got := eng.Store().Count(); gr.FactCount > 0 && got != gr.FactCount {
+		log.Printf("[bootstrap] note: restored %d facts but global receipt records %d (partial restore from %s)", got, gr.FactCount, completeDir)
+	}
+	log.Printf("[bootstrap] restored graph of %d repo(s) from %s", len(repoPaths), completeDir)
+	return true
+}
+
+// newestSnapshotDir picks the repo snapshot directory with the newest generated_at
+// among the graph's repos — the one whose facts.jsonl holds the complete store.
+// Returns false when no repo dir has a readable snapshot timestamp.
+func newestSnapshotDir(repos []facts.GraphRepoEntry, outDir string) (string, bool) {
+	var bestDir string
+	var bestTS time.Time
+	found := false
+	for _, r := range repos {
+		if r.Path == "" {
+			continue
+		}
+		dir := filepath.Join(r.Path, outDir)
+		ts, ok := snapshotGeneratedAt(dir)
+		if !ok {
+			continue
+		}
+		if !found || ts.After(bestTS) {
+			bestTS, bestDir, found = ts, dir, true
+		}
+	}
+	return bestDir, found
+}
+
+// snapshotGeneratedAt reads the generated_at timestamp from a snapshot dir,
+// preferring snapshot.meta.json and falling back to receipt.json.
+func snapshotGeneratedAt(dir string) (time.Time, bool) {
+	for _, name := range []string{"snapshot.meta.json", "receipt.json"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		var m struct {
+			GeneratedAt string `json:"generated_at"`
+		}
+		if err := json.Unmarshal(data, &m); err != nil || m.GeneratedAt == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, m.GeneratedAt); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -96,8 +96,11 @@ func TestNewEngine_SmokeGenerate(t *testing.T) {
 }
 
 // TestAutoLoadSnapshot verifies that an existing .enola/facts.jsonl is loaded
-// into the engine without a generate call.
+// into the engine without a generate call. HOME is isolated so no real global
+// receipt exists, exercising the single-repo fallback path.
 func TestAutoLoadSnapshot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{
 		ConfigPath: filepath.Join(t.TempDir(), "no-such-config.yaml"),
 	})
@@ -130,6 +133,53 @@ func TestAutoLoadSnapshot(t *testing.T) {
 	}
 	if eng.Snapshot() == nil {
 		t.Error("expected snapshot to be set after AutoLoadSnapshot")
+	}
+}
+
+// TestAutoLoadSnapshot_FromGlobalReceipt verifies the multi-repo restore path: a
+// prior session's ~/.enola/receipt.json is used to reload the graph on a fresh
+// engine, even when cfg.Repo points somewhere with no snapshot. HOME is isolated so
+// the receipt written by WriteGlobalReceipt is the only one seen.
+func TestAutoLoadSnapshot_FromGlobalReceipt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Session 1: generate a snapshot and record it in the global receipt.
+	repo := writeGoRepo(t)
+	eng1, cfg, err := bootstrap.NewEngine(bootstrap.Options{
+		ConfigPath: filepath.Join(t.TempDir(), "no-such-config.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	snap, err := eng1.GenerateSnapshot(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf("GenerateSnapshot: %v", err)
+	}
+	if err := eng1.WriteArtifacts(repo); err != nil {
+		t.Fatalf("WriteArtifacts: %v", err)
+	}
+	if err := eng1.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt: %v", err)
+	}
+
+	// Session 2 (restart): a brand-new engine whose cfg.Repo has NO snapshot, so a
+	// successful restore can only have come from the global receipt.
+	eng2, cfg2, err := bootstrap.NewEngine(bootstrap.Options{
+		ConfigPath: filepath.Join(t.TempDir(), "no-such-config.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("NewEngine 2: %v", err)
+	}
+	_ = cfg
+	cfg2.Repo = t.TempDir() // empty dir, no .enola
+	bootstrap.AutoLoadSnapshot(eng2, cfg2)
+
+	if got := eng2.Store().Count(); got != snap.Meta.FactCount {
+		t.Errorf("restored %d facts, want %d", got, snap.Meta.FactCount)
+	}
+	restored := eng2.Snapshot()
+	if restored == nil || restored.Meta.GeneratedAt == "" {
+		t.Fatalf("expected a restored snapshot with generated_at, got %+v", restored)
 	}
 }
 


### PR DESCRIPTION
The MCP server dropped its in-memory graph on restart: AutoLoadSnapshot reloaded only the configured repo's facts.jsonl, skipping insights and snapshot meta, so multi-repo graphs had to be regenerated every restart and had no generated_at to judge freshness against.

Restore now rebuilds the whole graph from disk with no extractor runs:
- engine.LoadGlobalReceipt reads the graph-wide registry (~/.enola/receipt.json).
- engine.RestoreFromDir republishes facts + insights + meta via the same atomic snapshotBundle swap as GenerateSnapshot.
- AutoLoadSnapshot uses the registry to reload every member repo from the newest snapshot dir (which holds the complete store), falling back to a single-repo restore, then to empty.

Add warn-only staleness surfacing (no auto-regeneration):
- engine.Staleness flags the graph when it is older than 24h, or a repo's git HEAD moved / working tree turned newly dirty since its snapshot.
- A receiving middleware prepends a one-line warning to read-tool results, memoized briefly to keep git off the hot path. Registered once so it also covers tools added on the same MCP server.

Tests: RestoreFromDir round-trip, Staleness (age + commit-moved), and a multi-repo restore-from-registry integration test. Existing HOME-dependent tests isolated so they no longer read the real global receipt.