### PR TITLE
Add a read-only localhost dashboard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,7 +217,7 @@ The shared module-graph construction and statistical-outlier helpers used by sev
 
 ---
 
-## The CLI surface (`pkg/cli` and `pkg/status`)
+## The CLI surface (`pkg/cli`, `pkg/status` and `pkg/dashboard`)
 
 `--help`, `--list` and `--status` are served from two public packages, for the same reason as `pkg/explain`: a wrapper binary must be able to print *its* version of each without restating the shared text. Both extension points are plain data, so nothing a wrapper adds is known here.
 
@@ -229,6 +229,14 @@ The shared module-graph construction and statistical-outlier helpers used by sev
 **[`pkg/status`](pkg/status)** is the usage tracker behind `--status`. `Tracker.OnToolCall` is registered as the server's tool callback (`bootstrap.Server.SetToolCallback`) and attributes each call to the repo it actually operated on, not to a fixed one. Counters live in `~/.enola/usage/<repo-base>-<hash8>.json` — outside the repo, so they survive both a restart and deleting `.enola/` — and each file carries the lifetime total plus the current run's session counts. `AggregateServer` collapses every file into the one server view `PrintStatus` renders; `AggregateUsage` produces the per-repo breakdown for `--status --all`.
 
 The value estimate is a deliberately simple model in [`pkg/status/value.go`](pkg/status/value.go): one weight per tool (the number of manual lookups a call replaces) times two conversion constants (seconds and tokens per lookup). `RegisterToolWeights` lets a wrapper price the tools it adds instead of letting them fall through to the default weight; it is guarded by a mutex because registration happens at startup while reads come from the tool callback.
+
+**[`pkg/dashboard`](pkg/dashboard)** serves the read-only page described in the README, on a loopback port bound at startup (`--no-dashboard` skips it). It is **strictly a viewer**: `buildPage` runs per request and every source is read through an accessor the MCP tools already use — `status.ServerSnapshot()`, the engine's published store, and the receipt/insight artifacts (preferring the in-memory copy, falling back to the last-written file on disk, since `AutoLoadSnapshot` restores facts without full receipt metadata). Nothing it does mutates server state, and every source degrades to an explanatory note rather than an error page.
+
+The page reads receipts into the engine's own `facts.Receipt` / `facts.GraphReceipt` types, re-exported from `pkg/facts` precisely so a consumer never hand-writes a JSON mirror that drifts.
+
+**The insight allowlist.** `insightLabels` in [`pkg/dashboard/insights.go`](pkg/dashboard/insights.go) maps explainer id → display label, one entry per explainer `bootstrap.NewEngine` registers, and it doubles as an admission list: `insightDetails` drops any insight whose `Source` is absent from it, and excludes it from the structural/candidate counts. This matters because both binaries share a repo's `.enola/insights.json` — without the filter, a file written by a build with extra explainers would surface findings this engine cannot produce. For the same reason the clickable insight counters render the *filtered* total rather than the receipt's raw `insight_count`, so the number you click always matches the list you get.
+
+**The overlay.** A wrapper adds panels through `Options` rather than by forking the page. `Overlay` is a template fragment redefining any of the blocks `OverlayBlocks()` publishes — `extra-styles`, `extra-cards`, `extra-modals`, `extra-scripts` — each of which is passed the page root, so the fragment reaches its own data as `{{.Extra}}`, computed per request by `Options.Extra(store)`. `InsightLabels` widens the allowlist above (a wrapper that registers explainers *must* use it, or its own findings are filtered out of its own dashboard) and `Title` names the product. Two tests hold the contract from both ends: `TestOverlayBlocksExistInPage` here, and a matching check in the wrapper that its fragment defines only published names. Note that every server gets its own `Clone` of the base template even without an overlay — `html/template` refuses to clone a template that has already executed, so rendering straight from the package-level base would break the *next* dashboard's construction.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -472,11 +472,24 @@ Run `enola --help` for the full text. With no flags, enola starts the MCP server
 | `--list` | List the MCP tools this build serves, with one-line summaries. |
 | `--status` | Show the MCP server's activity: uptime, per-tool call counts (this session and lifetime), and an estimate of the time and context those calls saved. |
 | `--status --all` | The same usage, broken down per repository. |
+| `--no-dashboard` | Start the MCP server without the localhost dashboard. |
 | `--version` | Print the build version. |
 | `--help`, `-h` | Show usage. |
 | `upgrade` | Download and install the latest release over the running binary. |
 
 Usage counters are recorded per repository under `~/.enola/usage/`, so they survive both server restarts and deleting a repo's `.enola/` directory — and `--status` works from any directory, not just a snapshotted one. The value estimate is exactly that: a static per-tool model of how many manual lookups (open a file, grep, read) one call replaces, converted to time and tokens.
+
+### The dashboard
+
+Starting the MCP server also starts a **read-only dashboard** on a free loopback port (`127.0.0.1`), printed to stderr on startup — run `enola --status` while the server is up to get the URL again. It refreshes every 30 seconds and shows, in one page:
+
+- the same activity and value data as `--status`;
+- the **snapshot receipt** — snapshot ID, enola version, git ref, extractors, fact/insight counts;
+- the **graph receipt** (`~/.enola/receipt.json`) with the repos currently in the graph, and clickable counters listing the services and cross-repo edges — the edges also render as a node-link diagram;
+- the **insights** grouped by explainer, filterable by confidence band, so you can see what each finding is and how certain it is;
+- **extraction quality** — per-service coverage, unresolved routes, and samples of skipped files and parse errors, which is where you look when a snapshot seems thin.
+
+It is strictly a viewer: every request reads through the same concurrency-safe accessors the MCP tools use and never mutates server state. It binds loopback only and serves nothing but that one page. Pass `--no-dashboard` to skip it.
 
 ---
 

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/cli"
+	"github.com/enola-labs/enola/pkg/dashboard"
 	"github.com/enola-labs/enola/pkg/explain"
 	"github.com/enola-labs/enola/pkg/status"
 )
@@ -34,6 +35,7 @@ func main() {
 	explainMode := false
 	statusMode := false
 	statusAll := false
+	noDashboard := false
 	cfgPath := "mcp-arch.yaml"
 	explainRepo := "" // optional positional repo path for --explain
 
@@ -56,6 +58,8 @@ func main() {
 			statusMode = true
 		case "--all":
 			statusAll = true
+		case "--no-dashboard":
+			noDashboard = true
 		default:
 			// In --explain mode the positional argument is the repository path;
 			// otherwise it is the config file path.
@@ -137,6 +141,21 @@ func main() {
 	tracker := status.NewTracker(repoPath)
 	tracker.SetStartTime(time.Now())
 	srv.SetToolCallback(tracker.OnToolCall)
+
+	// Start the localhost HTTP dashboard alongside the MCP server. It binds a
+	// free loopback port and serves a read-only, auto-refreshing view of the same
+	// data as --status plus the snapshot/graph receipts. Non-fatal: a dashboard
+	// failure must never stop the MCP server. The port is recorded on the tracker
+	// BEFORE the startup write, so a separate --status invocation can print the
+	// URL even before the first tool call.
+	if !noDashboard {
+		if dash, err := dashboard.Start(eng, dashboard.Options{}); err != nil {
+			log.Printf("dashboard: not started: %v (continuing without it)", err)
+		} else {
+			tracker.SetDashboardPort(dash.Port())
+			fmt.Fprintf(os.Stderr, "Dashboard: %s (auto-refreshes every 30s)\n", dash.URL())
+		}
+	}
 	tracker.PersistStartup()
 
 	if err := srv.Run(ctx); err != nil {

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -81,8 +81,9 @@ func DefaultHelp(bin Binary) HelpSpec {
 			{Flag: "--generate", Desc: "Generate a snapshot and exit (do not start MCP server)"},
 			{Flag: "--explain [path]", Desc: "Print a human-readable repository statistics report and exit"},
 			{Flag: "--list", Desc: "List the MCP tools this build can serve"},
-			{Flag: "--status", Desc: "Show MCP server status: uptime, tool usage and estimated value,\naggregated across every repo the server has served."},
+			{Flag: "--status", Desc: "Show MCP server status: uptime, tool usage and estimated value,\naggregated across every repo the server has served. While the server\nis running this also prints the dashboard URL."},
 			{Flag: "--status --all", Desc: "Show the per-repo breakdown instead (from ~/.enola/usage/)"},
+			{Flag: "--no-dashboard", Desc: "Do not start the localhost dashboard alongside the MCP server"},
 			{Flag: "--version", Desc: "Print version information"},
 			{Flag: "--help, -h", Desc: "Show this help message"},
 		},
@@ -98,9 +99,23 @@ func DefaultHelp(bin Binary) HelpSpec {
 			{Comment: "Check version", Command: bin.Name + " --version"},
 		},
 		Sections: []Section{
+			dashboardSection(),
 			mcpConfigSection(bin),
 			buildSection(bin),
 		},
+	}
+}
+
+// dashboardSection documents the read-only HTTP dashboard served alongside the
+// MCP server.
+func dashboardSection() Section {
+	return Section{
+		Title: "DASHBOARD",
+		Body: `  When the MCP server starts, a read-only HTTP dashboard is served on a free
+  localhost port (127.0.0.1). It shows the same status data plus the snapshot and
+  graph receipts, and refreshes every 30 seconds. Run "--status" while the server
+  is up to get its URL, or pass "--no-dashboard" to skip it entirely.
+`,
 	}
 }
 

--- a/pkg/cli/help_test.go
+++ b/pkg/cli/help_test.go
@@ -35,10 +35,11 @@ func TestDefaultHelp_MentionsEveryFlag(t *testing.T) {
 }
 
 // The shared help is what the OSS binary prints verbatim, so it must never
-// describe anything only a wrapper provides.
+// describe anything only a wrapper provides. (The dashboard is not in this list:
+// both binaries serve one, so DefaultHelp documents it.)
 func TestDefaultHelp_NoWrapperConcepts(t *testing.T) {
 	out := strings.ToLower(renderDefault(t))
-	for _, term := range []string{"license", "activate", "dashboard", "enterprise"} {
+	for _, term := range []string{"license", "activate", "enterprise"} {
 		if strings.Contains(out, term) {
 			t.Errorf("default help must not mention %q:\n%s", term, out)
 		}

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -1,0 +1,460 @@
+// Package dashboard serves a read-only localhost HTTP dashboard alongside the
+// enola MCP server. It binds a free ephemeral port on 127.0.0.1 and renders —
+// refreshing every 30 seconds — the same activity data as --status plus the
+// contents of the current-snapshot and graph-wide receipt.json files, so a user
+// can visually inspect what the snapshot captured.
+//
+// The dashboard is strictly a viewer: every request only reads through existing
+// concurrency-safe accessors (the engine's published snapshot, the status usage
+// files) and never mutates server state. All logging goes to stderr; stdout is
+// reserved for the MCP stdio protocol.
+//
+// It is a public package so a wrapper binary can add panels of its own without
+// forking the page: see Options for the template-overlay and insight-label
+// extension points.
+package dashboard
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/enola-labs/enola/pkg/facts"
+	"github.com/enola-labs/enola/pkg/status"
+)
+
+// refreshSeconds is the client-side auto-refresh interval, stated on the page.
+const refreshSeconds = 30
+
+//go:embed page.html.tmpl
+var pageTemplate string
+
+var baseTmpl = template.Must(template.New("dashboard").Parse(pageTemplate))
+
+// OverlayBlocks names the template blocks an Options.Overlay may redefine, in
+// page order. They are the stable half of the overlay contract — renaming one
+// silently drops a wrapper's panel — so a wrapper can assert its fragment
+// defines only these, and TestOverlayBlocksExistInPage keeps the page honest.
+func OverlayBlocks() []string {
+	return []string{"extra-styles", "extra-cards", "extra-modals", "extra-scripts"}
+}
+
+// Options configures a dashboard, and is the whole extension surface a wrapper
+// binary has. A zero Options is the plain engine dashboard.
+type Options struct {
+	// Overlay is a template fragment that redefines any of the page's extension
+	// blocks: "extra-styles" (inside <style>), "extra-cards" (end of the summary
+	// card grid), "extra-modals" (after the last modal) and "extra-scripts"
+	// (inside the trailing <script>). Each is empty by default.
+	//
+	// A fragment renders against the same page model as the rest of the template,
+	// so it reaches its own data through {{.Extra}} and may reuse the page's CSS
+	// classes — .card, .modal, .modal-panel, .count-link and .insight-summary are
+	// the stable ones.
+	Overlay string
+
+	// Extra computes the data the overlay blocks render, once per request from
+	// the live fact store, and is exposed to the template as {{.Extra}}. Leaving
+	// it nil — or returning nil, e.g. for an unlicensed feature — renders the
+	// blocks with no data, which a fragment guarded by {{if .Extra}} skips.
+	Extra func(*facts.Store) any
+
+	// InsightLabels adds explainer-id → display-label entries to the page's own
+	// map. That map is also the admission list (see insightDetails), so a wrapper
+	// that registers extra explainers MUST list them here or their insights are
+	// filtered out of its own dashboard.
+	InsightLabels map[string]string
+
+	// Title names the product in the page title, heading and footer. Defaults to
+	// defaultTitle.
+	Title string
+}
+
+// defaultTitle is the product name shown when Options.Title is empty.
+const defaultTitle = "enola"
+
+// engineView is the slice of the engine the dashboard depends on. Narrowing to
+// an interface keeps the handler testable without constructing a full engine.
+// *bootstrap.Engine satisfies it.
+//
+//   - GetArtifact fetches the live in-memory receipt ("receipt.json").
+//   - ActiveRepo + OutputDir locate the last-written receipt on disk, used as a
+//     fallback: AutoLoadSnapshot restores a snapshot's facts with an near-empty
+//     Meta, so after a server restart the in-memory receipt is blank while a full
+//     one persists at <repo>/.enola/receipt.json.
+type engineView interface {
+	GetArtifact(name string) ([]byte, error)
+	ActiveRepo() string
+	OutputDir(repoPath string) string
+	// Store exposes the live fact store, from which the dashboard enumerates the
+	// service and cross-repo-edge lists behind the graph-receipt counters (the
+	// receipt itself stores only the counts). Reads are concurrency-safe.
+	Store() *facts.Store
+}
+
+// Server is a running dashboard HTTP server bound to a loopback port.
+type Server struct {
+	port   int
+	eng    engineView
+	opts   Options
+	tmpl   *template.Template
+	labels map[string]string // insight-source allowlist + display labels
+	title  string            // product name in the page title/heading/footer
+}
+
+// Start binds a free ephemeral port on 127.0.0.1, serves the dashboard from a
+// background goroutine, and returns immediately. A serve error after startup is
+// logged to stderr and never propagated — the MCP server must keep running.
+//
+// An invalid Options.Overlay is reported here rather than at render time, so a
+// wrapper's template mistake fails loudly at startup instead of silently
+// dropping its panels from every page.
+func Start(eng *bootstrap.Engine, opts Options) (*Server, error) {
+	tmpl, err := buildTemplate(opts.Overlay)
+	if err != nil {
+		return nil, err
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("binding dashboard port: %w", err)
+	}
+	s := &Server{
+		port:   ln.Addr().(*net.TCPAddr).Port,
+		eng:    eng,
+		opts:   opts,
+		tmpl:   tmpl,
+		labels: mergedLabels(opts.InsightLabels),
+		title:  titleOr(opts.Title),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleIndex)
+
+	go func() {
+		if err := http.Serve(ln, mux); err != nil {
+			log.Printf("dashboard: serve stopped: %v", err)
+		}
+	}()
+
+	return s, nil
+}
+
+// Port returns the loopback port the dashboard is listening on.
+func (s *Server) Port() int { return s.port }
+
+// URL returns the dashboard's localhost URL.
+func (s *Server) URL() string { return fmt.Sprintf("http://127.0.0.1:%d", s.port) }
+
+// handleIndex gathers live data on each request (so the periodic reload shows
+// fresh numbers) and renders the page. Only the root path is served.
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := s.buildPage()
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.Execute(w, data); err != nil {
+		log.Printf("dashboard: render failed: %v", err)
+	}
+}
+
+// titleOr returns the configured product name, or the default when unset.
+func titleOr(title string) string {
+	if title == "" {
+		return defaultTitle
+	}
+	return title
+}
+
+// buildTemplate returns the page template for one server, with an optional
+// overlay fragment applied over it. Parsing a fragment onto a clone redefines
+// whichever extension blocks it declares and leaves the rest of the page
+// untouched.
+//
+// Every server gets its own clone, even without an overlay: html/template
+// refuses to Clone a template that has already executed, so serving a page
+// straight from baseTmpl would make the NEXT server's Clone fail. Keeping
+// baseTmpl un-executed is what lets a wrapper start a dashboard after a plain
+// one in the same process.
+func buildTemplate(overlay string) (*template.Template, error) {
+	t, err := baseTmpl.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning dashboard template: %w", err)
+	}
+	if overlay == "" {
+		return t, nil
+	}
+	if t, err = t.Parse(overlay); err != nil {
+		return nil, fmt.Errorf("parsing dashboard overlay: %w", err)
+	}
+	return t, nil
+}
+
+// toolRow is one row of the tool-usage table (session vs lifetime total).
+type toolRow struct {
+	Name    string
+	Session int
+	Total   int
+}
+
+// valueRow is one row of the value-estimate table (pre-formatted for display).
+type valueRow struct {
+	Label       string
+	Calls       int
+	TimeSaved   string
+	TokensSaved string
+}
+
+// pageData is the full template model.
+type pageData struct {
+	RefreshSeconds int
+	Title          string
+
+	Running       bool
+	PID           int
+	Port          int
+	Uptime        string
+	StartedAt     string
+	TrackingSince string
+	ReposTracked  int
+
+	Tools      []toolRow
+	Values     []valueRow
+	ValueTotal valueRow
+
+	HasReceipt  bool
+	Receipt     *facts.Receipt
+	ReceiptNote string
+
+	HasGraph  bool
+	Graph     *facts.GraphReceipt
+	GraphNote string
+
+	// Services and CrossRepoEdges are enumerated from the live fact store (not the
+	// receipt, which holds only counts) to back the clickable graph-receipt cards.
+	Services       []serviceRow
+	CrossRepoEdges []edgeRow
+	// EdgeDiagram is the node-link layout of CrossRepoEdges for the diagram view of
+	// the edges modal; nil when there are no edges (the modal shows the table only).
+	EdgeDiagram *diagramView
+
+	// Insights (grouped by explainer) back the clickable Insights card; the
+	// structural/candidate split is shown in the modal header.
+	Insights          []insightGroup
+	InsightStructural int
+	InsightCandidate  int
+	InsightTotal      int // structural + candidate; initial "shown" count for the modal filter
+
+	// Extraction-quality proof data: per-service coverage and the unmatched-route
+	// list (from the live store), plus the capped skip/parse-error samples (from the
+	// receipt) that back the clickable Extraction-quality cards.
+	Coverage         []coverageRow
+	UnresolvedRoutes []routeRow
+	SkippedSample    []string
+	ParseErrors      []facts.ParseError
+
+	// Extra is whatever Options.Extra returned for this request — the data the
+	// overlay blocks render. Nil in a plain engine dashboard, and nil whenever a
+	// wrapper declines to supply it (e.g. an unlicensed feature), which is what a
+	// fragment guarded by {{if .Extra}} keys off.
+	Extra any
+}
+
+// buildPage collects the status, current-snapshot receipt and graph-wide receipt
+// into the template model. Every source degrades gracefully to a note on error.
+func (s *Server) buildPage() pageData {
+	data := pageData{
+		RefreshSeconds: refreshSeconds,
+		Title:          s.title,
+		Port:           s.port,
+	}
+
+	ss := status.ServerSnapshot()
+	if ss.Found {
+		data.Running = ss.Alive
+		data.PID = ss.PID
+		data.ReposTracked = ss.Repos
+		if !ss.StartTime.IsZero() {
+			data.StartedAt = ss.StartTime.Format("2006-01-02 15:04:05")
+			if ss.Alive {
+				data.Uptime = formatDuration(time.Since(ss.StartTime))
+			}
+		}
+		if !ss.TrackingSince.IsZero() {
+			data.TrackingSince = ss.TrackingSince.Format("2006-01-02 15:04:05")
+		}
+		data.Tools = toolRows(ss.GrandTotal, ss.Session)
+		data.Values, data.ValueTotal = valueRows(ss.GrandTotal)
+	}
+
+	// Current-snapshot receipt: prefer the live in-memory receipt, falling back
+	// to the last-written one on disk (see currentReceipt).
+	if rv := s.currentReceipt(); rv != nil {
+		data.HasReceipt = true
+		data.Receipt = rv
+		// Capped skip/parse-error samples back the clickable Extraction-quality cards.
+		data.SkippedSample = rv.Quality.SkippedSample
+		data.ParseErrors = rv.Quality.ParseErrorSample
+	} else {
+		data.ReceiptNote = "No snapshot loaded yet — run generate_snapshot to populate this."
+	}
+
+	// Graph-wide receipt: ~/.enola/receipt.json on disk.
+	if gv, err := readGraphReceipt(); err != nil {
+		data.GraphNote = "No graph receipt yet — it is written to ~/.enola/receipt.json when a snapshot is generated."
+	} else {
+		data.HasGraph = true
+		data.Graph = gv
+	}
+
+	// Service and cross-repo-edge lists from the live store, backing the clickable
+	// counters. Empty (store not loaded) → the cards render as plain numbers.
+	data.Services, data.CrossRepoEdges = graphDetails(s.eng.Store())
+	data.EdgeDiagram = buildEdgeDiagram(data.Services, data.CrossRepoEdges)
+
+	// Insight list (grouped by explainer) backing the clickable Insights counter.
+	// Empty → the counter renders as a plain number.
+	data.Insights, data.InsightStructural, data.InsightCandidate = insightDetails(s.currentInsights(), s.labels)
+	data.InsightTotal = data.InsightStructural + data.InsightCandidate
+
+	// Cross-repo coverage + unmatched routes from the live store, backing the
+	// clickable Extraction-quality coverage cards.
+	data.Coverage, data.UnresolvedRoutes = coverageDetails(s.eng.Store())
+
+	// Whatever a wrapper's overlay blocks render, recomputed per request from the
+	// same live store as everything above.
+	if s.opts.Extra != nil {
+		data.Extra = s.opts.Extra(s.eng.Store())
+	}
+
+	return data
+}
+
+// currentReceipt returns the receipt to display for the current snapshot, or nil
+// if none is available. It prefers the live in-memory receipt (fresh after a
+// generate_snapshot), but falls back to the last-written receipt on disk when the
+// in-memory one is missing or blank — the common case after a server restart,
+// where AutoLoadSnapshot restores facts without full receipt metadata.
+func (s *Server) currentReceipt() *facts.Receipt {
+	if b, err := s.eng.GetArtifact("receipt.json"); err == nil {
+		var rv facts.Receipt
+		if err := json.Unmarshal(b, &rv); err == nil && rv.SnapshotID != "" {
+			return &rv
+		}
+	}
+
+	repo := s.eng.ActiveRepo()
+	if repo == "" {
+		return nil
+	}
+	b, err := os.ReadFile(filepath.Join(s.eng.OutputDir(repo), "receipt.json"))
+	if err != nil {
+		return nil
+	}
+	var rv facts.Receipt
+	if err := json.Unmarshal(b, &rv); err != nil {
+		return nil
+	}
+	return &rv
+}
+
+// currentInsights returns the insight list for the current snapshot, or nil. Like
+// currentReceipt it prefers the live in-memory artifact (fresh after generate) but
+// falls back to the last-written insights.json on disk — AutoLoadSnapshot restores
+// facts without the snapshot's insights, so after a server restart the in-memory
+// list is empty while a full one persists at <repo>/.enola/insights.json.
+func (s *Server) currentInsights() []facts.Insight {
+	if b, err := s.eng.GetArtifact("insights.json"); err == nil {
+		var ins []facts.Insight
+		if err := json.Unmarshal(b, &ins); err == nil && len(ins) > 0 {
+			return ins
+		}
+	}
+
+	repo := s.eng.ActiveRepo()
+	if repo == "" {
+		return nil
+	}
+	b, err := os.ReadFile(filepath.Join(s.eng.OutputDir(repo), "insights.json"))
+	if err != nil {
+		return nil
+	}
+	var ins []facts.Insight
+	if err := json.Unmarshal(b, &ins); err != nil {
+		return nil
+	}
+	return ins
+}
+
+// readGraphReceipt reads and parses the graph-wide receipt at ~/.enola/receipt.json.
+func readGraphReceipt() (*facts.GraphReceipt, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".enola", "receipt.json"))
+	if err != nil {
+		return nil, err
+	}
+	var gv facts.GraphReceipt
+	if err := json.Unmarshal(b, &gv); err != nil {
+		return nil, err
+	}
+	return &gv, nil
+}
+
+// toolRows builds the sorted union of tool-usage rows (session and lifetime).
+func toolRows(total, session map[string]int) []toolRow {
+	set := make(map[string]struct{}, len(total)+len(session))
+	for k := range total {
+		set[k] = struct{}{}
+	}
+	for k := range session {
+		set[k] = struct{}{}
+	}
+	names := make([]string, 0, len(set))
+	for k := range set {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	rows := make([]toolRow, 0, len(names))
+	for _, n := range names {
+		rows = append(rows, toolRow{Name: n, Session: session[n], Total: total[n]})
+	}
+	return rows
+}
+
+// valueRows builds the per-tool value-estimate rows plus the total row, reusing
+// the shared status value model so the numbers match --status exactly.
+func valueRows(total map[string]int) ([]valueRow, valueRow) {
+	rep := status.ComputeValue(total)
+	rows := make([]valueRow, 0, len(rep.Tools))
+	for _, tv := range rep.Tools {
+		rows = append(rows, valueRow{
+			Label:       tv.Tool,
+			Calls:       tv.Calls,
+			TimeSaved:   formatDuration(tv.TimeSaved),
+			TokensSaved: humanCount(tv.TokensSaved),
+		})
+	}
+	totalRow := valueRow{
+		Label:       "TOTAL",
+		Calls:       rep.TotalCalls,
+		TimeSaved:   formatDuration(rep.TotalTimeSaved),
+		TokensSaved: humanCount(rep.TotalTokensSaved),
+	}
+	return rows, totalRow
+}

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -1,0 +1,730 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+// fakeArtifacts is a stub engineView for handler tests. activeRepo/outputDir
+// drive the on-disk receipt fallback (empty by default → no fallback). store is
+// nil by default, so graphDetails yields empty lists and the counters render as
+// plain (non-clickable) numbers.
+type fakeArtifacts struct {
+	receipt    []byte
+	insights   []byte
+	err        error
+	activeRepo string
+	outputDir  string
+	store      *facts.Store
+}
+
+func (f fakeArtifacts) GetArtifact(name string) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if name == "insights.json" {
+		return f.insights, nil
+	}
+	return f.receipt, nil
+}
+
+func (f fakeArtifacts) ActiveRepo() string { return f.activeRepo }
+
+func (f fakeArtifacts) OutputDir(repoPath string) string { return f.outputDir }
+
+func (f fakeArtifacts) Store() *facts.Store { return f.store }
+
+// newTestServer builds a Server exactly as Start does — parsed template and
+// merged insight labels included — but without binding a port. Constructing the
+// struct literally instead would leave those nil, so a handler test would panic
+// rather than exercise what the real server renders.
+func newTestServer(port int, eng engineView, opts ...Options) *Server {
+	var o Options
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	tmpl, err := buildTemplate(o.Overlay)
+	if err != nil {
+		panic(err)
+	}
+	return &Server{port: port, eng: eng, opts: o, tmpl: tmpl, labels: mergedLabels(o.InsightLabels), title: titleOr(o.Title)}
+}
+
+// isolateHome points HOME at an empty temp dir so status.ServerSnapshot (which
+// reads ~/.enola/usage) and the graph-receipt read (~/.enola/receipt.json) are
+// deterministic and start empty.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func TestHandlerDegradesGracefully(t *testing.T) {
+	isolateHome(t)
+	s := newTestServer(54321, fakeArtifacts{err: errors.New("no snapshot generated")})
+
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("content-type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	wantContains := []string{
+		"location.reload()",                // JS-driven auto-refresh mechanism
+		"refreshes automatically every 30", // stated on the page
+		"127.0.0.1:54321",                  // the dashboard port/URL
+		"No snapshot loaded yet",           // degraded current receipt
+		"No graph receipt yet",             // degraded graph receipt
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandlerRendersReceipts(t *testing.T) {
+	home := isolateHome(t)
+
+	receipt := facts.Receipt{
+		SnapshotID:   "snap-abc123",
+		EnolaVersion: "9.9.9",
+		Extractors:   []string{"goextractor", "tsextractor"},
+		FactCount:    4242,
+	}
+	rb, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a graph receipt into the isolated ~/.enola/receipt.json.
+	graph := facts.GraphReceipt{
+		SnapshotID:   "graph-xyz",
+		ServiceCount: 7,
+		Repos:        []facts.GraphRepoEntry{{Label: "backend", Path: "/x/backend", FactCount: 100}},
+	}
+	gb, err := json.Marshal(graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".enola")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), gb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestServer(8080, fakeArtifacts{receipt: rb})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"snap-abc123", "goextractor", "tsextractor", "4242", // current receipt
+		"graph-xyz", "backend", "/x/backend", // graph receipt + repos table
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+// TestReceiptDiskFallback covers the server-restart case: the in-memory receipt
+// is blank (auto-loaded facts only), so the dashboard must fall back to the
+// last-written <repo>/.enola/receipt.json on disk.
+func TestReceiptDiskFallback(t *testing.T) {
+	isolateHome(t)
+	repo := t.TempDir()
+	outDir := filepath.Join(repo, ".enola")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	diskReceipt := facts.Receipt{SnapshotID: "sha256:ondisk", FactCount: 77}
+	db, err := json.Marshal(diskReceipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "receipt.json"), db, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// In-memory receipt is blank (only RepoPath set, SnapshotID empty), mimicking
+	// AutoLoadSnapshot; ActiveRepo/OutputDir point at the on-disk receipt.
+	blank, err := json.Marshal(facts.Receipt{RepoPath: repo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newTestServer(9, fakeArtifacts{receipt: blank, activeRepo: repo, outputDir: outDir})
+
+	rv := s.currentReceipt()
+	if rv == nil || rv.SnapshotID != "sha256:ondisk" || rv.FactCount != 77 {
+		t.Fatalf("currentReceipt = %+v, want the on-disk receipt", rv)
+	}
+}
+
+func TestHandlerNotFound(t *testing.T) {
+	isolateHome(t)
+	s := newTestServer(1, fakeArtifacts{err: errors.New("no snapshot generated")})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/other", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestStartBindsLoopbackPort(t *testing.T) {
+	s, err := Start(nil, Options{})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.Port() <= 0 {
+		t.Errorf("port = %d, want > 0", s.Port())
+	}
+	if want := "http://127.0.0.1:"; !strings.HasPrefix(s.URL(), want) {
+		t.Errorf("URL = %q, want prefix %q", s.URL(), want)
+	}
+}
+
+func TestToolRows(t *testing.T) {
+	total := map[string]int{"explore": 10, "query_facts": 5}
+	session := map[string]int{"explore": 2}
+	rows := toolRows(total, session)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	// Sorted by name: explore, query_facts.
+	if rows[0].Name != "explore" || rows[0].Session != 2 || rows[0].Total != 10 {
+		t.Errorf("row0 = %+v", rows[0])
+	}
+	if rows[1].Name != "query_facts" || rows[1].Session != 0 || rows[1].Total != 5 {
+		t.Errorf("row1 = %+v", rows[1])
+	}
+}
+
+// TestGraphDetails covers the store-backed enumeration directly: services sorted
+// by name with their depends_on counts, one edge per depends_on relation sorted
+// by consumer→provider, and empty lists for a nil store.
+func TestGraphDetails(t *testing.T) {
+	if s, e := graphDetails(nil); s != nil || e != nil {
+		t.Fatalf("graphDetails(nil) = (%v, %v), want (nil, nil)", s, e)
+	}
+
+	st := facts.NewStore()
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "frontend", Relations: []facts.Relation{
+		{Kind: facts.RelDependsOn, Target: "backend"},
+		{Kind: facts.RelImports, Target: "ignored"}, // non-edge relation is skipped
+	}})
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "backend"})
+
+	services, edges := graphDetails(st)
+	if len(services) != 2 || services[0].Name != "backend" || services[1].Name != "frontend" {
+		t.Fatalf("services = %+v, want [backend, frontend]", services)
+	}
+	if services[0].DependsOn != 0 || services[1].DependsOn != 1 {
+		t.Errorf("depends-on counts = %d/%d, want 0/1", services[0].DependsOn, services[1].DependsOn)
+	}
+	if len(edges) != 1 || edges[0].Consumer != "frontend" || edges[0].Provider != "backend" {
+		t.Fatalf("edges = %+v, want [frontend→backend]", edges)
+	}
+}
+
+// TestHandlerRendersModals verifies the clickable counters and modal contents are
+// rendered when the store holds service facts. The clickable count buttons live in
+// the graph-receipt cards, so a graph receipt must exist on disk for them to render.
+func TestHandlerRendersModals(t *testing.T) {
+	home := isolateHome(t)
+
+	graph := facts.GraphReceipt{SnapshotID: "graph-xyz", ServiceCount: 2, CrossRepoEdgeCount: 1}
+	gb, err := json.Marshal(graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".enola")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), gb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := facts.NewStore()
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "frontend", Relations: []facts.Relation{
+		{Kind: facts.RelDependsOn, Target: "backend"},
+	}})
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "backend"})
+
+	s := newTestServer(8080, fakeArtifacts{err: errors.New("no receipt"), store: st})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`id="services-modal"`,                   // services modal container
+		`id="edges-modal"`,                      // edges modal container
+		`onclick="openModal('services-modal')"`, // clickable services count
+		`onclick="openModal('edges-modal')"`,    // clickable edges count
+		"frontend", "backend",                   // service names / edge endpoints
+		// Diagram view + header toggle for the edges modal.
+		`id="edges-diagram"`,          // diagram view container
+		`<svg class="edge-graph"`,     // inline SVG node-link diagram
+		`id="edges-view-toggle"`,      // header toggle control
+		`onclick="toggleEdgesView()"`, // toggle handler
+		`id="edges-table"`,            // table view container (now a sibling)
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+// TestBuildEdgeDiagram covers the node-link layout: one node per service placed on
+// the ring, one edge per drawable relation, all coordinates inside the viewBox, a
+// deterministic result, and graceful handling of empty and unknown-endpoint inputs.
+func TestBuildEdgeDiagram(t *testing.T) {
+	if buildEdgeDiagram(nil, nil) != nil {
+		t.Fatal("empty input should yield a nil diagram")
+	}
+	svcs := []serviceRow{{Name: "backend"}, {Name: "frontend"}, {Name: "mobile"}}
+	edges := []edgeRow{
+		{Consumer: "frontend", Provider: "backend"},
+		{Consumer: "mobile", Provider: "backend"},
+		{Consumer: "frontend", Provider: "ghost"},  // unknown provider → skipped
+		{Consumer: "backend", Provider: "backend"}, // self-loop → skipped
+	}
+	d := buildEdgeDiagram(svcs, edges)
+	if d == nil {
+		t.Fatal("expected a diagram")
+	}
+	if len(d.Nodes) != 3 {
+		t.Errorf("nodes = %d, want 3", len(d.Nodes))
+	}
+	if len(d.Edges) != 2 {
+		t.Errorf("edges = %d, want 2 (unknown endpoint + self-loop dropped)", len(d.Edges))
+	}
+	for _, n := range d.Nodes {
+		if n.X < 0 || n.X > d.Width || n.Y < 0 || n.Y > d.Height {
+			t.Errorf("node %q at (%.1f,%.1f) outside viewBox %gx%g", n.Name, n.X, n.Y, d.Width, d.Height)
+		}
+		if n.Anchor != "start" && n.Anchor != "end" {
+			t.Errorf("node %q anchor = %q, want start|end", n.Name, n.Anchor)
+		}
+	}
+	// Deterministic: same inputs → identical layout.
+	if d2 := buildEdgeDiagram(svcs, edges); !reflect.DeepEqual(d, d2) {
+		t.Error("buildEdgeDiagram is not deterministic")
+	}
+}
+
+// TestInsightDetails covers the store-independent grouping: groups sorted by count
+// desc, items within a group sorted by confidence desc, the largest group's bar at
+// 100%, the structural/candidate split, evidence extraction, and nil → empty.
+func TestInsightDetails(t *testing.T) {
+	labels := mergedLabels(nil)
+
+	if g, s, c := insightDetails(nil, labels); g != nil || s != 0 || c != 0 {
+		t.Fatalf("insightDetails(nil) = (%v, %d, %d), want empty", g, s, c)
+	}
+
+	ins := []facts.Insight{
+		{Source: "hotspots", Title: "Hot symbol", Confidence: 0.65, Evidence: []facts.Evidence{{File: "a.go"}}},
+		{Source: "hotspots", Title: "Alloc in loop", Confidence: 0.85},
+		{Source: "hotspots", Title: "Boxing", Confidence: 0.65},
+		{Source: "cycles", Title: "Import cycle", Confidence: 1.0, Evidence: []facts.Evidence{{Symbol: "foo"}}},
+	}
+	groups, structural, candidate := insightDetails(ins, labels)
+
+	if len(groups) != 2 {
+		t.Fatalf("groups = %d, want 2", len(groups))
+	}
+	// hotspots (3) ranks before cycles (1).
+	if groups[0].Source != "hotspots" || groups[0].Count != 3 || groups[0].BarPct != 100 {
+		t.Errorf("group0 = %+v, want hotspots/3/100%%", groups[0])
+	}
+	if groups[0].Label != "Hotspots" {
+		t.Errorf("group0 label = %q, want Hotspots", groups[0].Label)
+	}
+	// Within hotspots, highest confidence first (85, 65, 65 by title).
+	if groups[0].Items[0].Title != "Alloc in loop" || groups[0].Items[0].Confidence != 85 {
+		t.Errorf("hotspots item0 = %+v, want Alloc in loop/85", groups[0].Items[0])
+	}
+	if groups[1].Source != "cycles" || groups[1].BarPct != 33 {
+		t.Errorf("group1 = %+v, want cycles/33%%", groups[1])
+	}
+	if !groups[1].Items[0].Structural || groups[1].Items[0].Evidence != "foo" {
+		t.Errorf("cycles item = %+v, want structural + evidence foo", groups[1].Items[0])
+	}
+	if structural != 1 || candidate != 3 {
+		t.Errorf("split = %d structural / %d candidate, want 1/3", structural, candidate)
+	}
+}
+
+// Both binaries share a repo's .enola/insights.json, so a file written by a build
+// with extra explainers must not leak findings this engine cannot produce — the
+// dropped insights must not reach the groups OR the structural/candidate counts.
+func TestInsightDetailsFiltersUnknownSources(t *testing.T) {
+	ins := []facts.Insight{
+		{Source: "cycles", Title: "Import cycle", Confidence: 1.0},
+		{Source: "performance", Title: "Slow loop", Confidence: 0.65},
+		{Source: "dead-code", Title: "Unused func", Confidence: 1.0},
+		{Source: "", Title: "Unstamped", Confidence: 0.5},
+	}
+
+	groups, structural, candidate := insightDetails(ins, mergedLabels(nil))
+	if len(groups) != 1 || groups[0].Source != "cycles" {
+		t.Fatalf("groups = %+v, want only cycles", groups)
+	}
+	if structural != 1 || candidate != 0 {
+		t.Errorf("split = %d/%d, want 1 structural / 0 candidate — dropped insights must not be counted", structural, candidate)
+	}
+
+	// A wrapper admits its own explainers by labelling them.
+	groups, structural, candidate = insightDetails(ins, mergedLabels(map[string]string{
+		"performance": "Performance",
+		"dead-code":   "Dead code",
+	}))
+	if len(groups) != 3 {
+		t.Fatalf("groups = %d, want 3 once the wrapper's labels are registered", len(groups))
+	}
+	if structural != 2 || candidate != 1 {
+		t.Errorf("split = %d/%d, want 2 structural / 1 candidate", structural, candidate)
+	}
+	for _, g := range groups {
+		if g.Source == "" {
+			t.Error("an unstamped source must stay filtered even for a wrapper")
+		}
+	}
+}
+
+// mergedLabels must copy, so one dashboard's wrapper labels never bleed into the
+// package map (and thus into another dashboard in the same process).
+func TestMergedLabelsDoesNotMutatePackageMap(t *testing.T) {
+	before := len(insightLabels)
+	m := mergedLabels(map[string]string{"performance": "Performance"})
+
+	if len(insightLabels) != before {
+		t.Errorf("insightLabels grew to %d, want %d — mergedLabels must copy", len(insightLabels), before)
+	}
+	if _, leaked := insightLabels["performance"]; leaked {
+		t.Error("wrapper label leaked into the package map")
+	}
+	if m["performance"] != "Performance" || m["cycles"] != "Dependency cycles" {
+		t.Errorf("merged map lost an entry: %+v", m)
+	}
+}
+
+// TestHandlerRendersInsightsModal verifies the clickable Insights counter and the
+// modal's grouped bars render when insights.json is available via GetArtifact. A
+// graph receipt is written to disk so the graph card (which hosts one clickable
+// counter) renders.
+func TestHandlerRendersInsightsModal(t *testing.T) {
+	home := isolateHome(t)
+
+	graph := facts.GraphReceipt{SnapshotID: "graph-xyz", InsightCount: 2}
+	gb, err := json.Marshal(graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".enola")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), gb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	insights := []facts.Insight{
+		{Source: "god-class", Title: "UserService is a god class", Confidence: 0.9},
+		{Source: "cycles", Title: "Import cycle a → b → a", Confidence: 1.0},
+	}
+	ib, err := json.Marshal(insights)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestServer(8080, fakeArtifacts{insights: ib})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`id="insights-modal"`,                   // modal container
+		`onclick="openModal('insights-modal')"`, // clickable counter
+		"God classes", "Dependency cycles",      // friendly labels
+		"UserService is a god class", // an insight title
+		"90%", "100%",                // confidence rendering
+		"structural",   // structural chip on the 100% insight
+		"1 structural", // header split
+		// confidence-band filter wiring
+		`id="insight-band"`,
+		"Structural (100%)",
+		`onchange="filterInsights(this.value)"`,
+		`data-conf="90"`,
+		`id="insight-shown"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+// TestCoverageDetails covers the store-backed coverage enumeration: per-service
+// classification, the unmatched-route list, sort order, and nil → empty.
+func TestCoverageDetails(t *testing.T) {
+	if s, u := coverageDetails(nil); s != nil || u != nil {
+		t.Fatalf("coverageDetails(nil) = (%v, %v), want (nil, nil)", s, u)
+	}
+
+	st := facts.NewStore()
+	// A connected service (one resolved depends_on edge).
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "frontend",
+		Props: map[string]any{"edge_coverage": []map[string]any{
+			{"detected": 139, "resolved": 131, "external": 0, "unresolved": 8},
+		}},
+		Relations: []facts.Relation{{Kind: facts.RelDependsOn, Target: "backend"}},
+	})
+	// A coverage-gap service: outbound detected but nothing resolved.
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "app",
+		Props: map[string]any{"edge_coverage": []map[string]any{
+			{"detected": 5, "resolved": 0, "external": 0, "unresolved": 5},
+		}},
+	})
+	st.Add(facts.Fact{Kind: facts.KindRoute, Name: "/v2/hide.json", Repo: "frontend",
+		File: "a.jsx", Line: 18,
+		Props: map[string]any{"method": "POST", "unmatched_by_server": true, "unmatched_reason": "path_unknown"}})
+	st.Add(facts.Fact{Kind: facts.KindRoute, Name: "/matched", Repo: "frontend",
+		Props: map[string]any{"method": "GET"}}) // not unmatched → excluded
+
+	services, unresolved := coverageDetails(st)
+	if len(services) != 2 || services[0].Service != "app" || services[1].Service != "frontend" {
+		t.Fatalf("services = %+v, want [app, frontend]", services)
+	}
+	if services[0].Status != svcCoverageGap {
+		t.Errorf("app status = %q, want %q", services[0].Status, svcCoverageGap)
+	}
+	if services[1].Status != svcConnected || services[1].Resolved != 1 || services[1].Unresolved != 8 {
+		t.Errorf("frontend row = %+v, want connected/resolved 1/unresolved 8", services[1])
+	}
+	if len(unresolved) != 1 || unresolved[0].Path != "/v2/hide.json" || unresolved[0].Method != "POST" || unresolved[0].Reason != "path_unknown" {
+		t.Fatalf("unresolved = %+v, want one POST /v2/hide.json path_unknown", unresolved)
+	}
+}
+
+// TestHandlerRendersQualityModals verifies the clickable Extraction-quality cards
+// and their modals render from the receipt samples and the live store.
+func TestHandlerRendersQualityModals(t *testing.T) {
+	isolateHome(t)
+
+	receipt := facts.Receipt{
+		SnapshotID: "snap-q",
+		Quality: facts.ReceiptQuality{
+			FilesSkipped:     0,
+			DirsSkipped:      1,
+			SkippedSample:    []string{".git/ (glob: .git/**)"},
+			ParseErrors:      1,
+			ParseErrorSample: []facts.ParseError{{Extractor: "goextractor", File: "bad.go", Msg: "syntax error near EOF"}},
+			Coverage:         &facts.CoverageSummary{ServicesTotal: 1, UnresolvedEdges: 1},
+		},
+	}
+	rb, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st := facts.NewStore()
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "frontend",
+		Props:     map[string]any{"edge_coverage": []map[string]any{{"detected": 9, "resolved": 8, "external": 0, "unresolved": 1}}},
+		Relations: []facts.Relation{{Kind: facts.RelDependsOn, Target: "backend"}}})
+	st.Add(facts.Fact{Kind: facts.KindRoute, Name: "/v2/hide.json", Repo: "frontend",
+		Props: map[string]any{"method": "POST", "unmatched_by_server": true, "unmatched_reason": "path_unknown"}})
+
+	s := newTestServer(8080, fakeArtifacts{receipt: rb, store: st})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`id="coverage-modal"`, `id="coverage-unresolved-modal"`, `id="skipped-modal"`, `id="parse-errors-modal"`,
+		`onclick="openModal('coverage-modal')"`,
+		`onclick="openModal('coverage-unresolved-modal')"`,
+		`onclick="openModal('skipped-modal')"`,
+		`onclick="openModal('parse-errors-modal')"`,
+		".git/ (glob: .git/**)", // skipped sample entry
+		"syntax error near EOF", // parse-error message
+		"/v2/hide.json",         // unmatched route path
+		"path_unknown",          // unmatched reason
+		"connected",             // service status
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestValueRowsHasTotal(t *testing.T) {
+	rows, total := valueRows(map[string]int{"explore": 3})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Label != "explore" || rows[0].Calls != 3 {
+		t.Errorf("row = %+v", rows[0])
+	}
+	if total.Label != "TOTAL" || total.Calls != 3 {
+		t.Errorf("total = %+v", total)
+	}
+}
+
+// The overlay is the whole contract a wrapper binary builds its extra panels on:
+// each of the four blocks must render, reach the wrapper's own data through
+// {{.Extra}}, and land inside the right part of the page.
+func TestOverlayRendersExtraBlocks(t *testing.T) {
+	isolateHome(t)
+
+	receipt, err := json.Marshal(facts.Receipt{SnapshotID: "snap-1", FactCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const overlay = `
+{{define "extra-styles"}}.wrapper-panel { color: hotpink; }{{end}}
+{{define "extra-cards"}}{{if .Extra}}<div class="card" id="wrapper-card">{{.Extra.Label}}</div>{{end}}{{end}}
+{{define "extra-modals"}}{{if .Extra}}<div class="modal" id="wrapper-modal">{{.Extra.Count}} things</div>{{end}}{{end}}
+{{define "extra-scripts"}}function wrapperFn() { return 1; }{{end}}`
+
+	type extra struct {
+		Label string
+		Count int
+	}
+	s := newTestServer(8080, fakeArtifacts{receipt: receipt}, Options{
+		Overlay: overlay,
+		Extra:   func(*facts.Store) any { return extra{Label: "Wrapper panel", Count: 7} },
+	})
+
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		".wrapper-panel { color: hotpink; }", // extra-styles
+		`id="wrapper-card"`, "Wrapper panel", // extra-cards, reading .Extra
+		`id="wrapper-modal"`, "7 things", // extra-modals
+		"function wrapperFn()", // extra-scripts
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("overlay output missing %q", want)
+		}
+	}
+
+	// Each block must land in its own region: styles inside <style>, scripts inside
+	// <script>, and the card inside the receipt card grid rather than after it.
+	if head := body[:strings.Index(body, "</style>")]; !strings.Contains(head, ".wrapper-panel") {
+		t.Error("extra-styles rendered outside the <style> block")
+	}
+	if card, grid := strings.Index(body, `id="wrapper-card"`), strings.Index(body, `id="wrapper-modal"`); card > grid {
+		t.Error("extra-cards should render before extra-modals")
+	}
+}
+
+// A wrapper that supplies no Extra (e.g. an unlicensed feature) must render a
+// clean page, not a half-built panel.
+func TestOverlayWithoutExtraDataRendersNothing(t *testing.T) {
+	isolateHome(t)
+
+	s := newTestServer(8080, fakeArtifacts{err: errors.New("no snapshot")}, Options{
+		Overlay: `{{define "extra-modals"}}{{if .Extra}}<div id="wrapper-modal"></div>{{end}}{{end}}`,
+	})
+
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if body := rec.Body.String(); strings.Contains(body, "wrapper-modal") {
+		t.Error("a nil Extra must render no panel")
+	}
+}
+
+// A broken overlay must fail at Start, where a wrapper author sees it — not
+// silently drop every panel from every page.
+func TestStartRejectsInvalidOverlay(t *testing.T) {
+	if _, err := Start(nil, Options{Overlay: `{{define "extra-cards"}}{{.Unclosed`}); err == nil {
+		t.Fatal("Start accepted a malformed overlay")
+	}
+}
+
+// html/template refuses to Clone a template that has already executed, so a
+// server must never render straight from the package-level base. Starting a
+// plain dashboard and then an overlay one in the same process is exactly the
+// order that regressed.
+func TestSecondServerCanStartAfterFirstHasRendered(t *testing.T) {
+	isolateHome(t)
+
+	first := newTestServer(1, fakeArtifacts{err: errors.New("no snapshot")})
+	first.handleIndex(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if _, err := buildTemplate(`{{define "extra-cards"}}<div id="late"></div>{{end}}`); err != nil {
+		t.Fatalf("overlay template after a render: %v", err)
+	}
+	if _, err := buildTemplate(""); err != nil {
+		t.Fatalf("plain template after a render: %v", err)
+	}
+}
+
+// OverlayBlocks is the published half of the overlay contract, so every name it
+// promises must actually be a block in the page — otherwise a wrapper's panel
+// parses cleanly and then renders nowhere.
+func TestOverlayBlocksExistInPage(t *testing.T) {
+	names := OverlayBlocks()
+	if len(names) == 0 {
+		t.Fatal("OverlayBlocks is empty")
+	}
+	for _, name := range names {
+		if baseTmpl.Lookup(name) == nil {
+			t.Errorf("OverlayBlocks names %q, but the page defines no such block", name)
+		}
+	}
+
+	// And the page must not carry extension blocks it never told wrappers about.
+	declared := make(map[string]bool, len(names))
+	for _, n := range names {
+		declared[n] = true
+	}
+	for _, tpl := range baseTmpl.Templates() {
+		if n := tpl.Name(); strings.HasPrefix(n, "extra-") && !declared[n] {
+			t.Errorf("page defines block %q, which OverlayBlocks does not list", n)
+		}
+	}
+}
+
+// The page is branded per binary, so a wrapper can name its own product without
+// forking the template — and the default must never be a wrapper's name.
+func TestTitleDefaultsAndOverrides(t *testing.T) {
+	isolateHome(t)
+	req := func() *http.Request { return httptest.NewRequest(http.MethodGet, "/", nil) }
+
+	rec := httptest.NewRecorder()
+	newTestServer(1, fakeArtifacts{err: errors.New("none")}).handleIndex(rec, req())
+	if body := rec.Body.String(); !strings.Contains(body, "<title>enola — dashboard</title>") {
+		t.Error("default title is not the engine's own name")
+	}
+
+	rec = httptest.NewRecorder()
+	newTestServer(1, fakeArtifacts{err: errors.New("none")}, Options{Title: "wrapper build"}).handleIndex(rec, req())
+	body := rec.Body.String()
+	for _, want := range []string{"<title>wrapper build — dashboard</title>", "<h1>wrapper build</h1>"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}

--- a/pkg/dashboard/edgediagram.go
+++ b/pkg/dashboard/edgediagram.go
@@ -1,0 +1,112 @@
+package dashboard
+
+import (
+	"math"
+	"sort"
+)
+
+// Diagram geometry. The viewBox is fixed; the SVG scales responsively in CSS.
+// Radius/center leave a margin on every side for the node labels that splay
+// outward from the ring.
+const (
+	diagramWidth   = 640.0
+	diagramHeight  = 460.0
+	diagramRadius  = 150.0
+	diagramNodeR   = 5.0
+	diagramCurve   = 0.14 // control-point offset as a fraction of the chord length
+	diagramLabelPx = 8.0  // gap between a node and its label
+)
+
+// diagramNode is one service node placed on the ring, with the text-anchor its
+// outward-splayed label should use.
+type diagramNode struct {
+	Name   string
+	X, Y   float64
+	LabelX float64
+	Anchor string // "start" | "end"
+}
+
+// diagramEdge is one directed consumer→provider edge as a quadratic curve whose
+// endpoints sit on the node rims (so the arrowhead lands on the provider's edge,
+// not its centre). The control point is offset perpendicular to the chord so a
+// bidirectional pair draws as two distinct arcs rather than one overlapping line.
+type diagramEdge struct {
+	X1, Y1 float64
+	CX, CY float64
+	X2, Y2 float64
+}
+
+// diagramView is the full node-link layout the template renders as inline SVG.
+type diagramView struct {
+	Width, Height float64
+	Nodes         []diagramNode
+	Edges         []diagramEdge
+}
+
+// buildEdgeDiagram lays the services out on a circle and routes each cross-repo
+// edge as a rim-to-rim curve, returning nil when there is nothing to draw. The
+// layout is a pure function of the (already-sorted) inputs — deterministic, so
+// the rendered SVG is stable across refreshes and unit-testable.
+func buildEdgeDiagram(services []serviceRow, edges []edgeRow) *diagramView {
+	if len(services) == 0 || len(edges) == 0 {
+		return nil
+	}
+
+	// Nodes on a circle, starting at the top and going clockwise, in the input's
+	// sorted order. Record each centre so edges can be routed rim-to-rim.
+	names := make([]string, 0, len(services))
+	for _, s := range services {
+		names = append(names, s.Name)
+	}
+	sort.Strings(names) // defensive: layout must not depend on caller ordering
+
+	cx, cy := diagramWidth/2, diagramHeight/2
+	type pt struct{ x, y float64 }
+	center := map[string]pt{}
+	view := &diagramView{Width: diagramWidth, Height: diagramHeight}
+
+	n := len(names)
+	for i, name := range names {
+		theta := -math.Pi/2 + 2*math.Pi*float64(i)/float64(n)
+		x := cx + diagramRadius*math.Cos(theta)
+		y := cy + diagramRadius*math.Sin(theta)
+		center[name] = pt{x, y}
+
+		anchor := "start"
+		labelX := x + diagramNodeR + diagramLabelPx
+		if math.Cos(theta) < -1e-9 { // left half → label ends at the node
+			anchor = "end"
+			labelX = x - diagramNodeR - diagramLabelPx
+		}
+		view.Nodes = append(view.Nodes, diagramNode{
+			Name: name, X: x, Y: y, LabelX: labelX, Anchor: anchor,
+		})
+	}
+
+	for _, e := range edges {
+		a, okA := center[e.Consumer]
+		b, okB := center[e.Provider]
+		if !okA || !okB || e.Consumer == e.Provider {
+			continue // endpoint not a known node (or a self-loop) → nothing to draw
+		}
+		dx, dy := b.x-a.x, b.y-a.y
+		dist := math.Hypot(dx, dy)
+		if dist < 1e-9 {
+			continue
+		}
+		ux, uy := dx/dist, dy/dist
+		// Trim both ends to the node rim.
+		x1, y1 := a.x+ux*diagramNodeR, a.y+uy*diagramNodeR
+		x2, y2 := b.x-ux*(diagramNodeR+3), b.y-uy*(diagramNodeR+3) // +3 leaves room for the arrowhead
+		// Control point: chord midpoint pushed perpendicular (left of the direction
+		// of travel), so A→B and B→A bow to opposite sides and stay distinct.
+		mx, my := (x1+x2)/2, (y1+y2)/2
+		off := dist * diagramCurve
+		cxp, cyp := mx-uy*off, my+ux*off
+		view.Edges = append(view.Edges, diagramEdge{
+			X1: x1, Y1: y1, CX: cxp, CY: cyp, X2: x2, Y2: y2,
+		})
+	}
+
+	return view
+}

--- a/pkg/dashboard/format.go
+++ b/pkg/dashboard/format.go
@@ -1,0 +1,35 @@
+package dashboard
+
+import (
+	"fmt"
+	"time"
+)
+
+// formatDuration renders a duration as "1h 2m 3s" / "2m 3s" / "3s", matching the
+// status package's --status output style.
+func formatDuration(d time.Duration) string {
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm %ds", hours, minutes, seconds)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}
+
+// humanCount renders a large count with K/M suffixes (e.g. 1.2M), matching the
+// status package's --status output style.
+func humanCount(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}

--- a/pkg/dashboard/graphdetail.go
+++ b/pkg/dashboard/graphdetail.go
@@ -1,0 +1,56 @@
+package dashboard
+
+import (
+	"sort"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+// serviceRow is one entry in the Services modal: a service node (a whole repo in
+// the cross-repo "graph of graphs") and how many other services it depends on.
+type serviceRow struct {
+	Name      string
+	DependsOn int
+}
+
+// edgeRow is one entry in the Cross-repo edges modal: a consumer service that
+// depends on a provider service.
+type edgeRow struct {
+	Consumer string
+	Provider string
+}
+
+// graphDetails enumerates the service and cross-repo-edge lists from the live
+// fact store — the same source the OSS engine reduces to the receipt's
+// service_count / cross_repo_edge_count. Services are the KindService nodes; each
+// cross-repo edge is a service node's depends_on relation (consumer → provider).
+// A nil store (no snapshot loaded, or a test fake) yields empty lists, so the
+// dashboard cards fall back to plain, non-clickable numbers. Store.ByKind is
+// concurrency-safe and returns fact copies, so this only ever reads.
+func graphDetails(store *facts.Store) (services []serviceRow, edges []edgeRow) {
+	if store == nil {
+		return nil, nil
+	}
+
+	for _, svc := range store.ByKind(facts.KindService) {
+		dependsOn := 0
+		for _, rel := range svc.Relations {
+			if rel.Kind == facts.RelDependsOn {
+				dependsOn++
+				edges = append(edges, edgeRow{Consumer: svc.Name, Provider: rel.Target})
+			}
+		}
+		services = append(services, serviceRow{Name: svc.Name, DependsOn: dependsOn})
+	}
+
+	// Stable output, mirroring the OSS receipt's sort-by-label convention.
+	sort.Slice(services, func(i, j int) bool { return services[i].Name < services[j].Name })
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Consumer != edges[j].Consumer {
+			return edges[i].Consumer < edges[j].Consumer
+		}
+		return edges[i].Provider < edges[j].Provider
+	})
+
+	return services, edges
+}

--- a/pkg/dashboard/insights.go
+++ b/pkg/dashboard/insights.go
@@ -1,0 +1,144 @@
+package dashboard
+
+import (
+	"math"
+	"sort"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+// insightRow is one insight in a category group of the Insights modal.
+type insightRow struct {
+	Title      string
+	Confidence int  // 0-100
+	Structural bool // confidence >= 1.0 — a certain (non-heuristic) finding
+	Evidence   string
+}
+
+// insightGroup is all insights produced by one explainer (Source), with a bar
+// width proportional to its share of the largest group.
+type insightGroup struct {
+	Source string
+	Label  string
+	Count  int
+	BarPct int // 0-100, relative to the largest group
+	Items  []insightRow
+}
+
+// insightLabels maps an explainer Source id to a human-friendly label, one entry
+// per explainer bootstrap.NewEngine registers. The engine has no display-name
+// registry, so this mirror lives here.
+//
+// It doubles as the ADMISSION LIST: insightDetails renders only sources found
+// here. Both binaries share a repo's .enola/insights.json, so a file written by
+// a build with extra explainers must not leak findings this engine cannot
+// produce into this engine's dashboard. A wrapper widens the list — labelling
+// and admitting in one step — through Options.InsightLabels.
+var insightLabels = map[string]string{
+	"hotspots":            "Hotspots",
+	"god-class":           "God classes",
+	"exported-surface":    "Exported surface",
+	"complexity-outliers": "Complexity outliers",
+	"dependency-depth":    "Dependency depth",
+	"cycles":              "Dependency cycles",
+	"layers":              "Layer violations",
+	"crossrepo":           "Cross-repo dependencies",
+	"coverage":            "Coverage gaps",
+	"unused-routes":       "Unused routes",
+}
+
+// mergedLabels returns the engine's label map widened by a wrapper's extra
+// entries. The result is a copy, so a Server never mutates package state and two
+// dashboards in one process cannot see each other's labels.
+func mergedLabels(extra map[string]string) map[string]string {
+	merged := make(map[string]string, len(insightLabels)+len(extra))
+	for source, label := range insightLabels {
+		merged[source] = label
+	}
+	for source, label := range extra {
+		merged[source] = label
+	}
+	return merged
+}
+
+// firstEvidence returns the most locating evidence string for an insight: the first
+// evidence's File, else Symbol, else Fact. Empty when there is no evidence.
+func firstEvidence(ev []facts.Evidence) string {
+	for _, e := range ev {
+		switch {
+		case e.File != "":
+			return e.File
+		case e.Symbol != "":
+			return e.Symbol
+		case e.Fact != "":
+			return e.Fact
+		}
+	}
+	return ""
+}
+
+// insightDetails groups insights by explainer Source for the modal: one bar per
+// group (count-ranked, width relative to the largest group), each expandable to its
+// insights (sorted certain-first). It also returns the structural vs candidate split
+// (confidence == 1.0 vs < 1.0) shown in the modal header. A nil/empty list yields no
+// groups, so the counters stay plain, non-clickable numbers.
+//
+// labels is both the display-name map and the admission list: an insight whose
+// Source is absent from it is dropped, and excluded from the returned counts.
+func insightDetails(ins []facts.Insight, labels map[string]string) (groups []insightGroup, structural, candidate int) {
+	if len(ins) == 0 {
+		return nil, 0, 0
+	}
+
+	bySource := make(map[string][]insightRow)
+	for _, in := range ins {
+		if _, known := labels[in.Source]; !known {
+			continue // produced by explainers this build does not have
+		}
+		conf := int(math.Round(in.Confidence * 100))
+		isStructural := in.Confidence >= 1.0
+		if isStructural {
+			structural++
+		} else {
+			candidate++
+		}
+		bySource[in.Source] = append(bySource[in.Source], insightRow{
+			Title:      in.Title,
+			Confidence: conf,
+			Structural: isStructural,
+			Evidence:   firstEvidence(in.Evidence),
+		})
+	}
+
+	maxCount := 1
+	for _, items := range bySource {
+		if len(items) > maxCount {
+			maxCount = len(items)
+		}
+	}
+
+	for source, items := range bySource {
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].Confidence != items[j].Confidence {
+				return items[i].Confidence > items[j].Confidence
+			}
+			return items[i].Title < items[j].Title
+		})
+		groups = append(groups, insightGroup{
+			Source: source,
+			Label:  labels[source],
+			Count:  len(items),
+			BarPct: int(math.Round(float64(len(items)) / float64(maxCount) * 100)),
+			Items:  items,
+		})
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Count != groups[j].Count {
+			return groups[i].Count > groups[j].Count
+		}
+		return groups[i].Label < groups[j].Label
+	})
+
+	return groups, structural, candidate
+}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -1,0 +1,466 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{.Title}} — dashboard</title>
+  <style>
+    :root {
+      --bg: #ffffff; --fg: #1a1a1a; --muted: #666; --border: #e2e2e2;
+      --card: #f7f7f8; --accent: #2563eb; --ok: #16a34a; --off: #b91c1c;
+      --warn: #b45309; --th: #efeff1;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #16181d; --fg: #e6e6e6; --muted: #9aa0aa; --border: #2c2f36;
+        --card: #1e2127; --accent: #6ea8fe; --ok: #4ade80; --off: #f87171;
+        --warn: #fbbf24; --th: #242832;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; padding: 2rem 1.25rem; background: var(--bg); color: var(--fg);
+      font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    .wrap { max-width: 960px; margin: 0 auto; }
+    header { display: flex; flex-wrap: wrap; align-items: baseline; gap: .75rem; margin-bottom: .25rem; }
+    h1 { font-size: 1.4rem; margin: 0; }
+    h2 { font-size: 1.05rem; margin: 2rem 0 .6rem; border-bottom: 1px solid var(--border); padding-bottom: .35rem; }
+    .refresh { color: var(--muted); font-size: .85rem; margin-bottom: 1.25rem; }
+    .badge { font-size: .8rem; font-weight: 600; padding: .1rem .5rem; border-radius: 999px; }
+    .badge.on { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
+    .badge.off { background: color-mix(in srgb, var(--off) 18%, transparent); color: var(--off); }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .75rem; }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: .75rem .9rem; }
+    .card .k { color: var(--muted); font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; }
+    .card .v { font-size: 1.15rem; font-weight: 600; margin-top: .15rem; word-break: break-word; }
+    .table-scroll { overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; font-variant-numeric: tabular-nums; }
+    th, td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--border); white-space: nowrap; }
+    th { background: var(--th); font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; color: var(--muted); }
+    td.num, th.num { text-align: right; }
+    tr.total td { font-weight: 700; border-top: 2px solid var(--border); }
+    .note { color: var(--muted); font-style: italic; }
+    .chips { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .2rem; }
+    .chip { background: var(--th); border: 1px solid var(--border); border-radius: 6px; padding: .05rem .45rem; font-size: .8rem; }
+    footer { margin-top: 2.5rem; color: var(--muted); font-size: .8rem; }
+    code { background: var(--th); padding: .05rem .3rem; border-radius: 4px; }
+    .count-link {
+      background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
+      color: var(--accent); font: inherit; font-weight: 600; text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+    .modal {
+      display: none; position: fixed; inset: 0; z-index: 50;
+      align-items: center; justify-content: center; padding: 1.25rem;
+      background: color-mix(in srgb, #000 55%, transparent);
+    }
+    .modal.open { display: flex; }
+    .modal-panel {
+      background: var(--bg); color: var(--fg); border: 1px solid var(--border);
+      border-radius: 12px; width: 100%; max-width: 560px; max-height: 80vh;
+      overflow: auto; padding: 1.1rem 1.25rem; box-shadow: 0 10px 40px rgba(0,0,0,.35);
+    }
+    .modal-head { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: .75rem; }
+    .modal-head h3 { margin: 0; font-size: 1.05rem; }
+    .modal-close {
+      background: none; border: 0; cursor: pointer; color: var(--muted);
+      font-size: 1.4rem; line-height: 1; padding: 0;
+    }
+    .modal-close:hover { color: var(--fg); }
+    .modal-panel.wide { max-width: 720px; }
+    .modal-head-actions { display: flex; align-items: center; gap: .55rem; }
+    .view-toggle {
+      background: none; border: 1px solid var(--border); border-radius: 6px;
+      cursor: pointer; color: var(--muted); padding: .2rem .3rem; line-height: 0;
+      display: inline-flex; align-items: center;
+    }
+    .view-toggle:hover { color: var(--fg); border-color: var(--muted); }
+    .view-toggle .vt-icon { fill: currentColor; stroke: currentColor; }
+    .edges-view[hidden] { display: none; }
+    .edge-graph { display: block; width: 100%; height: auto; max-height: 62vh; }
+    .edge-graph .edge-line { fill: none; stroke: var(--muted); stroke-width: 1.5; opacity: .5; }
+    .edge-graph #edge-arrow path { fill: var(--muted); }
+    .edge-graph .node circle { fill: var(--accent); }
+    .edge-graph .node text { fill: var(--fg); font-size: 12px; dominant-baseline: middle; }
+    .insight-summary { color: var(--muted); font-size: .85rem; margin: -.25rem 0 .6rem; }
+    .insight-filter { display: flex; align-items: center; gap: .5rem; margin: 0 0 .9rem; font-size: .85rem; }
+    .insight-filter label { color: var(--muted); }
+    .insight-filter select {
+      font: inherit; color: var(--fg); background: var(--card);
+      border: 1px solid var(--border); border-radius: 6px; padding: .2rem .4rem;
+    }
+    .insight-group { border: 1px solid var(--border); border-radius: 8px; margin-bottom: .5rem; overflow: hidden; }
+    .insight-group > summary {
+      list-style: none; cursor: pointer; display: flex; align-items: center; gap: .6rem;
+      padding: .5rem .7rem; background: var(--card);
+    }
+    .insight-group > summary::-webkit-details-marker { display: none; }
+    .insight-group > summary::before {
+      content: "▸"; color: var(--muted); font-size: .8rem; transition: transform .12s ease;
+    }
+    .insight-group[open] > summary::before { transform: rotate(90deg); }
+    .ig-label { flex: 0 0 auto; font-weight: 600; min-width: 8.5rem; }
+    .bar-track { flex: 1 1 auto; height: 8px; background: var(--th); border-radius: 999px; overflow: hidden; }
+    .bar-fill { height: 100%; min-width: 3px; background: var(--accent); border-radius: 999px; }
+    .ig-count { flex: 0 0 auto; font-variant-numeric: tabular-nums; font-weight: 600; min-width: 3ch; text-align: right; }
+    .insight-group .table-scroll { padding: .1rem .3rem .4rem; }
+    td.title { white-space: normal; }
+    .structural-chip { margin-left: .4rem; font-size: .72rem; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 0 .35rem; }
+    {{/* extra-styles: extension slot — see pkg/dashboard.Options.Overlay */}}
+    {{block "extra-styles" $}}{{end}}
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>{{.Title}}</h1>
+    {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
+  </header>
+  <div class="refresh">This page refreshes automatically every {{.RefreshSeconds}} seconds. Served on <code>http://127.0.0.1:{{.Port}}</code>.</div>
+
+  <div class="grid">
+    <div class="card"><div class="k">Server</div><div class="v">{{if .Running}}PID {{.PID}}{{else}}stopped{{end}}</div></div>
+    {{if .Uptime}}<div class="card"><div class="k">Uptime</div><div class="v">{{.Uptime}}</div></div>{{end}}
+    {{if .StartedAt}}<div class="card"><div class="k">Started</div><div class="v">{{.StartedAt}}</div></div>{{end}}
+    {{if .TrackingSince}}<div class="card"><div class="k">Tracking since</div><div class="v">{{.TrackingSince}}</div></div>{{end}}
+    <div class="card"><div class="k">Repos tracked</div><div class="v">{{.ReposTracked}}</div></div>
+    <div class="card"><div class="k">Dashboard port</div><div class="v">{{.Port}}</div></div>
+  </div>
+
+  <h2>Tool usage</h2>
+  {{if .Tools}}
+  <div class="table-scroll"><table>
+    <thead><tr><th>Tool</th><th class="num">Session</th><th class="num">Total</th></tr></thead>
+    <tbody>
+      {{range .Tools}}<tr><td>{{.Name}}</td><td class="num">{{.Session}}</td><td class="num">{{.Total}}</td></tr>{{end}}
+    </tbody>
+  </table></div>
+  {{else}}<p class="note">No tool calls recorded yet.</p>{{end}}
+
+  <h2>Value estimate <span class="note">(approximate)</span></h2>
+  {{if .Values}}
+  <div class="table-scroll"><table>
+    <thead><tr><th>Tool</th><th class="num">Calls</th><th class="num">~Time saved</th><th class="num">~Tokens saved</th></tr></thead>
+    <tbody>
+      {{range .Values}}<tr><td>{{.Label}}</td><td class="num">{{.Calls}}</td><td class="num">{{.TimeSaved}}</td><td class="num">{{.TokensSaved}}</td></tr>{{end}}
+      <tr class="total"><td>{{.ValueTotal.Label}}</td><td class="num">{{.ValueTotal.Calls}}</td><td class="num">{{.ValueTotal.TimeSaved}}</td><td class="num">{{.ValueTotal.TokensSaved}}</td></tr>
+    </tbody>
+  </table></div>
+  {{else}}<p class="note">No value recorded yet.</p>{{end}}
+
+  <h2>Current snapshot receipt</h2>
+  {{if .HasReceipt}}{{with .Receipt}}
+  <div class="grid">
+    <div class="card"><div class="k">Snapshot ID</div><div class="v">{{.SnapshotID}}</div></div>
+    <div class="card"><div class="k">enola version</div><div class="v">{{.EnolaVersion}}</div></div>
+    <div class="card"><div class="k">Generated at</div><div class="v">{{.GeneratedAt}}</div></div>
+    <div class="card"><div class="k">Duration</div><div class="v">{{.Duration}}</div></div>
+    <div class="card"><div class="k">Facts</div><div class="v">{{.FactCount}}</div></div>
+    <div class="card"><div class="k">Insights</div><div class="v">{{if $.Insights}}<button type="button" class="count-link" onclick="openModal('insights-modal')">{{$.InsightTotal}}</button>{{else}}{{.InsightCount}}{{end}}</div></div>
+    {{/* extra-cards: extension slot — see pkg/dashboard.Options.Overlay */}}
+    {{block "extra-cards" $}}{{end}}
+    {{if .Git}}<div class="card"><div class="k">Git</div><div class="v">{{.Git.Ref}}{{if .Git.Commit}} @ {{.Git.Commit}}{{end}}{{if .Git.Dirty}} (dirty){{end}}</div></div>{{end}}
+  </div>
+  <div class="card" style="margin-top:.75rem"><div class="k">Repo path</div><div class="v">{{.RepoPath}}</div></div>
+  {{if .Extractors}}<div style="margin-top:.75rem"><div class="k">Extractors</div><div class="chips">{{range .Extractors}}<span class="chip">{{.}}</span>{{end}}</div></div>{{end}}
+  {{if .Explainers}}<div style="margin-top:.6rem"><div class="k">Explainers</div><div class="chips">{{range .Explainers}}<span class="chip">{{.}}</span>{{end}}</div></div>{{end}}
+
+  <h3 style="margin:1.25rem 0 .5rem;font-size:.95rem">Extraction quality</h3>
+  <div class="grid">
+    <div class="card"><div class="k">Files seen</div><div class="v">{{.Quality.FilesSeen}}</div></div>
+    <div class="card"><div class="k">Files parsed</div><div class="v">{{.Quality.FilesParsed}}</div></div>
+    <div class="card"><div class="k">Files skipped</div><div class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.FilesSkipped}}</button>{{else}}{{.Quality.FilesSkipped}}{{end}}</div></div>
+    <div class="card"><div class="k">Dirs skipped</div><div class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.DirsSkipped}}</button>{{else}}{{.Quality.DirsSkipped}}{{end}}</div></div>
+    <div class="card"><div class="k">Parse errors</div><div class="v">{{if $.ParseErrors}}<button type="button" class="count-link" onclick="openModal('parse-errors-modal')">{{.Quality.ParseErrors}}</button>{{else}}{{.Quality.ParseErrors}}{{end}}</div></div>
+    {{if .Quality.Coverage}}{{with .Quality.Coverage}}
+    <div class="card"><div class="k">Services</div><div class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.ServicesTotal}}</button>{{else}}{{.ServicesTotal}}{{end}}</div></div>
+    <div class="card"><div class="k">Coverage gaps</div><div class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.CoverageGaps}}</button>{{else}}{{.CoverageGaps}}{{end}}</div></div>
+    <div class="card"><div class="k">Unresolved edges</div><div class="v">{{if $.UnresolvedRoutes}}<button type="button" class="count-link" onclick="openModal('coverage-unresolved-modal')">{{.UnresolvedEdges}}</button>{{else}}{{.UnresolvedEdges}}{{end}}</div></div>
+    {{end}}{{end}}
+  </div>
+  {{end}}{{else}}<p class="note">{{.ReceiptNote}}</p>{{end}}
+
+  <h2>Graph receipt <span class="note">(~/.enola/receipt.json)</span></h2>
+  {{if .HasGraph}}{{with .Graph}}
+  <div class="grid">
+    <div class="card"><div class="k">Snapshot ID</div><div class="v">{{.SnapshotID}}</div></div>
+    <div class="card"><div class="k">enola version</div><div class="v">{{.EnolaVersion}}</div></div>
+    <div class="card"><div class="k">Generated at</div><div class="v">{{.GeneratedAt}}</div></div>
+    <div class="card"><div class="k">Facts</div><div class="v">{{.FactCount}}</div></div>
+    <div class="card"><div class="k">Insights</div><div class="v">{{if $.Insights}}<button type="button" class="count-link" onclick="openModal('insights-modal')">{{$.InsightTotal}}</button>{{else}}{{.InsightCount}}{{end}}</div></div>
+    <div class="card"><div class="k">Services</div><div class="v">{{if $.Services}}<button type="button" class="count-link" onclick="openModal('services-modal')">{{.ServiceCount}}</button>{{else}}{{.ServiceCount}}{{end}}</div></div>
+    <div class="card"><div class="k">Cross-repo edges</div><div class="v">{{if $.CrossRepoEdges}}<button type="button" class="count-link" onclick="openModal('edges-modal')">{{.CrossRepoEdgeCount}}</button>{{else}}{{.CrossRepoEdgeCount}}{{end}}</div></div>
+  </div>
+  {{if .Repos}}
+  <h3 style="margin:1.25rem 0 .5rem;font-size:.95rem">Repos in graph</h3>
+  <div class="table-scroll"><table>
+    <thead><tr><th>Label</th><th>Path</th><th>Added</th><th>In graph for</th><th class="num">Facts</th></tr></thead>
+    <tbody>
+      {{range .Repos}}<tr><td>{{.Label}}</td><td>{{.Path}}</td><td>{{.AddedAt}}</td><td>{{.InGraphFor}}</td><td class="num">{{.FactCount}}</td></tr>{{end}}
+    </tbody>
+  </table></div>
+  {{end}}
+  {{end}}{{else}}<p class="note">{{.GraphNote}}</p>{{end}}
+
+  <footer>{{.Title}} dashboard · read-only · localhost only</footer>
+</div>
+
+{{if .Services}}
+<div class="modal" id="services-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel" role="dialog" aria-modal="true" aria-label="Services">
+    <div class="modal-head">
+      <h3>Services <span class="note">({{len .Services}})</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="table-scroll"><table>
+      <thead><tr><th>Service</th><th class="num">Depends on</th></tr></thead>
+      <tbody>
+        {{range .Services}}<tr><td>{{.Name}}</td><td class="num">{{.DependsOn}}</td></tr>{{end}}
+      </tbody>
+    </table></div>
+  </div>
+</div>
+{{end}}
+
+{{if .CrossRepoEdges}}
+<div class="modal" id="edges-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel wide" role="dialog" aria-modal="true" aria-label="Cross-repo edges">
+    <div class="modal-head">
+      <h3>Cross-repo edges <span class="note">({{len .CrossRepoEdges}})</span></h3>
+      <div class="modal-head-actions">
+        {{if .EdgeDiagram}}
+        <button type="button" id="edges-view-toggle" class="view-toggle" aria-label="Switch to table view" aria-pressed="true" title="Toggle diagram / table view" onclick="toggleEdgesView()">
+          <svg class="vt-icon vt-to-table" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="2.2" rx="1"/><rect x="1.5" y="6.9" width="13" height="2.2" rx="1"/><rect x="1.5" y="11.3" width="13" height="2.2" rx="1"/></svg>
+          <svg class="vt-icon vt-to-diagram" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" hidden><circle cx="3.2" cy="3.2" r="2.1"/><circle cx="12.8" cy="4.6" r="2.1"/><circle cx="7.5" cy="12.6" r="2.1"/><path d="M4.6 4.2 11 4.2 M4.4 4.9 6.6 11 M11.4 6 8.4 11.2" stroke-width="1.3" fill="none"/></svg>
+        </button>
+        {{end}}
+        <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+      </div>
+    </div>
+    {{if .EdgeDiagram}}
+    <div id="edges-diagram" class="edges-view">
+      <svg class="edge-graph" viewBox="0 0 {{.EdgeDiagram.Width}} {{.EdgeDiagram.Height}}" role="img" aria-label="Cross-repo edge diagram">
+        <defs>
+          <marker id="edge-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z"/>
+          </marker>
+        </defs>
+        {{range .EdgeDiagram.Edges}}<path class="edge-line" d="M{{.X1}},{{.Y1}} Q{{.CX}},{{.CY}} {{.X2}},{{.Y2}}" marker-end="url(#edge-arrow)"/>{{end}}
+        {{range .EdgeDiagram.Nodes}}<g class="node"><circle cx="{{.X}}" cy="{{.Y}}" r="5"/><text x="{{.LabelX}}" y="{{.Y}}" text-anchor="{{.Anchor}}">{{.Name}}</text></g>{{end}}
+      </svg>
+    </div>
+    {{end}}
+    <div id="edges-table" class="edges-view"{{if .EdgeDiagram}} hidden{{end}}>
+      <div class="table-scroll"><table>
+        <thead><tr><th>Consumer</th><th></th><th>Provider</th></tr></thead>
+        <tbody>
+          {{range .CrossRepoEdges}}<tr><td>{{.Consumer}}</td><td class="note">&rarr;</td><td>{{.Provider}}</td></tr>{{end}}
+        </tbody>
+      </table></div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+{{if .Insights}}
+<div class="modal" id="insights-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel wide" role="dialog" aria-modal="true" aria-label="Insights">
+    <div class="modal-head">
+      <h3>Insights</h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="insight-summary">{{.InsightStructural}} structural &middot; {{.InsightCandidate}} candidate{{if ne .InsightCandidate 1}}s{{end}} &mdash; grouped by explainer, click a row to expand</div>
+    <div class="insight-filter">
+      <label for="insight-band">Confidence</label>
+      <select id="insight-band" onchange="filterInsights(this.value)">
+        <option value="all">All</option>
+        <option value="structural">Structural (100%)</option>
+        <option value="high">High (85&ndash;99%)</option>
+        <option value="medium">Medium (65&ndash;84%)</option>
+        <option value="low">Low (&lt;65%)</option>
+      </select>
+      <span class="note"><span id="insight-shown">{{.InsightTotal}}</span> shown</span>
+    </div>
+    {{range .Insights}}
+    <details class="insight-group">
+      <summary>
+        <span class="ig-label">{{.Label}}</span>
+        <span class="bar-track"><span class="bar-fill" style="width:{{.BarPct}}%"></span></span>
+        <span class="ig-count">{{.Count}}</span>
+      </summary>
+      <div class="table-scroll"><table>
+        <thead><tr><th>Title</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
+        <tbody>
+          {{range .Items}}<tr data-conf="{{.Confidence}}"><td class="title">{{.Title}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip">structural</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
+        </tbody>
+      </table></div>
+    </details>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+{{if .Coverage}}
+<div class="modal" id="coverage-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel wide" role="dialog" aria-modal="true" aria-label="Cross-repo coverage">
+    <div class="modal-head">
+      <h3>Cross-repo coverage <span class="note">({{len .Coverage}} services)</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="table-scroll"><table>
+      <thead><tr><th>Service</th><th class="num">Resolved</th><th class="num">Detected</th><th class="num">Unresolved</th><th class="num">External</th><th>Status</th></tr></thead>
+      <tbody>
+        {{range .Coverage}}<tr><td>{{.Service}}</td><td class="num">{{.Resolved}}</td><td class="num">{{.Detected}}</td><td class="num">{{.Unresolved}}</td><td class="num">{{.External}}</td><td>{{.Status}}</td></tr>{{end}}
+      </tbody>
+    </table></div>
+  </div>
+</div>
+{{end}}
+
+{{if .UnresolvedRoutes}}
+<div class="modal" id="coverage-unresolved-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel wide" role="dialog" aria-modal="true" aria-label="Unresolved edges">
+    <div class="modal-head">
+      <h3>Unresolved edges <span class="note">({{len .UnresolvedRoutes}})</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="insight-summary">Client call sites for which no loaded server route matched.</div>
+    <div class="table-scroll"><table>
+      <thead><tr><th>Method</th><th>Path</th><th>Repo</th><th>Reason</th></tr></thead>
+      <tbody>
+        {{range .UnresolvedRoutes}}<tr><td>{{.Method}}</td><td class="title">{{.Path}}</td><td>{{.Repo}}</td><td>{{.Reason}}</td></tr>{{end}}
+      </tbody>
+    </table></div>
+  </div>
+</div>
+{{end}}
+
+{{if .SkippedSample}}
+<div class="modal" id="skipped-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel" role="dialog" aria-modal="true" aria-label="Skipped">
+    <div class="modal-head">
+      <h3>Skipped <span class="note">(sample, up to 20)</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="insight-summary">Files and directories the walker ignored; each names the glob that matched it.</div>
+    <div class="chips">{{range .SkippedSample}}<span class="chip">{{.}}</span>{{end}}</div>
+  </div>
+</div>
+{{end}}
+
+{{if .ParseErrors}}
+<div class="modal" id="parse-errors-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel wide" role="dialog" aria-modal="true" aria-label="Parse errors">
+    <div class="modal-head">
+      <h3>Parse errors <span class="note">(sample, up to 20)</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="table-scroll"><table>
+      <thead><tr><th>Extractor</th><th>File</th><th>Message</th></tr></thead>
+      <tbody>
+        {{range .ParseErrors}}<tr><td>{{.Extractor}}</td><td>{{.File}}</td><td class="title">{{.Msg}}</td></tr>{{end}}
+      </tbody>
+    </table></div>
+  </div>
+</div>
+{{end}}
+
+{{/* extra-modals: extension slot — see pkg/dashboard.Options.Overlay */}}
+{{block "extra-modals" $}}{{end}}
+
+<script>
+  // JS-driven auto-refresh (replaces the old <meta refresh>) so it can be paused
+  // while a modal is open — otherwise a reload would close the modal mid-read.
+  var refreshMs = {{.RefreshSeconds}} * 1000;
+  var reloadTimer = null;
+  function startRefresh() { stopRefresh(); reloadTimer = setTimeout(function () { location.reload(); }, refreshMs); }
+  function stopRefresh() { if (reloadTimer !== null) { clearTimeout(reloadTimer); reloadTimer = null; } }
+  function openModal(id) {
+    var m = document.getElementById(id);
+    if (!m) return;
+    stopRefresh();
+    m.classList.add('open');
+    if (id === 'insights-modal') {
+      var sel = document.getElementById('insight-band');
+      if (sel) { sel.value = 'all'; filterInsights('all'); } // reopen starts unfiltered
+    }
+  }
+
+  // insightBandMatch reports whether a row's confidence percent falls in the band.
+  function insightBandMatch(band, c) {
+    switch (band) {
+      case 'structural': return c >= 100;
+      case 'high':       return c >= 85 && c < 100;
+      case 'medium':     return c >= 65 && c < 85;
+      case 'low':        return c < 65;
+      default:           return true; // all
+    }
+  }
+  // filterInsights shows only rows in the chosen confidence band, then rescales each
+  // explainer group's count and bar to the visible rows and hides emptied groups.
+  function filterInsights(band) {
+    var modal = document.getElementById('insights-modal');
+    if (!modal) return;
+    var groups = modal.querySelectorAll('.insight-group');
+    var visibleCounts = [];
+    var maxVisible = 1;
+    groups.forEach(function (g) {
+      var n = 0;
+      g.querySelectorAll('tbody tr').forEach(function (r) {
+        var show = insightBandMatch(band, parseInt(r.getAttribute('data-conf'), 10));
+        r.style.display = show ? '' : 'none';
+        if (show) n++;
+      });
+      visibleCounts.push(n);
+      if (n > maxVisible) maxVisible = n;
+    });
+    var total = 0;
+    groups.forEach(function (g, i) {
+      var n = visibleCounts[i];
+      g.style.display = n ? '' : 'none';
+      var count = g.querySelector('.ig-count');
+      if (count) count.textContent = n;
+      var bar = g.querySelector('.bar-fill');
+      if (bar) bar.style.width = Math.round(n / maxVisible * 100) + '%';
+      total += n;
+    });
+    var shown = document.getElementById('insight-shown');
+    if (shown) shown.textContent = total;
+  }
+  // toggleEdgesView flips the Cross-repo edges modal between the node-link diagram
+  // and the consumer→provider table, updating the header toggle's icon and state.
+  function toggleEdgesView() {
+    var diagram = document.getElementById('edges-diagram');
+    var table = document.getElementById('edges-table');
+    var btn = document.getElementById('edges-view-toggle');
+    if (!diagram || !table) return;
+    var showTable = !diagram.hidden; // diagram currently visible → switch to table
+    diagram.hidden = showTable;
+    table.hidden = !showTable;
+    if (btn) {
+      btn.setAttribute('aria-pressed', showTable ? 'false' : 'true');
+      btn.setAttribute('aria-label', showTable ? 'Switch to diagram view' : 'Switch to table view');
+      var toTable = btn.querySelector('.vt-to-table');
+      var toDiagram = btn.querySelector('.vt-to-diagram');
+      if (toTable) toTable.hidden = showTable;
+      if (toDiagram) toDiagram.hidden = !showTable;
+    }
+  }
+  {{/* extra-scripts: extension slot — see pkg/dashboard.Options.Overlay */}}
+  {{block "extra-scripts" $}}{{end}}
+  function closeModal(el) {
+    var m = el && el.closest ? el.closest('.modal') : el;
+    if (m && m.classList) m.classList.remove('open');
+    startRefresh();
+  }
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      var open = document.querySelector('.modal.open');
+      if (open) closeModal(open);
+    }
+  });
+  startRefresh();
+</script>
+</body>
+</html>

--- a/pkg/dashboard/quality.go
+++ b/pkg/dashboard/quality.go
@@ -1,0 +1,159 @@
+package dashboard
+
+import (
+	"sort"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+// coverageRow is one service's cross-repo coverage, backing the Services / Coverage
+// gaps cards. Resolved is the count of resolved outbound (depends_on) edges;
+// Detected/Unresolved/External are summed across the service's edge_coverage
+// entries; Status classifies the node (connected | coverage_gap | isolated).
+type coverageRow struct {
+	Service    string
+	Resolved   int
+	Detected   int
+	Unresolved int
+	External   int
+	Status     string
+}
+
+// routeRow is one unmatched client route, backing the Unresolved edges card — a
+// client call site for which no loaded server route matched.
+type routeRow struct {
+	Method string
+	Path   string
+	Repo   string
+	Reason string
+	File   string
+	Line   int
+}
+
+// Service coverage classifications — mirrors facts.ClassifyService (the OSS logic
+// is internal-only, so the tiny decision is reproduced here).
+const (
+	svcConnected   = "connected"
+	svcCoverageGap = "coverage_gap"
+	svcIsolated    = "isolated"
+)
+
+// classifyService reproduces facts.ClassifyService: any resolved outbound edge →
+// connected; else detected-but-unresolved call sites → coverage_gap (a blind spot);
+// else a genuine leaf → isolated.
+func classifyService(resolved, detected, unresolved int) string {
+	if resolved > 0 {
+		return svcConnected
+	}
+	if detected > 0 && unresolved > 0 {
+		return svcCoverageGap
+	}
+	return svcIsolated
+}
+
+// coverageDetails enumerates cross-repo coverage from the live store: one row per
+// service node (with its edge_coverage tallies and classification) and the list of
+// unmatched client routes (the constituents of the unresolved-edges count). A nil
+// store yields empty lists, so the cards fall back to plain numbers.
+func coverageDetails(store *facts.Store) (services []coverageRow, unresolved []routeRow) {
+	if store == nil {
+		return nil, nil
+	}
+
+	for _, svc := range store.ByKind(facts.KindService) {
+		resolved := 0
+		for _, rel := range svc.Relations {
+			if rel.Kind == facts.RelDependsOn {
+				resolved++
+			}
+		}
+		detected := edgeCoverageSum(svc, "detected")
+		unres := edgeCoverageSum(svc, "unresolved")
+		services = append(services, coverageRow{
+			Service:    svc.Name,
+			Resolved:   resolved,
+			Detected:   detected,
+			Unresolved: unres,
+			External:   edgeCoverageSum(svc, "external"),
+			Status:     classifyService(resolved, detected, unres),
+		})
+	}
+	sort.Slice(services, func(i, j int) bool { return services[i].Service < services[j].Service })
+
+	for _, r := range store.ByKind(facts.KindRoute) {
+		if !propBool(r, "unmatched_by_server") {
+			continue
+		}
+		unresolved = append(unresolved, routeRow{
+			Method: propStr(r, "method"),
+			Path:   r.Name,
+			Repo:   r.Repo,
+			Reason: propStr(r, "unmatched_reason"),
+			File:   r.File,
+			Line:   r.Line,
+		})
+	}
+	sort.Slice(unresolved, func(i, j int) bool {
+		if unresolved[i].Repo != unresolved[j].Repo {
+			return unresolved[i].Repo < unresolved[j].Repo
+		}
+		if unresolved[i].Path != unresolved[j].Path {
+			return unresolved[i].Path < unresolved[j].Path
+		}
+		return unresolved[i].Line < unresolved[j].Line
+	})
+
+	return services, unresolved
+}
+
+// edgeCoverageSum totals a numeric field across a service node's edge_coverage prop
+// (one entry per edge_type). Mirrors the engine's readCoverageField: the value may
+// be []map[string]any or []any, with int (in-process) or float64 (JSON) numbers.
+func edgeCoverageSum(svc facts.Fact, field string) int {
+	if svc.Props == nil {
+		return 0
+	}
+	var entries []map[string]any
+	switch v := svc.Props["edge_coverage"].(type) {
+	case []map[string]any:
+		entries = v
+	case []any:
+		for _, item := range v {
+			if m, ok := item.(map[string]any); ok {
+				entries = append(entries, m)
+			}
+		}
+	default:
+		return 0
+	}
+	total := 0
+	for _, m := range entries {
+		switch n := m[field].(type) {
+		case int:
+			total += n
+		case float64:
+			total += int(n)
+		}
+	}
+	return total
+}
+
+// propStr returns a string-valued prop, or "" when absent/non-string.
+func propStr(f facts.Fact, key string) string {
+	if f.Props == nil {
+		return ""
+	}
+	if s, ok := f.Props[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// propBool returns a bool-valued prop, or false when absent/non-bool.
+func propBool(f facts.Fact, key string) bool {
+	if f.Props == nil {
+		return false
+	}
+	b, ok := f.Props[key].(bool)
+	return ok && b
+}

--- a/pkg/facts/facts.go
+++ b/pkg/facts/facts.go
@@ -21,6 +21,20 @@ type (
 	Artifact = internal.Artifact
 )
 
+// Receipt / provenance types (aliases — identical to the internal types).
+// Re-exported so consumers that read a receipt back — the dashboard, and any
+// out-of-module tool checking provenance or extraction quality — unmarshal into
+// the engine's own shapes instead of hand-written JSON mirrors that drift.
+type (
+	Receipt         = internal.Receipt
+	ReceiptQuality  = internal.ReceiptQuality
+	GraphReceipt    = internal.GraphReceipt
+	GraphRepoEntry  = internal.GraphRepoEntry
+	CoverageSummary = internal.CoverageSummary
+	ParseError      = internal.ParseError
+	GitInfo         = internal.GitInfo
+)
+
 // Graph / impact-analysis types (aliases — identical to the internal types).
 // Re-exported so out-of-module consumers (the enterprise architecture validator)
 // can run reverse-dependency impact analysis over a snapshot's facts.


### PR DESCRIPTION
Starting the MCP server now also serves one auto-refreshing page on a free loopback port; --no-dashboard opts out, and --status prints the URL while the server is up. The page shows the same activity and value data as --status plus the snapshot and graph receipts, the service and cross-repo-edge lists (with a node-link diagram), insights grouped by explainer and filterable by confidence, and the extraction-quality proof — coverage, unresolved routes, and the skipped-file and parse-error samples. It is strictly a viewer: every request reads through the same concurrency-safe accessors the MCP tools use, and each source degrades to an explanatory note rather than an error page. Receipts are read into facts.Receipt/facts.GraphReceipt, now re-exported from pkg/facts so consumers stop hand-writing JSON mirrors that drift. Only insights from explainers this build registers are rendered — the label map doubles as the admission list — and the clickable counters render that filtered total, so the number you click always matches the list you get. Options keeps the page extensible without forking it: a template overlay over the blocks OverlayBlocks() publishes, a per-request function supplying their data, extra insight labels, and the product title.