### PR TITLE
Add --help, --list and --status to the CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,7 +186,7 @@ The shared module-graph construction and statistical-outlier helpers used by sev
 
 ## The explain package (`pkg/explain`)
 
-`pkg/explain` ([`pkg/explain/explain.go`](pkg/explain/explain.go)) is a **public** package rather than `internal/` for one reason: `enola-enterprise` imports it to append its own license-gated sections (dead code, package metrics) to the base `Report` before rendering. It is the only package in the OSS codebase with that cross-module consumer.
+`pkg/explain` ([`pkg/explain/explain.go`](pkg/explain/explain.go)) is a **public** package rather than `internal/` for one reason: `enola-enterprise` imports it to append its own license-gated sections (dead code, package metrics) to the base `Report` before rendering. It is one of several `pkg/` packages that exist for that cross-module consumer — see [The CLI surface](#the-cli-surface-pkgcli-and-pkgstatus) for the two that back `--help`, `--list` and `--status`.
 
 ### `Report` and `Compute()`
 
@@ -214,6 +214,21 @@ The shared module-graph construction and statistical-outlier helpers used by sev
 ### Output format
 
 `Render()` produces plain aligned text (not Markdown), designed to read well in a terminal without paging. Sections are separated by `═` rule lines (60 characters). Key-value pairs use `fmt.Fprintf` with a 20-character label width; tables (hotspots) use fixed-width column formats. No color codes — output is safe to pipe or capture in CI.
+
+---
+
+## The CLI surface (`pkg/cli` and `pkg/status`)
+
+`--help`, `--list` and `--status` are served from two public packages, for the same reason as `pkg/explain`: a wrapper binary must be able to print *its* version of each without restating the shared text. Both extension points are plain data, so nothing a wrapper adds is known here.
+
+**[`pkg/cli`](pkg/cli)** renders what a binary prints about itself.
+
+- `OSSTools()` is the `--list` catalogue: name plus a one-line summary. It is hand-written on purpose — the descriptions registered with `mcp.AddTool` are multi-paragraph agent prompts, unusable in a terminal. `TestE2E_ToolCatalogueMatchesRegisteredTools` ([`internal/server/e2e_test.go`](internal/server/e2e_test.go)) asserts set equality against the tools the running server actually registers, so the two cannot drift. `RenderToolList(ToolListSpec)` renders it; a wrapper passes its own tools in `Extra` (or an unlock note via `ExtraLocked`/`LockedNote`), and with a zero spec the output never mentions that a wrapper exists.
+- `DefaultHelp(Binary)` returns the `HelpSpec` shared by every enola binary — usage, flags, config path, examples, MCP configuration, build — with the binary's name, command package and version ldflag substituted in. A wrapper appends to `Commands`/`Flags`/`Sections`, qualifies a shared flag with `AppendFlagNote`, and places its own blocks precisely with `InsertSectionsBefore`. `RenderHelp` does the layout (a 22-column description gutter, with continuation lines aligned to it).
+
+**[`pkg/status`](pkg/status)** is the usage tracker behind `--status`. `Tracker.OnToolCall` is registered as the server's tool callback (`bootstrap.Server.SetToolCallback`) and attributes each call to the repo it actually operated on, not to a fixed one. Counters live in `~/.enola/usage/<repo-base>-<hash8>.json` — outside the repo, so they survive both a restart and deleting `.enola/` — and each file carries the lifetime total plus the current run's session counts. `AggregateServer` collapses every file into the one server view `PrintStatus` renders; `AggregateUsage` produces the per-repo breakdown for `--status --all`.
+
+The value estimate is a deliberately simple model in [`pkg/status/value.go`](pkg/status/value.go): one weight per tool (the number of manual lookups a call replaces) times two conversion constants (seconds and tokens per lookup). `RegisterToolWeights` lets a wrapper price the tools it adds instead of letting them fall through to the default weight; it is guarded by a mutex because registration happens at startup while reads come from the tool callback.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -461,6 +461,25 @@ For interactive per-module blast-radius queries with configurable depth, see the
 
 ---
 
+## Command-line reference
+
+Run `enola --help` for the full text. With no flags, enola starts the MCP server on stdio.
+
+| Flag | What it does |
+|------|--------------|
+| `--generate [config_path]` | Generate a snapshot and exit — no MCP server. Artifacts go to `output.dir` (default `.enola/`). |
+| `--explain [repo_path]` | Print the statistics report above and exit. Read-only: nothing is written to `.enola/`. |
+| `--list` | List the MCP tools this build serves, with one-line summaries. |
+| `--status` | Show the MCP server's activity: uptime, per-tool call counts (this session and lifetime), and an estimate of the time and context those calls saved. |
+| `--status --all` | The same usage, broken down per repository. |
+| `--version` | Print the build version. |
+| `--help`, `-h` | Show usage. |
+| `upgrade` | Download and install the latest release over the running binary. |
+
+Usage counters are recorded per repository under `~/.enola/usage/`, so they survive both server restarts and deleting a repo's `.enola/` directory — and `--status` works from any directory, not just a snapshotted one. The value estimate is exactly that: a static per-tool model of how many manual lookups (open a file, grep, read) one call replaces, converted to time and tokens.
+
+---
+
 ## Learn more
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — the concept, the fact model, the pipeline, and the full tool reference.

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -6,12 +6,15 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/enola-labs/enola/internal/config"
 	"github.com/enola-labs/enola/internal/upgrade"
 	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/enola-labs/enola/pkg/cli"
 	"github.com/enola-labs/enola/pkg/explain"
+	"github.com/enola-labs/enola/pkg/status"
 )
 
 func main() {
@@ -29,6 +32,8 @@ func main() {
 
 	generateMode := false
 	explainMode := false
+	statusMode := false
+	statusAll := false
 	cfgPath := "mcp-arch.yaml"
 	explainRepo := "" // optional positional repo path for --explain
 
@@ -37,10 +42,20 @@ func main() {
 		case "--version":
 			fmt.Fprintf(os.Stderr, "enola version %s\n", version.Version)
 			os.Exit(0)
+		case "--help", "-h":
+			cli.RenderHelp(os.Stderr, helpSpec())
+			os.Exit(0)
+		case "--list":
+			fmt.Fprint(os.Stderr, cli.RenderToolList(cli.ToolListSpec{}))
+			os.Exit(0)
 		case "--generate":
 			generateMode = true
 		case "--explain":
 			explainMode = true
+		case "--status":
+			statusMode = true
+		case "--all":
+			statusAll = true
 		default:
 			// In --explain mode the positional argument is the repository path;
 			// otherwise it is the config file path.
@@ -50,6 +65,17 @@ func main() {
 				cfgPath = arg
 			}
 		}
+	}
+
+	// --status reads only the recorded usage under ~/.enola/usage/, so it runs
+	// before the engine is built and never touches the repo.
+	if statusMode {
+		if statusAll {
+			status.PrintStatusAll()
+		} else {
+			status.PrintStatus()
+		}
+		os.Exit(0)
 	}
 
 	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{
@@ -102,9 +128,36 @@ func main() {
 		log.Fatalf("failed to create server: %v", err)
 	}
 
+	// Record per-tool usage so a later `enola --status` has something to report.
+	// Per-repo counters are loaded lazily from ~/.enola/usage/ on first touch, so
+	// they survive restarts; the config's repo is the fallback for calls made
+	// before any snapshot is loaded. srv.StartTime() is only set once Run() is
+	// called, so stamp the start time here to get a correct uptime.
+	repoPath, _ := filepath.Abs(cfg.Repo)
+	tracker := status.NewTracker(repoPath)
+	tracker.SetStartTime(time.Now())
+	srv.SetToolCallback(tracker.OnToolCall)
+	tracker.PersistStartup()
+
 	if err := srv.Run(ctx); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+// helpSpec is the `--help` text for this binary: the shared engine help with
+// the OSS-only `upgrade` command documented on top.
+func helpSpec() cli.HelpSpec {
+	spec := cli.DefaultHelp(cli.Binary{
+		Name:       "enola",
+		CmdPackage: "./cmd/enola",
+		VersionVar: "github.com/enola-labs/enola/internal/version.Version",
+	})
+	spec.Usage = append(spec.Usage, "enola upgrade")
+	spec.Commands = append(spec.Commands, cli.FlagDoc{
+		Flag: "upgrade",
+		Desc: "Download and install the latest enola release, replacing the\nrunning binary in place.",
+	})
+	return spec
 }
 
 // runExplain indexes the given repository (defaulting to the configured repo)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/tree-sitter/tree-sitter-ruby v0.21.1-0.20240818211811-7dbc1e2d0e2d
 	github.com/tree-sitter/tree-sitter-rust v0.23.3
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
+	golang.org/x/sys v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -25,5 +26,4 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/enola-labs/enola/internal/config"
 	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/enola-labs/enola/pkg/cli"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -139,6 +140,41 @@ func TestE2E_ListTools(t *testing.T) {
 	for _, name := range expectedTools {
 		if !got[name] {
 			t.Errorf("expected tool %q to be registered; registered: %v", name, keys(got))
+		}
+	}
+}
+
+// The `--list` catalogue in pkg/cli is hand-written (the registered MCP
+// descriptions are multi-paragraph agent prompts, unusable in a terminal list),
+// so nothing but this test keeps it honest: registering a tool without
+// cataloguing it — or cataloguing one that was renamed away — fails here.
+func TestE2E_ToolCatalogueMatchesRegisteredTools(t *testing.T) {
+	s := startInMemory(t)
+	res, err := s.cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	registered := map[string]bool{}
+	for _, tool := range res.Tools {
+		registered[tool.Name] = true
+	}
+	catalogued := map[string]bool{}
+	for _, entry := range cli.OSSTools() {
+		if entry.Description == "" {
+			t.Errorf("catalogue entry %q has no description", entry.Name)
+		}
+		catalogued[entry.Name] = true
+	}
+
+	for name := range registered {
+		if !catalogued[name] {
+			t.Errorf("tool %q is registered but missing from cli.OSSTools()", name)
+		}
+	}
+	for name := range catalogued {
+		if !registered[name] {
+			t.Errorf("tool %q is in cli.OSSTools() but not registered by the server", name)
 		}
 	}
 }

--- a/internal/server/usage_e2e_test.go
+++ b/internal/server/usage_e2e_test.go
@@ -1,0 +1,81 @@
+package server_test
+
+// End-to-end cover for the usage tracking behind `enola --status`: it wires a
+// status.Tracker as the server's tool callback exactly as cmd/enola/main.go
+// does, drives real tool calls over the in-memory transport, and asserts the
+// counters that --status renders actually landed on disk.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/enola-labs/enola/pkg/status"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestE2E_ToolUsageIsRecordedForStatus(t *testing.T) {
+	// status writes under ~/.enola/usage/; keep the developer's real stats out of it.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+
+	ctx := context.Background()
+	eng, cfg := newTestEngine(t)
+
+	srv, err := bootstrap.NewServer(eng, cfg)
+	if err != nil {
+		t.Fatalf("bootstrap.NewServer: %v", err)
+	}
+
+	repo := copyTree(t, filepath.Join("..", "engine", "testdata", "repos", "go_sample"), t.TempDir())
+	tracker := status.NewTracker(repo)
+	tracker.SetStartTime(time.Now())
+	srv.SetToolCallback(tracker.OnToolCall)
+	tracker.PersistStartup()
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	if _, err := srv.MCP().Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "enola-test", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	// A snapshot must exist before query_facts returns anything, so this both
+	// sets up the second call and is itself a recorded call.
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "generate_snapshot", Arguments: map[string]any{"repo_path": repo},
+	}); err != nil {
+		t.Fatalf("generate_snapshot: %v", err)
+	}
+	for range 2 {
+		if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name: "query_facts", Arguments: map[string]any{"kind": "module"},
+		}); err != nil {
+			t.Fatalf("query_facts: %v", err)
+		}
+	}
+
+	ss := status.ServerSnapshot()
+	if !ss.Found {
+		t.Fatal("no usage recorded; --status would report nothing after three tool calls")
+	}
+	for tool, want := range map[string]int{"generate_snapshot": 1, "query_facts": 2} {
+		if got := ss.GrandTotal[tool]; got != want {
+			t.Errorf("lifetime count for %q: got %d, want %d", tool, got, want)
+		}
+		if got := ss.Session[tool]; got != want {
+			t.Errorf("session count for %q: got %d, want %d", tool, got, want)
+		}
+	}
+
+	// The value estimate is what makes --status more than a counter dump.
+	if rep := status.ComputeValue(ss.GrandTotal); rep.TotalCalls != 3 || rep.TotalTokensSaved == 0 {
+		t.Errorf("value report over recorded usage: %d calls, %d tokens saved", rep.TotalCalls, rep.TotalTokensSaved)
+	}
+}

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// descColumn is the column at which a flag's or command's description starts.
+// Continuation lines in a multi-line description are indented to match.
+const descColumn = 22
+
+// FlagDoc documents one flag or command. Desc may span several lines; the
+// renderer indents continuations to the description column.
+type FlagDoc struct {
+	Flag string
+	Desc string
+}
+
+// Section is a free-form trailing block of the help text (LICENSE, BUILD, …).
+// Body is emitted verbatim, so it carries its own indentation.
+type Section struct {
+	Title string
+	Body  string
+}
+
+// Example is one entry of the EXAMPLES block: a comment line and the command
+// it introduces.
+type Example struct {
+	Comment string
+	Command string
+}
+
+// Binary identifies the binary the help text is describing. It is what makes
+// the shared help reusable: everything a wrapper needs to rename is in here.
+type Binary struct {
+	Name       string // executable name, e.g. "enola"
+	CmdPackage string // go build target, e.g. "./cmd/enola"
+	VersionVar string // ldflags -X target for the version string
+
+	// BuildOutput is the artifact name a source build produces, when it differs
+	// from Name (e.g. "enola-ent" for enola-enterprise). Defaults to Name.
+	BuildOutput string
+}
+
+// output returns the artifact name to show in the BUILD section.
+func (b Binary) output() string {
+	if b.BuildOutput != "" {
+		return b.BuildOutput
+	}
+	return b.Name
+}
+
+// HelpSpec is the rendered form of `--help`. A wrapper binary starts from
+// DefaultHelp and appends to Commands/Flags/Sections rather than restating the
+// shared text.
+type HelpSpec struct {
+	Bin       Binary
+	Tagline   string    // one-line description, printed beside the binary name
+	Intro     string    // short paragraph under the title
+	Usage     []string  // USAGE lines, already prefixed with the binary name
+	Commands  []FlagDoc // COMMANDS block; omitted when empty
+	Flags     []FlagDoc // FLAGS block
+	ConfigDoc string    // CONFIG_PATH block body (one line); omitted when empty
+	Examples  []Example // EXAMPLES block
+	Sections  []Section // trailing blocks, in order
+}
+
+// DefaultHelp returns the help shared by every enola binary. It documents only
+// what the engine itself provides — it never mentions licensing, activation or
+// anything a wrapper adds.
+func DefaultHelp(bin Binary) HelpSpec {
+	return HelpSpec{
+		Bin:     bin,
+		Tagline: "MCP server for architectural snapshots",
+		Intro:   "Give your AI agent a map of the codebase before it starts exploring.",
+		Usage: []string{
+			bin.Name + " [flags] [config_path]",
+		},
+		Flags: []FlagDoc{
+			{Flag: "--generate", Desc: "Generate a snapshot and exit (do not start MCP server)"},
+			{Flag: "--explain [path]", Desc: "Print a human-readable repository statistics report and exit"},
+			{Flag: "--list", Desc: "List the MCP tools this build can serve"},
+			{Flag: "--status", Desc: "Show MCP server status: uptime, tool usage and estimated value,\naggregated across every repo the server has served."},
+			{Flag: "--status --all", Desc: "Show the per-repo breakdown instead (from ~/.enola/usage/)"},
+			{Flag: "--version", Desc: "Print version information"},
+			{Flag: "--help, -h", Desc: "Show this help message"},
+		},
+		ConfigDoc: "Path to the config file (default: mcp-arch.yaml)",
+		Examples: []Example{
+			{Comment: "Start MCP server with default config", Command: bin.Name},
+			{Comment: "Start MCP server with custom config", Command: bin.Name + " my-config.yaml"},
+			{Comment: "Generate a snapshot and exit", Command: bin.Name + " --generate"},
+			{Comment: "Print a statistics report for a repository and exit", Command: bin.Name + " --explain /path/to/repo"},
+			{Comment: "Generate snapshot with custom config", Command: bin.Name + " --generate my-config.yaml"},
+			{Comment: "Check MCP server status", Command: bin.Name + " --status"},
+			{Comment: "Show usage broken down per repo", Command: bin.Name + " --status --all"},
+			{Comment: "Check version", Command: bin.Name + " --version"},
+		},
+		Sections: []Section{
+			mcpConfigSection(bin),
+			buildSection(bin),
+		},
+	}
+}
+
+// mcpConfigSection documents how to register the binary with an MCP client.
+func mcpConfigSection(bin Binary) Section {
+	return Section{
+		Title: "MCP CONFIGURATION",
+		Body: fmt.Sprintf(`  Add to your MCP client's config (e.g., Cursor mcp.json):
+
+    {
+      "mcpServers": {
+        "enola": {
+          "command": "%s",
+          "args": ["mcp-arch.yaml"]
+        }
+      }
+    }
+
+  Or if installed globally via "go install":
+
+    {
+      "mcpServers": {
+        "enola": {
+          "command": "%s"
+        }
+      }
+    }
+`, bin.Name, bin.Name),
+	}
+}
+
+// buildSection documents the version ldflag for a source build.
+func buildSection(bin Binary) Section {
+	return Section{
+		Title: "BUILD",
+		Body: fmt.Sprintf(`  Version can be set at build time with ldflags:
+
+    go build -ldflags "-X %s=0.1.0" -o %s %s
+`, bin.VersionVar, bin.output(), bin.CmdPackage),
+	}
+}
+
+// AppendFlagNote appends note as extra lines to an existing flag's description,
+// so a wrapper can qualify a shared flag without restating the Flags slice. It
+// is a no-op when the flag is absent.
+func (s *HelpSpec) AppendFlagNote(flag, note string) {
+	for i := range s.Flags {
+		if s.Flags[i].Flag == flag {
+			s.Flags[i].Desc += "\n" + note
+			return
+		}
+	}
+}
+
+// InsertSectionsBefore inserts sections immediately before the section with the
+// given title, so a wrapper can place its own blocks precisely rather than only
+// at the end. Sections are appended when the title is not found.
+func (s *HelpSpec) InsertSectionsBefore(title string, secs ...Section) {
+	for i, sec := range s.Sections {
+		if sec.Title == title {
+			rest := append([]Section{}, s.Sections[i:]...)
+			s.Sections = append(append(s.Sections[:i:i], secs...), rest...)
+			return
+		}
+	}
+	s.Sections = append(s.Sections, secs...)
+}
+
+// RenderHelp writes the help text for spec to w.
+func RenderHelp(w io.Writer, spec HelpSpec) {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s — %s\n\n%s\n", spec.Bin.Name, spec.Tagline, spec.Intro)
+
+	if len(spec.Usage) > 0 {
+		b.WriteString("\nUSAGE\n")
+		for _, u := range spec.Usage {
+			fmt.Fprintf(&b, "  %s\n", u)
+		}
+	}
+	writeDocs(&b, "COMMANDS", spec.Commands)
+	writeDocs(&b, "FLAGS", spec.Flags)
+
+	if spec.ConfigDoc != "" {
+		fmt.Fprintf(&b, "\nCONFIG_PATH\n  %s\n", spec.ConfigDoc)
+	}
+
+	if len(spec.Examples) > 0 {
+		b.WriteString("\nEXAMPLES\n")
+		for i, ex := range spec.Examples {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "  # %s\n  %s\n", ex.Comment, ex.Command)
+		}
+	}
+
+	for _, sec := range spec.Sections {
+		fmt.Fprintf(&b, "\n%s\n%s", sec.Title, sec.Body)
+	}
+
+	// Help goes to a terminal stream; a write failure has nowhere useful to go.
+	_, _ = io.WriteString(w, b.String())
+}
+
+// writeDocs renders a titled block of flag/command documentation, wrapping each
+// description's continuation lines to the description column.
+func writeDocs(b *strings.Builder, title string, docs []FlagDoc) {
+	if len(docs) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n%s\n", title)
+	for _, d := range docs {
+		lines := strings.Split(d.Desc, "\n")
+		fmt.Fprintf(b, "  %-*s%s\n", descColumn-2, d.Flag, lines[0])
+		for _, cont := range lines[1:] {
+			fmt.Fprintf(b, "%s%s\n", strings.Repeat(" ", descColumn), cont)
+		}
+	}
+}

--- a/pkg/cli/help_test.go
+++ b/pkg/cli/help_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func testBinary() Binary {
+	return Binary{
+		Name:       "enola",
+		CmdPackage: "./cmd/enola",
+		VersionVar: "github.com/enola-labs/enola/internal/version.Version",
+	}
+}
+
+func renderDefault(t *testing.T) string {
+	t.Helper()
+	var b strings.Builder
+	RenderHelp(&b, DefaultHelp(testBinary()))
+	return b.String()
+}
+
+func TestDefaultHelp_MentionsEveryFlag(t *testing.T) {
+	out := renderDefault(t)
+	for _, flag := range []string{"--generate", "--explain", "--list", "--status", "--status --all", "--version", "--help, -h"} {
+		if !strings.Contains(out, flag) {
+			t.Errorf("flag %q missing from default help", flag)
+		}
+	}
+	for _, title := range []string{"USAGE", "FLAGS", "CONFIG_PATH", "EXAMPLES", "MCP CONFIGURATION", "BUILD"} {
+		if !strings.Contains(out, title) {
+			t.Errorf("section %q missing from default help", title)
+		}
+	}
+}
+
+// The shared help is what the OSS binary prints verbatim, so it must never
+// describe anything only a wrapper provides.
+func TestDefaultHelp_NoWrapperConcepts(t *testing.T) {
+	out := strings.ToLower(renderDefault(t))
+	for _, term := range []string{"license", "activate", "dashboard", "enterprise"} {
+		if strings.Contains(out, term) {
+			t.Errorf("default help must not mention %q:\n%s", term, out)
+		}
+	}
+}
+
+func TestDefaultHelp_NoCommandsBlockWhenEmpty(t *testing.T) {
+	if strings.Contains(renderDefault(t), "COMMANDS") {
+		t.Error("COMMANDS block should be omitted when no commands are declared")
+	}
+}
+
+func TestRenderHelp_MultiLineDescriptionsAlign(t *testing.T) {
+	var b strings.Builder
+	spec := DefaultHelp(testBinary())
+	spec.Flags = []FlagDoc{{Flag: "--status", Desc: "first line\nsecond line"}}
+	RenderHelp(&b, spec)
+
+	var found bool
+	for _, line := range strings.Split(b.String(), "\n") {
+		if strings.HasSuffix(line, "second line") {
+			found = true
+			if got := len(line) - len("second line"); got != descColumn {
+				t.Errorf("continuation indent = %d, want %d", got, descColumn)
+			}
+		}
+	}
+	if !found {
+		t.Error("continuation line not rendered")
+	}
+}
+
+func TestAppendFlagNote(t *testing.T) {
+	spec := DefaultHelp(testBinary())
+	spec.AppendFlagNote("--status", "Also prints the dashboard URL.")
+
+	var b strings.Builder
+	RenderHelp(&b, spec)
+	if !strings.Contains(b.String(), "Also prints the dashboard URL.") {
+		t.Error("appended flag note not rendered")
+	}
+
+	// An unknown flag is a no-op, not a panic or a stray entry.
+	before := len(spec.Flags)
+	spec.AppendFlagNote("--nope", "ignored")
+	if len(spec.Flags) != before {
+		t.Error("AppendFlagNote on an unknown flag must not add a flag")
+	}
+	if strings.Contains(b.String(), "ignored") {
+		t.Error("note for an unknown flag must not be rendered")
+	}
+}
+
+func TestInsertSectionsBefore(t *testing.T) {
+	spec := DefaultHelp(testBinary())
+	spec.InsertSectionsBefore("MCP CONFIGURATION", Section{Title: "LICENSE", Body: "  key stuff\n"})
+
+	var b strings.Builder
+	RenderHelp(&b, spec)
+	out := b.String()
+
+	lic, mcp := strings.Index(out, "\nLICENSE\n"), strings.Index(out, "\nMCP CONFIGURATION\n")
+	if lic < 0 || mcp < 0 {
+		t.Fatalf("expected both sections to render:\n%s", out)
+	}
+	if lic > mcp {
+		t.Error("inserted section should precede MCP CONFIGURATION")
+	}
+
+	// An unknown anchor appends rather than dropping the section.
+	spec.InsertSectionsBefore("NOPE", Section{Title: "TRAILING", Body: "  x\n"})
+	if spec.Sections[len(spec.Sections)-1].Title != "TRAILING" {
+		t.Error("section with an unknown anchor should be appended last")
+	}
+}
+
+// InsertSectionsBefore must not write through the shared backing array of the
+// slice it was handed — two specs built from the same DefaultHelp are independent.
+func TestInsertSectionsBefore_DoesNotAliasSiblingSpec(t *testing.T) {
+	a := DefaultHelp(testBinary())
+	b := a
+	b.Sections = append([]Section{}, a.Sections...)
+
+	a.InsertSectionsBefore("MCP CONFIGURATION", Section{Title: "ONLY_IN_A", Body: "  x\n"})
+
+	for _, sec := range b.Sections {
+		if sec.Title == "ONLY_IN_A" {
+			t.Error("insertion leaked into a sibling spec")
+		}
+	}
+}

--- a/pkg/cli/tools.go
+++ b/pkg/cli/tools.go
@@ -1,0 +1,122 @@
+// Package cli renders what an enola binary prints about itself: the `--list`
+// tool catalogue and the `--help` text.
+//
+// It is a public package rather than internal/ because a wrapper binary (e.g.
+// enola-enterprise) builds on the same surfaces: it lists its own license-gated
+// tools alongside the engine's, and extends the shared help with sections that
+// are meaningless here. Both extension points are data — ToolListSpec.Extra and
+// HelpSpec's Commands/Flags/Sections — so nothing about a wrapper's features
+// leaks into this package.
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ToolEntry is one row of the `--list` catalogue: a tool name and a one-line
+// summary. The summaries here are deliberately terminal-sized; the MCP tool
+// descriptions registered in internal/server are multi-paragraph agent prompts
+// and unusable in a list.
+type ToolEntry struct {
+	Name        string
+	Description string
+}
+
+// OSSTools returns the catalogue of tools the engine's MCP server registers.
+//
+// This list must stay in step with Server.registerTools in internal/server —
+// TestToolCatalogueMatchesRegisteredTools enforces that, so adding a tool
+// without cataloguing it fails the build.
+func OSSTools() []ToolEntry {
+	return []ToolEntry{
+		{Name: "generate_snapshot", Description: "Index a repository and extract its architecture as queryable facts."},
+		{Name: "explore", Description: "Primary exploration tool — use this first after generate_snapshot."},
+		{Name: "query_facts", Description: "Precision filter over extracted facts."},
+		{Name: "show_symbol", Description: "Return the source code implementation of a named symbol."},
+		{Name: "traverse", Description: "Walk the dependency/call graph from a starting node."},
+		{Name: "find_path", Description: "Find the shortest path between two nodes in the architectural graph."},
+		{Name: "impact_analysis", Description: "Compute the blast radius of changing a target node."},
+		{Name: "coverage_report", Description: "Per-service edge coverage — tell a genuinely isolated service from one whose edges could not be resolved."},
+		{Name: "query_insights", Description: "Fetch the architectural findings explainers computed during generate_snapshot (cycles, god-class, unused routes, …)."},
+		{Name: "set_baseline", Description: "Pin the current snapshot as the baseline for diff_snapshot."},
+		{Name: "diff_snapshot", Description: "Show what changed in the architecture between the baseline snapshot and the current one."},
+		{Name: "snapshot_receipt", Description: "Show the receipt for the current snapshot — a compact manifest of what the graph was generated over and how complete extraction was."},
+		{Name: "compare_receipts", Description: "Compare the current snapshot's receipt against a baseline's to check they are comparable before trusting a diff."},
+	}
+}
+
+// ToolListSpec describes an optional second group of tools to render after the
+// engine's own. A zero spec yields the plain engine catalogue with no reference
+// to any wrapper — which is what the OSS binary passes.
+type ToolListSpec struct {
+	// Extra holds a wrapper's own tools. Rendered under ExtraHeading, unless
+	// ExtraLocked is set.
+	Extra []ToolEntry
+
+	// ExtraHeading titles the second group (e.g. "Enterprise tools:").
+	ExtraHeading string
+
+	// ExtraLocked reports that the wrapper's tools exist but are not currently
+	// available (e.g. unlicensed). LockedNote is printed in place of Extra.
+	ExtraLocked bool
+
+	// LockedNote explains how to unlock the tools. Only used when ExtraLocked.
+	LockedNote string
+}
+
+// nameColumn is the minimum width of the tool-name column. A longer name widens
+// it for every group, so the descriptions stay in one line.
+const nameColumn = 22
+
+// RenderToolList renders the `--list` output for the given spec.
+func RenderToolList(spec ToolListSpec) string {
+	var b strings.Builder
+
+	engine := OSSTools()
+	width := nameWidth(engine, spec.Extra)
+
+	b.WriteString("Available tools:\n")
+	if spec.hasSecondGroup() {
+		// Only label the engine's group when there is another one to tell it apart from.
+		b.WriteString("\nOSS tools:\n")
+	} else {
+		b.WriteString("\n")
+	}
+	writeEntries(&b, engine, width)
+
+	switch {
+	case spec.ExtraLocked:
+		fmt.Fprintf(&b, "\n%s\n", spec.LockedNote)
+	case len(spec.Extra) > 0:
+		fmt.Fprintf(&b, "\n%s\n", spec.ExtraHeading)
+		writeEntries(&b, spec.Extra, width)
+	}
+
+	return b.String()
+}
+
+// nameWidth returns the tool-name column width for the given groups.
+func nameWidth(groups ...[]ToolEntry) int {
+	width := nameColumn
+	for _, g := range groups {
+		for _, t := range g {
+			if len(t.Name) > width {
+				width = len(t.Name)
+			}
+		}
+	}
+	return width
+}
+
+// hasSecondGroup reports whether anything is rendered after the engine's tools.
+func (s ToolListSpec) hasSecondGroup() bool {
+	return s.ExtraLocked || len(s.Extra) > 0
+}
+
+// writeEntries renders one group of catalogue rows at the given name width.
+func writeEntries(b *strings.Builder, entries []ToolEntry, width int) {
+	for _, t := range entries {
+		fmt.Fprintf(b, "  %-*s  %s\n", width, t.Name, t.Description)
+	}
+}

--- a/pkg/cli/tools_test.go
+++ b/pkg/cli/tools_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderToolList_EngineOnly(t *testing.T) {
+	out := RenderToolList(ToolListSpec{})
+
+	for _, tool := range OSSTools() {
+		if !strings.Contains(out, tool.Name) {
+			t.Errorf("tool %q missing from the default catalogue", tool.Name)
+		}
+	}
+	// With no second group there is nothing to distinguish, so the engine's
+	// tools are not labelled and no wrapper is referenced.
+	for _, unwanted := range []string{"OSS tools:", "Enterprise", "ENOLA_LICENSE_KEY"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("default catalogue should not mention %q:\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestRenderToolList_WithExtraGroup(t *testing.T) {
+	out := RenderToolList(ToolListSpec{
+		Extra:        []ToolEntry{{Name: "extra_tool", Description: "Does something extra."}},
+		ExtraHeading: "Extra tools:",
+	})
+
+	if !strings.Contains(out, "OSS tools:") {
+		t.Error("engine tools should be labelled once a second group exists")
+	}
+	if !strings.Contains(out, "Extra tools:") || !strings.Contains(out, "extra_tool") {
+		t.Errorf("extra group missing:\n%s", out)
+	}
+	if !strings.Contains(out, "generate_snapshot") {
+		t.Error("engine tools must still be listed alongside the extra group")
+	}
+}
+
+// A wrapper tool with a long name widens the column for every group, so no row
+// runs its description into the name.
+func TestRenderToolList_LongNameWidensEveryGroup(t *testing.T) {
+	const long = "a_very_long_wrapper_tool_name"
+	out := RenderToolList(ToolListSpec{
+		Extra:        []ToolEntry{{Name: long, Description: "Long."}},
+		ExtraHeading: "Extra tools:",
+	})
+
+	for _, line := range strings.Split(out, "\n") {
+		for _, name := range []string{"explore", long} {
+			if !strings.HasPrefix(line, "  "+name+" ") {
+				continue
+			}
+			desc := strings.Index(line, strings.TrimSpace(line[2+len(name):]))
+			if want := 2 + len(long) + 2; desc != want {
+				t.Errorf("%q description starts at column %d, want %d", name, desc, want)
+			}
+		}
+	}
+}
+
+func TestRenderToolList_LockedGroup(t *testing.T) {
+	out := RenderToolList(ToolListSpec{
+		Extra:        []ToolEntry{{Name: "extra_tool", Description: "Does something extra."}},
+		ExtraHeading: "Extra tools:",
+		ExtraLocked:  true,
+		LockedNote:   "Extra tools are not available.",
+	})
+
+	if strings.Contains(out, "extra_tool") {
+		t.Error("locked tools must not be listed")
+	}
+	if !strings.Contains(out, "Extra tools are not available.") {
+		t.Errorf("locked note missing:\n%s", out)
+	}
+	if !strings.Contains(out, "generate_snapshot") {
+		t.Error("engine tools must still be listed when the extra group is locked")
+	}
+}

--- a/pkg/status/aggregate.go
+++ b/pkg/status/aggregate.go
@@ -1,0 +1,210 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// RepoUsage is one repo's lifetime totals within an aggregate view.
+type RepoUsage struct {
+	RepoPath      string
+	Counts        map[string]int // lifetime grand total
+	TrackingSince time.Time
+}
+
+// Aggregate is the cross-repo rollup of all per-repo usage files.
+type Aggregate struct {
+	Repos         []RepoUsage    // sorted by tokens saved, descending
+	Combined      map[string]int // summed grand totals across all repos
+	TrackingSince time.Time      // earliest across all repos
+}
+
+// AggregateUsage reads every per-repo usage file in dir and sums their lifetime
+// totals. It is best-effort: unreadable/malformed files are skipped. A missing
+// directory yields an empty aggregate with no error.
+func AggregateUsage(dir string) (Aggregate, error) {
+	var agg Aggregate
+	agg.Combined = make(map[string]int)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return agg, nil
+		}
+		return agg, err
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var info StatusInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			continue
+		}
+		agg.Repos = append(agg.Repos, RepoUsage{
+			RepoPath:      info.RepoPath,
+			Counts:        info.ToolCounts,
+			TrackingSince: info.TrackingSince,
+		})
+		for k, v := range info.ToolCounts {
+			agg.Combined[k] += v
+		}
+		if !info.TrackingSince.IsZero() && (agg.TrackingSince.IsZero() || info.TrackingSince.Before(agg.TrackingSince)) {
+			agg.TrackingSince = info.TrackingSince
+		}
+	}
+
+	// Sort repos by estimated tokens saved, descending (biggest value first).
+	sort.Slice(agg.Repos, func(i, j int) bool {
+		return ComputeValue(agg.Repos[i].Counts).TotalTokensSaved >
+			ComputeValue(agg.Repos[j].Counts).TotalTokensSaved
+	})
+
+	return agg, nil
+}
+
+// ServerStatus is the aggregated view of a single MCP server's activity across
+// every repo it has served: the historical grand total plus the current
+// session. This is what plain --status renders — it is not tied to any cwd.
+type ServerStatus struct {
+	GrandTotal    map[string]int // sum of ToolCounts across all repos (lifetime)
+	Session       map[string]int // sum of SessionCounts for the current server run
+	StartTime     time.Time      // newest StartTime seen (the current/most-recent run)
+	PID           int            // PID of that run
+	DashboardPort int            // localhost HTTP dashboard port of that run (0 if none)
+	Alive         bool           // whether that PID is still running
+	TrackingSince time.Time      // earliest TrackingSince across all repos
+	Repos         int            // number of repos with recorded usage
+	Found         bool           // false if no usage files exist
+}
+
+// AggregateServer collapses all per-repo usage files in dir into one server
+// view. The grand total sums every file; the session sums only files written by
+// the current server run — identified as those sharing the newest StartTime, so
+// stale session counts from a previous run (files not re-touched yet) are
+// excluded. Best-effort: unreadable/malformed files are skipped.
+func AggregateServer(dir string) ServerStatus {
+	ss := ServerStatus{
+		GrandTotal: make(map[string]int),
+		Session:    make(map[string]int),
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ss
+	}
+
+	var infos []StatusInfo
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var info StatusInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			continue
+		}
+		infos = append(infos, info)
+	}
+	if len(infos) == 0 {
+		return ss
+	}
+	ss.Found = true
+	ss.Repos = len(infos)
+
+	// First pass: grand total, newest StartTime, earliest TrackingSince.
+	for _, info := range infos {
+		for k, v := range info.ToolCounts {
+			ss.GrandTotal[k] += v
+		}
+		if info.StartTime.After(ss.StartTime) {
+			ss.StartTime = info.StartTime
+			ss.PID = info.PID
+			ss.DashboardPort = info.DashboardPort
+		}
+		if !info.TrackingSince.IsZero() && (ss.TrackingSince.IsZero() || info.TrackingSince.Before(ss.TrackingSince)) {
+			ss.TrackingSince = info.TrackingSince
+		}
+	}
+
+	// Second pass: session counts only from files belonging to the current run.
+	for _, info := range infos {
+		if info.StartTime.Equal(ss.StartTime) {
+			for k, v := range info.SessionCounts {
+				ss.Session[k] += v
+			}
+		}
+	}
+
+	ss.Alive = isProcessAlive(ss.PID)
+	return ss
+}
+
+// PrintStatusAll renders the cross-repo aggregate to stderr. Because the stats
+// live under ~/.enola/usage/, this works from any directory and includes repos
+// whose working copies have since been deleted.
+func PrintStatusAll() {
+	dir, err := usageDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "No usage data available: %v\n", err)
+		return
+	}
+	agg, err := AggregateUsage(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "No usage data available: %v\n", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "\n=== enola MCP Status — all repos ===\n")
+	if len(agg.Repos) == 0 {
+		fmt.Fprintf(os.Stderr, "  (no usage recorded yet)\n\n")
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Repos:          %d\n", len(agg.Repos))
+	if !agg.TrackingSince.IsZero() {
+		fmt.Fprintf(os.Stderr, "Tracking since: %s\n", agg.TrackingSince.Format("2006-01-02 15:04:05"))
+	}
+
+	// Align the repo column to the longest path (capped for readability).
+	maxLen := len("TOTAL")
+	for _, r := range agg.Repos {
+		if l := len(displayRepo(r.RepoPath)); l > maxLen {
+			maxLen = l
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\nValue Estimate (approximate):\n")
+	fmt.Fprintf(os.Stderr, "  %-*s  %6s  %12s  %14s\n", maxLen, "repo", "calls", "~time saved", "~tokens saved")
+	for _, r := range agg.Repos {
+		v := ComputeValue(r.Counts)
+		fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
+			maxLen, displayRepo(r.RepoPath), v.TotalCalls, formatDuration(v.TotalTimeSaved), humanCount(v.TotalTokensSaved))
+	}
+	total := ComputeValue(agg.Combined)
+	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
+		maxLen, "TOTAL", total.TotalCalls, formatDuration(total.TotalTimeSaved), humanCount(total.TotalTokensSaved))
+	fmt.Fprintf(os.Stderr, "\n")
+}
+
+// displayRepo renders a repo path for the aggregate table. The full path is
+// used so repos that share a base name stay distinguishable. Empty paths render
+// as "(unknown)".
+func displayRepo(p string) string {
+	if p == "" {
+		return "(unknown)"
+	}
+	return p
+}

--- a/pkg/status/aggregate_test.go
+++ b/pkg/status/aggregate_test.go
@@ -1,0 +1,88 @@
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeUsage(t *testing.T, dir string, info StatusInfo) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.MarshalIndent(info, "", "  ")
+	name := usageKey(info.RepoPath) + ".json"
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAggregateUsage(t *testing.T) {
+	dir := t.TempDir()
+
+	t1 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) // earlier
+	writeUsage(t, dir, StatusInfo{
+		RepoPath:      "/repo/a",
+		TrackingSince: t1,
+		ToolCounts:    map[string]int{"explore": 2, "query_facts": 1},
+	})
+	writeUsage(t, dir, StatusInfo{
+		RepoPath:      "/repo/b",
+		TrackingSince: t2,
+		ToolCounts:    map[string]int{"explore": 3},
+	})
+
+	agg, err := AggregateUsage(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agg.Repos) != 2 {
+		t.Fatalf("repos: got %d, want 2", len(agg.Repos))
+	}
+	if agg.Combined["explore"] != 5 {
+		t.Errorf("combined explore: got %d, want 5", agg.Combined["explore"])
+	}
+	if agg.Combined["query_facts"] != 1 {
+		t.Errorf("combined query_facts: got %d, want 1", agg.Combined["query_facts"])
+	}
+	if !agg.TrackingSince.Equal(t2) {
+		t.Errorf("TrackingSince: got %v, want earliest %v", agg.TrackingSince, t2)
+	}
+	// Sorted by tokens saved desc: repo/a (2*15 + 1*8 = 38 ops) beats repo/b (3*15 = 45 ops)?
+	// explore weight 15, query_facts weight 8: a = 38 ops, b = 45 ops -> b first.
+	if agg.Repos[0].RepoPath != "/repo/b" {
+		t.Errorf("expected repo/b first (higher tokens saved), got %q", agg.Repos[0].RepoPath)
+	}
+}
+
+func TestAggregateUsageMissingDir(t *testing.T) {
+	agg, err := AggregateUsage(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if len(agg.Repos) != 0 || len(agg.Combined) != 0 {
+		t.Error("missing dir should yield empty aggregate")
+	}
+}
+
+func TestAggregateUsageSkipsMalformed(t *testing.T) {
+	dir := t.TempDir()
+	for name, content := range map[string]string{"bad.json": "{not json", "note.txt": "ignored"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeUsage(t, dir, StatusInfo{RepoPath: "/repo/a", ToolCounts: map[string]int{"explore": 1}})
+
+	agg, err := AggregateUsage(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agg.Repos) != 1 {
+		t.Errorf("should skip malformed/non-json: got %d repos, want 1", len(agg.Repos))
+	}
+}

--- a/pkg/status/alive_unix.go
+++ b/pkg/status/alive_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package status
+
+import (
+	"os"
+	"syscall"
+)
+
+// isProcessAlive reports whether a process with the given PID is running.
+// On Unix, signal 0 performs the existence/permission check without delivering
+// a signal.
+func isProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return syscall.Kill(p.Pid, 0) == nil
+}

--- a/pkg/status/alive_windows.go
+++ b/pkg/status/alive_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package status
+
+import "golang.org/x/sys/windows"
+
+// stillActive is the exit code Windows reports for a process that is still
+// running (STILL_ACTIVE). A process that genuinely exits with code 259 would be
+// misreported as alive, which is an acceptable edge case for a status check.
+const stillActive = 259
+
+// isProcessAlive reports whether a process with the given PID is running.
+// Windows has no signal-0 check, so we open the process and query its exit code.
+func isProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}

--- a/pkg/status/dashboard_port_test.go
+++ b/pkg/status/dashboard_port_test.go
@@ -1,0 +1,39 @@
+package status
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDashboardPortRoundTrip verifies the dashboard port set on the tracker is
+// persisted via PersistStartup and resurfaces through AggregateServer/
+// ServerSnapshot — the path that lets a separate --status process print the URL.
+func TestDashboardPortRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	tr := NewTracker("/tmp/example-repo")
+	tr.SetStartTime(time.Now())
+	tr.SetDashboardPort(45678)
+	tr.PersistStartup()
+
+	dir, err := usageDir()
+	if err != nil {
+		t.Fatalf("usageDir: %v", err)
+	}
+
+	ss := AggregateServer(dir)
+	if !ss.Found {
+		t.Fatal("AggregateServer.Found = false, want true (PersistStartup should have written a file)")
+	}
+	if ss.DashboardPort != 45678 {
+		t.Errorf("AggregateServer.DashboardPort = %d, want 45678", ss.DashboardPort)
+	}
+	if !ss.Alive {
+		t.Error("AggregateServer.Alive = false, want true (current process PID)")
+	}
+
+	// ServerSnapshot resolves usageDir itself and must agree.
+	if got := ServerSnapshot().DashboardPort; got != 45678 {
+		t.Errorf("ServerSnapshot.DashboardPort = %d, want 45678", got)
+	}
+}

--- a/pkg/status/footprint.go
+++ b/pkg/status/footprint.go
@@ -1,0 +1,137 @@
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// charsPerToken is the rough characters-per-token ratio used to convert source
+// bytes into an estimated token count. Matches the engine's own heuristic
+// (pkg/mcputil/mcputil.go approxTokensPerChar = 4).
+const charsPerToken = 4
+
+// snapshotArtifactSubdirs are the rotated/pinned snapshot directories inside
+// .enola/ whose sizes are rolled up rather than listed file-by-file.
+var snapshotArtifactSubdirs = []string{"previous", "baseline"}
+
+// FileSize is a single entry in the .enola footprint.
+type FileSize struct {
+	Name  string // file or subdir name (relative to .enola/)
+	Bytes int64
+	IsDir bool // true for rolled-up subdirs (previous/, baseline/)
+}
+
+// Footprint describes how much snapshotted data lives in .enola/, plus the
+// stats of the snapshot itself (what the user gets to work with without
+// re-parsing the source).
+type Footprint struct {
+	Files      []FileSize // top-level .enola entries, subdirs rolled up
+	TotalBytes int64      // sum of everything under .enola/
+
+	// Snapshot stats (from snapshot.meta.json / receipt.json; zero if absent).
+	FilesIndexed int
+	FilesParsed  int
+	Facts        int
+	Insights     int
+	SourceBytes  int64 // total bytes of indexed source files (os.Stat sum)
+	SourceTokens int   // SourceBytes / charsPerToken
+}
+
+// snapshotMeta is a minimal projection of .enola/snapshot.meta.json. We read the
+// JSON directly rather than importing internal/facts, so a status report never
+// drags the engine's type graph in and stays robust to engine internals.
+type snapshotMeta struct {
+	RepoPath     string `json:"repo_path"`
+	FactCount    int    `json:"fact_count"`
+	InsightCount int    `json:"insight_count"`
+	FilesSeen    int    `json:"files_seen"`
+	FilesParsed  int    `json:"files_parsed"`
+	FileHashes   []struct {
+		Path string `json:"path"`
+	} `json:"file_hashes"`
+}
+
+// ScanFootprint walks the given .enola directory and reads the snapshot metadata
+// to produce a Footprint. It is best-effort: missing or malformed files yield
+// zero values rather than errors.
+func ScanFootprint(enolaDir string) Footprint {
+	var fp Footprint
+
+	entries, err := os.ReadDir(enolaDir)
+	if err != nil {
+		return fp
+	}
+
+	rollup := make(map[string]bool, len(snapshotArtifactSubdirs))
+	for _, d := range snapshotArtifactSubdirs {
+		rollup[d] = true
+	}
+
+	for _, e := range entries {
+		full := filepath.Join(enolaDir, e.Name())
+		if e.IsDir() {
+			size := dirSize(full)
+			fp.Files = append(fp.Files, FileSize{Name: e.Name(), Bytes: size, IsDir: true})
+			fp.TotalBytes += size
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		fp.Files = append(fp.Files, FileSize{Name: e.Name(), Bytes: info.Size()})
+		fp.TotalBytes += info.Size()
+	}
+
+	fp.applySnapshotMeta(enolaDir)
+	return fp
+}
+
+// applySnapshotMeta enriches the footprint with snapshot stats read from
+// snapshot.meta.json, including summing the on-disk size of every indexed source
+// file to estimate how many tokens of code are snapshotted.
+func (fp *Footprint) applySnapshotMeta(enolaDir string) {
+	data, err := os.ReadFile(filepath.Join(enolaDir, "snapshot.meta.json"))
+	if err != nil {
+		return
+	}
+	var meta snapshotMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return
+	}
+
+	fp.Facts = meta.FactCount
+	fp.Insights = meta.InsightCount
+	fp.FilesParsed = meta.FilesParsed
+	fp.FilesIndexed = len(meta.FileHashes)
+	if fp.FilesIndexed == 0 {
+		fp.FilesIndexed = meta.FilesSeen
+	}
+
+	for _, fh := range meta.FileHashes {
+		p := fh.Path
+		if !filepath.IsAbs(p) && meta.RepoPath != "" {
+			p = filepath.Join(meta.RepoPath, p)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		fp.SourceBytes += info.Size()
+	}
+	fp.SourceTokens = int(fp.SourceBytes / charsPerToken)
+}
+
+// dirSize returns the total size of all regular files under dir (recursive).
+func dirSize(dir string) int64 {
+	var total int64
+	_ = filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total
+}

--- a/pkg/status/footprint_test.go
+++ b/pkg/status/footprint_test.go
@@ -1,0 +1,120 @@
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanFootprint(t *testing.T) {
+	repo := t.TempDir()
+	enolaDir := filepath.Join(repo, ".enola")
+	if err := os.MkdirAll(enolaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two source files with known sizes.
+	srcA := filepath.Join(repo, "a.go")
+	srcB := filepath.Join(repo, "pkg", "b.go")
+	if err := os.MkdirAll(filepath.Dir(srcB), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	contentA := make([]byte, 400)
+	contentB := make([]byte, 400)
+	if err := os.WriteFile(srcA, contentA, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcB, contentB, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Minimal snapshot.meta.json referencing the two files by relative path.
+	meta := map[string]any{
+		"repo_path":     repo,
+		"fact_count":    42,
+		"insight_count": 7,
+		"files_parsed":  2,
+		"file_hashes": []map[string]string{
+			{"path": "a.go"},
+			{"path": "pkg/b.go"},
+		},
+	}
+	metaBytes, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(enolaDir, "snapshot.meta.json"), metaBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A facts artifact so the .enola dir has some listed size.
+	if err := os.WriteFile(filepath.Join(enolaDir, "facts.jsonl"), make([]byte, 100), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A rolled-up subdir.
+	prev := filepath.Join(enolaDir, "previous")
+	if err := os.MkdirAll(prev, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prev, "facts.jsonl"), make([]byte, 50), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := ScanFootprint(enolaDir)
+
+	if fp.Facts != 42 {
+		t.Errorf("Facts: got %d, want 42", fp.Facts)
+	}
+	if fp.FilesIndexed != 2 {
+		t.Errorf("FilesIndexed: got %d, want 2", fp.FilesIndexed)
+	}
+	if fp.SourceBytes != 800 {
+		t.Errorf("SourceBytes: got %d, want 800", fp.SourceBytes)
+	}
+	if fp.SourceTokens != 800/charsPerToken {
+		t.Errorf("SourceTokens: got %d, want %d", fp.SourceTokens, 800/charsPerToken)
+	}
+	// total = facts.jsonl(100) + meta(len) + previous/(50)
+	if fp.TotalBytes < 150 {
+		t.Errorf("TotalBytes too small: got %d", fp.TotalBytes)
+	}
+
+	// previous/ must appear as a rolled-up dir entry.
+	var sawPrev bool
+	for _, f := range fp.Files {
+		if f.Name == "previous" {
+			sawPrev = true
+			if !f.IsDir || f.Bytes != 50 {
+				t.Errorf("previous entry: got IsDir=%v bytes=%d, want true/50", f.IsDir, f.Bytes)
+			}
+		}
+	}
+	if !sawPrev {
+		t.Error("expected previous/ subdir in footprint")
+	}
+}
+
+func TestScanFootprintMissingDir(t *testing.T) {
+	fp := ScanFootprint(filepath.Join(t.TempDir(), "does-not-exist"))
+	if fp.TotalBytes != 0 || fp.Facts != 0 {
+		t.Errorf("missing dir should yield zero footprint, got %+v", fp)
+	}
+}
+
+func TestScanFootprintOldFormatNoFileHashes(t *testing.T) {
+	// Old-format meta without file_hashes: source size unknown, but counts and
+	// dir sizes still report.
+	enolaDir := t.TempDir()
+	meta := map[string]any{"fact_count": 10, "files_seen": 5}
+	metaBytes, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(enolaDir, "snapshot.meta.json"), metaBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fp := ScanFootprint(enolaDir)
+	if fp.Facts != 10 {
+		t.Errorf("Facts: got %d, want 10", fp.Facts)
+	}
+	if fp.FilesIndexed != 5 {
+		t.Errorf("FilesIndexed should fall back to files_seen: got %d, want 5", fp.FilesIndexed)
+	}
+	if fp.SourceBytes != 0 {
+		t.Errorf("SourceBytes should be 0 without file_hashes, got %d", fp.SourceBytes)
+	}
+}

--- a/pkg/status/main_test.go
+++ b/pkg/status/main_test.go
@@ -1,0 +1,28 @@
+package status
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain sandboxes the home directory for the entire package test binary, so
+// no test can ever write usage files into the developer's real ~/.enola/usage/.
+// Individual tests may still call t.Setenv("HOME", ...) to point at their own
+// temp dir; this is a backstop for any that forget.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "enola-status-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	for _, key := range []string{
+		"HOME",        // unix/darwin: os.UserHomeDir reads $HOME
+		"USERPROFILE", // windows
+	} {
+		if err := os.Setenv(key, tmp); err != nil {
+			panic(err)
+		}
+	}
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}

--- a/pkg/status/persist_test.go
+++ b/pkg/status/persist_test.go
@@ -1,0 +1,227 @@
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// setupHome points os.UserHomeDir at a temp dir and returns a repo path.
+func setupHome(t *testing.T) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	return t.TempDir()
+}
+
+func readFile(t *testing.T, path string) StatusInfo {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read status file: %v", err)
+	}
+	var info StatusInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatalf("unmarshal status file: %v", err)
+	}
+	return info
+}
+
+// Stats are written to the home store (~/.enola/usage/), keyed by repo, not
+// inside the repo.
+func TestOnToolCallWritesToHomeStore(t *testing.T) {
+	repo := setupHome(t)
+	tr := NewTracker(repo)
+	tr.SetStartTime(time.Now())
+	tr.OnToolCall("explore", repo)
+	tr.OnToolCall("explore", repo)
+	tr.OnToolCall("query_facts", repo)
+
+	homePath, err := usagePath(canonicalRepoPath(repo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(homePath); err != nil {
+		t.Fatalf("expected home store file at %s: %v", homePath, err)
+	}
+	if _, err := os.Stat(legacyPath(repo)); err == nil {
+		t.Error("no file should be written to the legacy in-repo location")
+	}
+
+	info := readFile(t, homePath)
+	if info.ToolCounts["explore"] != 2 || info.SessionCounts["explore"] != 2 {
+		t.Errorf("explore: total=%d session=%d, want 2/2", info.ToolCounts["explore"], info.SessionCounts["explore"])
+	}
+	if info.TrackingSince.IsZero() {
+		t.Error("TrackingSince should be stamped on first run")
+	}
+	if info.RepoPath != canonicalRepoPath(repo) {
+		t.Errorf("RepoPath: got %q, want %q", info.RepoPath, canonicalRepoPath(repo))
+	}
+}
+
+// Usage is attributed to the repo each call reports, even from one tracker.
+func TestOnToolCallAttributesPerRepo(t *testing.T) {
+	_ = setupHome(t)
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	tr := NewTracker(repoA) // fallback repoA
+	tr.SetStartTime(time.Now())
+	tr.OnToolCall("explore", repoA)
+	tr.OnToolCall("impact_analysis", repoB)
+	tr.OnToolCall("impact_analysis", repoB)
+
+	a := tr.GetStatus(repoA)
+	b := tr.GetStatus(repoB)
+	if a.ToolCounts["explore"] != 1 || a.ToolCounts["impact_analysis"] != 0 {
+		t.Errorf("repoA counts wrong: %+v", a.ToolCounts)
+	}
+	if b.ToolCounts["impact_analysis"] != 2 || b.ToolCounts["explore"] != 0 {
+		t.Errorf("repoB counts wrong: %+v", b.ToolCounts)
+	}
+
+	// Each repo has its own file.
+	pa, _ := usagePath(canonicalRepoPath(repoA))
+	pb, _ := usagePath(canonicalRepoPath(repoB))
+	if pa == pb {
+		t.Fatal("repoA and repoB must map to different files")
+	}
+	readFile(t, pa)
+	readFile(t, pb)
+}
+
+// An empty repo argument falls back to the tracker's fallback repo.
+func TestOnToolCallEmptyRepoUsesFallback(t *testing.T) {
+	_ = setupHome(t)
+	fallback := t.TempDir()
+	tr := NewTracker(fallback)
+	tr.SetStartTime(time.Now())
+	tr.OnToolCall("explore", "")
+
+	if tr.GetStatus(fallback).ToolCounts["explore"] != 1 {
+		t.Error("empty repo should attribute to the fallback repo")
+	}
+}
+
+// After a "restart" (new tracker), a repo's lifetime total is carried forward
+// on first touch while the session starts empty.
+func TestAccumulatesAcrossRestart(t *testing.T) {
+	repo := setupHome(t)
+
+	tr1 := NewTracker(repo)
+	start1 := time.Now().Add(-time.Hour)
+	tr1.SetStartTime(start1)
+	tr1.OnToolCall("explore", repo)
+	tr1.OnToolCall("explore", repo)
+	tr1.OnToolCall("query_facts", repo)
+
+	tr2 := NewTracker(repo)
+	tr2.SetStartTime(time.Now())
+	tr2.OnToolCall("explore", repo)         // total 3, session 1
+	tr2.OnToolCall("impact_analysis", repo) // total 1, session 1
+
+	info := tr2.GetStatus(repo)
+	if info.ToolCounts["explore"] != 3 {
+		t.Errorf("explore grand total: got %d, want 3", info.ToolCounts["explore"])
+	}
+	if info.SessionCounts["explore"] != 1 {
+		t.Errorf("explore session: got %d, want 1", info.SessionCounts["explore"])
+	}
+	if info.ToolCounts["query_facts"] != 1 {
+		t.Errorf("query_facts grand total (from baseline): got %d, want 1", info.ToolCounts["query_facts"])
+	}
+	if _, ok := info.SessionCounts["query_facts"]; ok {
+		t.Error("query_facts should not appear in session 2 (only in baseline)")
+	}
+	if !info.TrackingSince.Equal(start1) {
+		t.Errorf("TrackingSince: got %v, want %v (from first session)", info.TrackingSince, start1)
+	}
+}
+
+// A legacy in-repo status file is migrated to the home store on first touch,
+// and the legacy file is removed.
+func TestMigratesLegacyFile(t *testing.T) {
+	repo := setupHome(t)
+
+	legacyDir := filepath.Join(repo, ".enola")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"pid":123,"start_time":"2020-01-01T00:00:00Z","repo_path":"` + repo + `","tool_counts":{"explore":5}}`
+	if err := os.WriteFile(legacyPath(repo), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := NewTracker(repo)
+	tr.SetStartTime(time.Now())
+	tr.OnToolCall("explore", repo) // triggers migration, then +1
+
+	homePath, _ := usagePath(canonicalRepoPath(repo))
+	info := readFile(t, homePath)
+	if info.ToolCounts["explore"] != 6 {
+		t.Errorf("migrated total + 1 call: got %d, want 6", info.ToolCounts["explore"])
+	}
+	if _, err := os.Stat(legacyPath(repo)); !os.IsNotExist(err) {
+		t.Error("legacy file should be removed after migration")
+	}
+}
+
+// A migration whose home-store write fails must NOT delete the legacy file, so
+// the accumulated usage data survives and migration is retried on the next call.
+func TestMigrationPreservesLegacyOnWriteFailure(t *testing.T) {
+	repo := setupHome(t)
+
+	// Seed a legacy in-repo status file with real accumulated counts.
+	legacyDir := filepath.Join(repo, ".enola")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"pid":123,"start_time":"2020-01-01T00:00:00Z","repo_path":"` + repo + `","tool_counts":{"explore":5}}`
+	if err := os.WriteFile(legacyPath(repo), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sabotage the home store: create ~/.enola/usage as a *regular file* so the
+	// migrating write's MkdirAll of that directory fails ("not a directory").
+	// Deterministic across platforms and unaffected by running as root, unlike
+	// chmod-based permission tricks.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".enola"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".enola", "usage"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := NewTracker(repo)
+	tr.SetStartTime(time.Now())
+	tr.OnToolCall("explore", repo) // triggers migration; home write fails
+
+	// The legacy file must still be present with its data intact.
+	if _, err := os.Stat(legacyPath(repo)); err != nil {
+		t.Fatalf("legacy file must survive a failed migration write: %v", err)
+	}
+	info, _, err := ReadStatus(legacyPath(repo))
+	if err != nil {
+		t.Fatalf("legacy file unreadable after failed migration: %v", err)
+	}
+	if info.ToolCounts["explore"] != 5 {
+		t.Errorf("legacy data corrupted: explore=%d, want 5", info.ToolCounts["explore"])
+	}
+}
+
+// A fresh tracker with nothing on disk counts normally.
+func TestFreshStart(t *testing.T) {
+	repo := setupHome(t)
+	tr := NewTracker(repo)
+	tr.SetStartTime(time.Now())
+	tr.OnToolCall("explore", repo)
+	if tr.GetStatus(repo).ToolCounts["explore"] != 1 {
+		t.Error("fresh tracker should count normally")
+	}
+}

--- a/pkg/status/server_test.go
+++ b/pkg/status/server_test.go
@@ -1,0 +1,73 @@
+package status
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAggregateServer(t *testing.T) {
+	dir := t.TempDir()
+
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	older := now.Add(-48 * time.Hour)
+	trackA := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	trackB := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) // earliest
+
+	// Two repos from the current run (same newest StartTime).
+	writeUsage(t, dir, StatusInfo{
+		RepoPath: "/repo/a", PID: os.Getpid(), StartTime: now, TrackingSince: trackA,
+		ToolCounts:    map[string]int{"explore": 5, "query_facts": 2},
+		SessionCounts: map[string]int{"explore": 3},
+	})
+	writeUsage(t, dir, StatusInfo{
+		RepoPath: "/repo/b", PID: os.Getpid(), StartTime: now, TrackingSince: trackB,
+		ToolCounts:    map[string]int{"explore": 1},
+		SessionCounts: map[string]int{"explore": 1},
+	})
+	// A repo last touched in an EARLIER run: counts in grand total, but its
+	// stale session must be excluded.
+	writeUsage(t, dir, StatusInfo{
+		RepoPath: "/repo/c", PID: 999999, StartTime: older, TrackingSince: trackA,
+		ToolCounts:    map[string]int{"generate_snapshot": 4},
+		SessionCounts: map[string]int{"generate_snapshot": 4},
+	})
+
+	ss := AggregateServer(dir)
+	if !ss.Found {
+		t.Fatal("expected Found=true")
+	}
+	if ss.Repos != 3 {
+		t.Errorf("Repos: got %d, want 3", ss.Repos)
+	}
+	// Grand total sums all three files.
+	if ss.GrandTotal["explore"] != 6 || ss.GrandTotal["query_facts"] != 2 || ss.GrandTotal["generate_snapshot"] != 4 {
+		t.Errorf("GrandTotal wrong: %+v", ss.GrandTotal)
+	}
+	// Session sums only the current-run files (a+b), not c.
+	if ss.Session["explore"] != 4 {
+		t.Errorf("Session explore: got %d, want 4 (3+1, excluding older run)", ss.Session["explore"])
+	}
+	if _, ok := ss.Session["generate_snapshot"]; ok {
+		t.Error("stale session from older run must be excluded")
+	}
+	if !ss.StartTime.Equal(now) {
+		t.Errorf("StartTime: got %v, want newest %v", ss.StartTime, now)
+	}
+	if ss.PID != os.Getpid() {
+		t.Errorf("PID: got %d, want current-run pid %d", ss.PID, os.Getpid())
+	}
+	if !ss.Alive {
+		t.Error("Alive should be true (current process pid is alive)")
+	}
+	if !ss.TrackingSince.Equal(trackB) {
+		t.Errorf("TrackingSince: got %v, want earliest %v", ss.TrackingSince, trackB)
+	}
+}
+
+func TestAggregateServerEmpty(t *testing.T) {
+	ss := AggregateServer(t.TempDir())
+	if ss.Found {
+		t.Error("empty dir should yield Found=false")
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,392 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// StatusFile is the name of the status file written to .enola/.
+const StatusFile = ".enola-status.json"
+
+// StatusInfo holds the serializable status data.
+//
+// ToolCounts is the lifetime grand total (accumulated across server restarts);
+// SessionCounts is the usage of the current process only (since the last
+// reload). Both are persisted so a separate --status invocation, which only
+// reads this file, can render both tiers.
+type StatusInfo struct {
+	PID           int            `json:"pid"`
+	StartTime     time.Time      `json:"start_time"`               // current process start (drives Uptime)
+	TrackingSince time.Time      `json:"tracking_since,omitempty"` // first-ever start (drives grand-total window)
+	RepoPath      string         `json:"repo_path"`
+	ToolCounts    map[string]int `json:"tool_counts"`              // lifetime grand total
+	SessionCounts map[string]int `json:"session_counts,omitempty"` // since last reload
+
+	// DashboardPort is the localhost port of an HTTP dashboard served by this
+	// process (0 if none). It is persisted so a separate --status invocation,
+	// which never talks to the running server, can print the dashboard URL.
+	//
+	// The OSS server serves no dashboard and always leaves this zero; a wrapper
+	// binary that does sets it via Tracker.SetDashboardPort. Because both share
+	// ~/.enola/usage/, an OSS --status may read a file written by such a wrapper
+	// — printing that URL is correct, since it points at the server that is
+	// actually running.
+	DashboardPort int `json:"dashboard_port,omitempty"`
+}
+
+// Tracker accumulates per-repo tool usage counters and manages the on-disk
+// status files. A single server can serve many repos over its lifetime, so
+// usage is attributed to the repo each call actually operated on (passed to
+// OnToolCall) rather than to a single fixed repo.
+//
+// Each repo gets its own repoState and its own file under ~/.enola/usage/.
+type Tracker struct {
+	mu            sync.Mutex
+	start         time.Time
+	dashboardPort int    // localhost HTTP dashboard port (0 if none), persisted per write
+	fallbackRepo  string // used when a call reports an empty repo path
+	repos         map[string]*repoState
+}
+
+// repoState holds one repo's counters. baseline is the lifetime total loaded
+// from disk (immutable for the process); session is this process's increments.
+// The persisted grand total is baseline + session.
+type repoState struct {
+	repoPath      string
+	filePath      string
+	baseline      map[string]int
+	session       map[string]int
+	trackingSince time.Time
+}
+
+// NewTracker creates a multi-repo tracker. fallbackRepo (typically the server's
+// launch dir) is used to attribute calls that report an empty repo path.
+func NewTracker(fallbackRepo string) *Tracker {
+	return &Tracker{
+		fallbackRepo: canonicalRepoPath(fallbackRepo),
+		repos:        make(map[string]*repoState),
+	}
+}
+
+// SetStartTime records the current process start time (drives Uptime).
+func (t *Tracker) SetStartTime(tm time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.start = tm
+}
+
+// SetDashboardPort records the localhost HTTP dashboard port so it is persisted
+// with every status write and can be surfaced by a separate --status process.
+func (t *Tracker) SetDashboardPort(p int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.dashboardPort = p
+}
+
+// PersistStartup writes the fallback repo's status file once at startup, so a
+// usage file carrying this process's PID, start time and dashboard port exists
+// even before the first tool call is recorded. Best-effort.
+func (t *Tracker) PersistStartup() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.writeLocked(t.stateLocked(t.fallbackRepo))
+}
+
+// OnToolCall is the callback registered with the server. repo is the absolute
+// path of the repo the call operated on; an empty repo falls back to the
+// tracker's fallback repo.
+func (t *Tracker) OnToolCall(toolName, repo string) {
+	if repo == "" {
+		repo = t.fallbackRepo
+	}
+	repo = canonicalRepoPath(repo)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	rs := t.stateLocked(repo)
+	rs.session[toolName]++
+	t.writeLocked(rs)
+}
+
+// GetStatus returns the current status snapshot for a single repo. Caller need
+// not hold the lock.
+func (t *Tracker) GetStatus(repo string) StatusInfo {
+	repo = canonicalRepoPath(repo)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.infoLocked(t.stateLocked(repo))
+}
+
+// stateLocked returns the repoState for repo, lazily creating it and loading
+// its baseline (with legacy migration) from disk on first touch. Caller holds t.mu.
+func (t *Tracker) stateLocked(repo string) *repoState {
+	if rs, ok := t.repos[repo]; ok {
+		return rs
+	}
+	rs := &repoState{
+		repoPath: repo,
+		baseline: make(map[string]int),
+		session:  make(map[string]int),
+	}
+	fp, err := usagePath(repo)
+	if err != nil {
+		fp = legacyPath(repo)
+	}
+	rs.filePath = fp
+	t.repos[repo] = rs
+
+	t.loadLocked(rs)
+	if rs.trackingSince.IsZero() {
+		rs.trackingSince = t.start
+	}
+	return rs
+}
+
+// loadLocked seeds a repoState's baseline from its home file, or migrates a
+// legacy in-repo file (adopt totals, write through to home, remove legacy).
+// Best-effort. Caller holds t.mu.
+func (t *Tracker) loadLocked(rs *repoState) {
+	info, _, err := ReadStatus(rs.filePath)
+	migrated := false
+	if err != nil {
+		legacy := legacyPath(rs.repoPath)
+		if legacy == rs.filePath {
+			return // already using the legacy location; nothing to migrate
+		}
+		info, _, err = ReadStatus(legacy)
+		if err != nil {
+			return // nothing to load; fresh start
+		}
+		migrated = true
+	}
+
+	for k, v := range info.ToolCounts {
+		rs.baseline[k] = v
+	}
+	rs.trackingSince = info.TrackingSince
+	if migrated {
+		// Only remove the legacy file once the write to its new home has
+		// actually succeeded. If the write fails (disk full, permission
+		// denied, unwritable dir), leave the legacy file intact so the data
+		// survives and migration is retried on the next call.
+		if err := t.writeLockedErr(rs); err == nil {
+			_ = os.Remove(legacyPath(rs.repoPath))
+		}
+	}
+}
+
+// infoLocked builds a StatusInfo (grand total + session) for a repo. Caller holds t.mu.
+func (t *Tracker) infoLocked(rs *repoState) StatusInfo {
+	total := make(map[string]int, len(rs.baseline)+len(rs.session))
+	for k, v := range rs.baseline {
+		total[k] = v
+	}
+	for k, v := range rs.session {
+		total[k] += v
+	}
+	session := make(map[string]int, len(rs.session))
+	for k, v := range rs.session {
+		session[k] = v
+	}
+	return StatusInfo{
+		PID:           os.Getpid(),
+		StartTime:     t.start,
+		TrackingSince: rs.trackingSince,
+		RepoPath:      rs.repoPath,
+		ToolCounts:    total,
+		SessionCounts: session,
+		DashboardPort: t.dashboardPort,
+	}
+}
+
+// writeLocked persists a repo's counters to its file, best-effort. Caller holds t.mu.
+func (t *Tracker) writeLocked(rs *repoState) {
+	_ = t.writeLockedErr(rs)
+}
+
+// writeLockedErr persists a repo's counters to its file and returns any error,
+// so callers that must not act on a failed write (e.g. legacy-file migration)
+// can check it. Caller holds t.mu.
+func (t *Tracker) writeLockedErr(rs *repoState) error {
+	data, err := json.MarshalIndent(t.infoLocked(rs), "", "  ")
+	if err != nil {
+		return err
+	}
+	// Ensure the containing directory exists (~/.enola/usage or legacy .enola).
+	if err := os.MkdirAll(filepath.Dir(rs.filePath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(rs.filePath, data, 0o644)
+}
+
+// ReadStatus reads and validates a status file at the given path.
+func ReadStatus(path string) (StatusInfo, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return StatusInfo{}, false, err
+	}
+	var info StatusInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return StatusInfo{}, false, err
+	}
+	// Check if PID is still alive
+	alive := isProcessAlive(info.PID)
+	return info, alive, nil
+}
+
+// ServerSnapshot returns the aggregated cross-repo server view (the same data
+// PrintStatus renders), resolving the usage directory itself. It is the exported
+// entry point for consumers outside this package, such as the HTTP dashboard.
+// A missing/unreadable usage directory yields a zero-value (Found=false) status.
+func ServerSnapshot() ServerStatus {
+	dir, err := usageDir()
+	if err != nil {
+		return ServerStatus{}
+	}
+	return AggregateServer(dir)
+}
+
+// PrintStatus prints the MCP server's activity — the historical grand total and
+// the current session — aggregated across every repo the server has served. It
+// is independent of the current working directory. The per-repo breakdown is
+// available via PrintStatusAll (--status --all).
+func PrintStatus() {
+	dir, err := usageDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "No status available: %v\n", err)
+		return
+	}
+	ss := AggregateServer(dir)
+	if !ss.Found {
+		fmt.Fprintf(os.Stderr, "No usage recorded yet.\n")
+		fmt.Fprintf(os.Stderr, "Start the MCP server, then run with --status (or --status --all).\n")
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "\n=== enola MCP Status ===\n")
+
+	if ss.Alive {
+		fmt.Fprintf(os.Stderr, "Server:    running (PID %d)\n", ss.PID)
+		fmt.Fprintf(os.Stderr, "Uptime:    %s\n", formatDuration(time.Since(ss.StartTime)))
+		if ss.DashboardPort > 0 {
+			fmt.Fprintf(os.Stderr, "Dashboard: http://127.0.0.1:%d (auto-refreshes every 30s)\n", ss.DashboardPort)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Server:    not running (was PID %d)\n", ss.PID)
+		if !ss.StartTime.IsZero() {
+			fmt.Fprintf(os.Stderr, "Started at: %s\n", ss.StartTime.Format("2006-01-02 15:04:05"))
+		}
+	}
+
+	if !ss.TrackingSince.IsZero() {
+		fmt.Fprintf(os.Stderr, "Tracking since: %s\n", ss.TrackingSince.Format("2006-01-02 15:04:05"))
+	}
+	fmt.Fprintf(os.Stderr, "Repos tracked: %d\n", ss.Repos)
+
+	printToolUsage(ss.GrandTotal, ss.Session)
+	printValue(ss.GrandTotal, ss.Session)
+	fmt.Fprintf(os.Stderr, "\n")
+}
+
+// printToolUsage renders per-tool call counts in two tiers: session (current
+// process, since last reload) and total (lifetime grand total).
+func printToolUsage(total, session map[string]int) {
+	fmt.Fprintf(os.Stderr, "\nTool Usage:\n")
+	if len(total) == 0 {
+		fmt.Fprintf(os.Stderr, "  (no tool calls yet)\n")
+		return
+	}
+
+	// Union of tool names, sorted.
+	names := sortedUnion(total, session)
+
+	maxLen := len("tool")
+	for _, name := range names {
+		if len(name) > maxLen {
+			maxLen = len(name)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "  %-*s  %8s  %8s\n", maxLen, "tool", "session", "total")
+	for _, name := range names {
+		fmt.Fprintf(os.Stderr, "  %-*s  %8d  %8d\n", maxLen, name, session[name], total[name])
+	}
+}
+
+// sortedUnion returns the sorted union of the keys of the given maps.
+func sortedUnion(maps ...map[string]int) []string {
+	set := make(map[string]struct{})
+	for _, m := range maps {
+		for k := range m {
+			set[k] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(set))
+	for k := range set {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// printValue renders the estimated time and context (tokens) saved by the
+// recorded tool usage. The per-tool table and grand TOTAL are computed on the
+// lifetime totals; a trailing line adds the current-session subtotal. Figures
+// are estimates from a static per-tool model.
+func printValue(total, session map[string]int) {
+	if len(total) == 0 {
+		return
+	}
+	rep := ComputeValue(total)
+
+	fmt.Fprintf(os.Stderr, "\nValue Estimate (approximate):\n")
+
+	// Align the tool column to the longest name.
+	maxLen := len("this session")
+	for _, tv := range rep.Tools {
+		if len(tv.Tool) > maxLen {
+			maxLen = len(tv.Tool)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "  %-*s  %6s  %12s  %14s\n", maxLen, "tool", "calls", "~time saved", "~tokens saved")
+	for _, tv := range rep.Tools {
+		fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
+			maxLen, tv.Tool, tv.Calls, formatDuration(tv.TimeSaved), humanCount(tv.TokensSaved))
+	}
+	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
+		maxLen, "TOTAL", rep.TotalCalls, formatDuration(rep.TotalTimeSaved), humanCount(rep.TotalTokensSaved))
+
+	sess := ComputeValue(session)
+	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
+		maxLen, "this session", sess.TotalCalls, formatDuration(sess.TotalTimeSaved), humanCount(sess.TotalTokensSaved))
+}
+
+// humanCount renders a large count with thousands/millions suffixes (e.g. 1.2M).
+func humanCount(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm %ds", hours, minutes, seconds)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}

--- a/pkg/status/store.go
+++ b/pkg/status/store.go
@@ -1,0 +1,83 @@
+package status
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Usage stats are stored per-repo under the user's home directory so they
+// survive deletion of the repo (and its ephemeral .enola/ snapshot dir):
+//
+//	~/.enola/usage/<repo-base>-<hash8>.json
+//
+// Keying by absolute repo path means each server writes only its own file (no
+// cross-repo write contention), and the folder can be aggregated by reading it.
+
+// canonicalRepoPath normalizes a repo path so the same repo always maps to the
+// same usage key regardless of how it was referenced — making it absolute and
+// resolving symlinks (e.g. macOS /var → /private/var). Falls back gracefully if
+// the path can't be resolved (e.g. it doesn't exist yet).
+func canonicalRepoPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = p
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}
+
+// usageDir returns the directory holding per-repo usage files.
+func usageDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".enola", "usage"), nil
+}
+
+// usageKey derives a stable, human-readable filename stem for a repo from its
+// absolute path: the sanitized base name plus a short hash of the full path
+// (so two repos with the same base name don't collide).
+func usageKey(absRepoPath string) string {
+	sum := sha256.Sum256([]byte(absRepoPath))
+	short := hex.EncodeToString(sum[:])[:8]
+	base := sanitizeBase(filepath.Base(absRepoPath))
+	if base == "" {
+		base = "repo"
+	}
+	return base + "-" + short
+}
+
+// usagePath returns the per-repo usage file path under usageDir().
+func usagePath(absRepoPath string) (string, error) {
+	dir, err := usageDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, usageKey(absRepoPath)+".json"), nil
+}
+
+// legacyPath returns the old in-repo status file location, used for migration
+// and back-compat reads.
+func legacyPath(absRepoPath string) string {
+	return filepath.Join(absRepoPath, ".enola", StatusFile)
+}
+
+// sanitizeBase keeps a repo base name safe for use as a filename stem.
+func sanitizeBase(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}

--- a/pkg/status/store_test.go
+++ b/pkg/status/store_test.go
@@ -1,0 +1,57 @@
+package status
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUsageKeyDeterministicAndDistinct(t *testing.T) {
+	a1 := usageKey("/src/enola")
+	a2 := usageKey("/src/enola")
+	b := usageKey("/src/vendored/enola")
+
+	if a1 != a2 {
+		t.Errorf("usageKey not stable for same path: %q vs %q", a1, a2)
+	}
+	if a1 == b {
+		t.Error("usageKey should differ for different paths")
+	}
+	// Human-readable base is preserved.
+	if !strings.HasPrefix(a1, "enola-") {
+		t.Errorf("usageKey should start with the repo base name: %q", a1)
+	}
+	// Two repos sharing a base name must not collide (hash disambiguates).
+	x := usageKey("/a/proj")
+	y := usageKey("/b/proj")
+	if x == y {
+		t.Error("same base name in different dirs must produce different keys")
+	}
+}
+
+func TestUsagePathUnderUsageDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir, err := usageDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := usagePath("/some/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(p) != dir {
+		t.Errorf("usagePath dir = %q, want %q", filepath.Dir(p), dir)
+	}
+	if filepath.Ext(p) != ".json" {
+		t.Errorf("usagePath should end in .json: %q", p)
+	}
+}
+
+func TestSanitizeBase(t *testing.T) {
+	if got := sanitizeBase("my repo/weird:name"); strings.ContainsAny(got, " /:") {
+		t.Errorf("sanitizeBase left unsafe chars: %q", got)
+	}
+	if got := sanitizeBase("ok-name_1.2"); got != "ok-name_1.2" {
+		t.Errorf("sanitizeBase mangled safe chars: %q", got)
+	}
+}

--- a/pkg/status/value.go
+++ b/pkg/status/value.go
@@ -1,0 +1,128 @@
+package status
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// The value model converts raw tool-call counts into two human-meaningful
+// factors: time saved and tokens (context) saved. Each tool is assigned a
+// single weight — the number of manual operations (file reads, greps, symbol
+// lookups) a caller would otherwise perform to get the same answer. Two global
+// constants convert that weight into wall-clock time and token estimates.
+//
+// These are deliberately estimates: they are derived entirely from call counts
+// and a static table, with no changes to the engine itself. Tune the numbers
+// freely — the model is one weight per tool plus two conversion constants.
+const (
+	// secondsPerManualOp is the assumed wall-clock cost of one manual lookup
+	// (open a file, read it, decide) that a single tool call replaces.
+	secondsPerManualOp = 30
+
+	// tokensPerManualOp is the assumed context cost of one manual lookup —
+	// roughly the tokens of an average source file an agent would read.
+	tokensPerManualOp = 2000
+
+	// defaultWeight is used for any tool name not in toolWeights, so the value
+	// model degrades gracefully if the tool set grows.
+	defaultWeight = 5
+)
+
+// toolWeights maps each tool to the number of manual operations one call of it
+// replaces. It covers the tools this engine registers (see pkg/cli.OSSTools);
+// a wrapper binary that adds its own MCP tools prices them via
+// RegisterToolWeights rather than by editing this table.
+//
+// weightsMu guards the map: registration happens once at startup, but reads run
+// from the MCP server's tool callback and, in wrapper binaries, from concurrent
+// HTTP handlers.
+var (
+	weightsMu   sync.RWMutex
+	toolWeights = map[string]int{
+		"show_symbol":       3,
+		"snapshot_receipt":  3,
+		"set_baseline":      4,
+		"query_facts":       8,
+		"compare_receipts":  10,
+		"traverse":          10,
+		"find_path":         12,
+		"explore":           15,
+		"diff_snapshot":     15,
+		"coverage_report":   20,
+		"impact_analysis":   25,
+		"query_insights":    30,
+		"generate_snapshot": 100,
+	}
+)
+
+// RegisterToolWeights merges caller-supplied per-tool weights into the value
+// model, so a wrapper binary that registers additional MCP tools can price them
+// instead of letting them fall back to defaultWeight. Call it during startup,
+// before the server begins serving. Later registrations win for a given tool.
+func RegisterToolWeights(extra map[string]int) {
+	weightsMu.Lock()
+	defer weightsMu.Unlock()
+	for tool, w := range extra {
+		toolWeights[tool] = w
+	}
+}
+
+// weightFor returns the manual-ops-avoided weight for a tool. This is the single
+// lookup point for the value model; a future config- or license-sourced override
+// (e.g. per-customer tuning or usage gating) would slot in here.
+func weightFor(tool string) int {
+	weightsMu.RLock()
+	defer weightsMu.RUnlock()
+	if w, ok := toolWeights[tool]; ok {
+		return w
+	}
+	return defaultWeight
+}
+
+// ToolValue is the estimated value delivered by a single tool.
+type ToolValue struct {
+	Tool             string
+	Calls            int
+	ManualOpsAvoided int
+	TimeSaved        time.Duration
+	TokensSaved      int
+}
+
+// ValueReport aggregates per-tool value plus totals.
+type ValueReport struct {
+	Tools            []ToolValue // sorted by tool name
+	TotalCalls       int
+	TotalManualOps   int
+	TotalTimeSaved   time.Duration
+	TotalTokensSaved int
+}
+
+// ComputeValue turns raw tool-call counts into an estimated value report.
+func ComputeValue(counts map[string]int) ValueReport {
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var rep ValueReport
+	rep.Tools = make([]ToolValue, 0, len(names))
+	for _, name := range names {
+		calls := counts[name]
+		ops := calls * weightFor(name)
+		tv := ToolValue{
+			Tool:             name,
+			Calls:            calls,
+			ManualOpsAvoided: ops,
+			TimeSaved:        time.Duration(ops) * secondsPerManualOp * time.Second,
+			TokensSaved:      ops * tokensPerManualOp,
+		}
+		rep.Tools = append(rep.Tools, tv)
+		rep.TotalCalls += calls
+		rep.TotalManualOps += ops
+		rep.TotalTimeSaved += tv.TimeSaved
+		rep.TotalTokensSaved += tv.TokensSaved
+	}
+	return rep
+}

--- a/pkg/status/value_test.go
+++ b/pkg/status/value_test.go
@@ -1,0 +1,95 @@
+package status
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeValue(t *testing.T) {
+	counts := map[string]int{
+		"generate_snapshot": 2, // weight 100 -> 200 ops
+		"query_facts":       3, // weight 8   -> 24 ops
+		"mystery_tool":      4, // unknown    -> defaultWeight 5 -> 20 ops
+	}
+
+	rep := ComputeValue(counts)
+
+	// Tools are sorted by name.
+	if len(rep.Tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(rep.Tools))
+	}
+	if rep.Tools[0].Tool != "generate_snapshot" {
+		t.Errorf("expected first tool sorted as generate_snapshot, got %q", rep.Tools[0].Tool)
+	}
+
+	// Unknown tool falls back to defaultWeight.
+	var mystery ToolValue
+	for _, tv := range rep.Tools {
+		if tv.Tool == "mystery_tool" {
+			mystery = tv
+		}
+	}
+	if mystery.ManualOpsAvoided != 4*defaultWeight {
+		t.Errorf("mystery_tool ops: got %d, want %d", mystery.ManualOpsAvoided, 4*defaultWeight)
+	}
+
+	// Totals: 200 + 24 + 20 = 244 manual ops.
+	wantOps := 200 + 24 + 20
+	if rep.TotalManualOps != wantOps {
+		t.Errorf("TotalManualOps: got %d, want %d", rep.TotalManualOps, wantOps)
+	}
+	if rep.TotalCalls != 9 {
+		t.Errorf("TotalCalls: got %d, want 9", rep.TotalCalls)
+	}
+	wantTime := time.Duration(wantOps) * secondsPerManualOp * time.Second
+	if rep.TotalTimeSaved != wantTime {
+		t.Errorf("TotalTimeSaved: got %s, want %s", rep.TotalTimeSaved, wantTime)
+	}
+	if rep.TotalTokensSaved != wantOps*tokensPerManualOp {
+		t.Errorf("TotalTokensSaved: got %d, want %d", rep.TotalTokensSaved, wantOps*tokensPerManualOp)
+	}
+}
+
+func TestComputeValueEmpty(t *testing.T) {
+	rep := ComputeValue(map[string]int{})
+	if len(rep.Tools) != 0 || rep.TotalCalls != 0 || rep.TotalTokensSaved != 0 {
+		t.Errorf("empty counts should yield zero-value report, got %+v", rep)
+	}
+}
+
+func TestWeightForKnownTools(t *testing.T) {
+	// Every tool in the catalog should have an explicit (non-default) weight so
+	// the value model is intentional rather than falling through.
+	for _, tool := range []string{
+		"generate_snapshot", "explore", "query_facts", "show_symbol", "traverse",
+		"find_path", "impact_analysis", "coverage_report", "query_insights",
+		"set_baseline", "diff_snapshot", "snapshot_receipt", "compare_receipts",
+	} {
+		if _, ok := toolWeights[tool]; !ok {
+			t.Errorf("tool %q has no explicit weight in toolWeights", tool)
+		}
+	}
+}
+
+func TestRegisterToolWeights(t *testing.T) {
+	const tool = "wrapper_only_tool"
+	t.Cleanup(func() {
+		weightsMu.Lock()
+		delete(toolWeights, tool)
+		weightsMu.Unlock()
+	})
+
+	if got := weightFor(tool); got != defaultWeight {
+		t.Fatalf("unregistered tool weight: got %d, want defaultWeight %d", got, defaultWeight)
+	}
+
+	RegisterToolWeights(map[string]int{tool: 42})
+	if got := weightFor(tool); got != 42 {
+		t.Errorf("registered tool weight: got %d, want 42", got)
+	}
+
+	// A registration must not disturb the built-in weights.
+	if got := weightFor("generate_snapshot"); got != 100 {
+		t.Errorf("generate_snapshot weight after registration: got %d, want 100", got)
+	}
+}


### PR DESCRIPTION
Introduces two public packages. pkg/cli renders what the binary prints about itself: the tool catalogue behind --list, and a composable help spec behind --help (usage, flags, config path, examples, MCP configuration, build), which also documents the previously undocumented `upgrade` command. pkg/status records per-tool usage under ~/.enola/usage/, keyed by absolute repo path so counters survive both a restart and deleting .enola/, letting --status report uptime, session and lifetime call counts, and an estimate of the time and context those calls saved; --status --all breaks the same data down per repo. The server wires a status.Tracker as its tool callback so calls are attributed to the repo each one actually operated on. Two e2e tests keep it honest: one asserts the --list catalogue is exactly the set of tools the running server registers, the other drives real MCP calls and checks the recorded counters and value report. README gains a command-line reference; ARCHITECTURE documents both packages.