### PR TITLE
fix: correct reversed cross-repo edges and mislabeled graph nodes

### DIFF
--- a/internal/facts/graph.go
+++ b/internal/facts/graph.go
@@ -13,7 +13,7 @@ type Graph struct {
 	forward  map[string][]Edge   // fact name → outgoing edges
 	reverse  map[string][]Edge   // fact name → incoming edges
 	facts    []Fact              // reference to the store's facts (for metadata lookups)
-	factIdx  map[string]int      // fact name → first index in facts slice
+	factIdx  map[string][]int    // fact name → every index in facts slice declaring that name
 	edgeSeen map[string]struct{} // deduplication: "source\x00kind\x00target"
 }
 
@@ -44,6 +44,13 @@ type TraversalNode struct {
 	// or calls into packages that weren't analyzed). The edge is real; the
 	// destination symbol just isn't in the graph.
 	Unresolved bool `json:"unresolved,omitempty"`
+	// Conflated lists the distinct fact kinds sharing this node's name, when more
+	// than one does. Graph nodes are keyed by name, so same-named facts merge into
+	// one node and their edges are unioned. Kind/File/Repo above describe whichever
+	// fact best fits the relation that reached the node; this field admits that the
+	// node also stands for others, so a walk through it is not read as more precise
+	// than it is.
+	Conflated []string `json:"conflated,omitempty"`
 }
 
 // TraversalEdge is an edge traversed during traversal.
@@ -100,7 +107,7 @@ func NewGraph(ff []Fact) *Graph {
 		forward:  make(map[string][]Edge),
 		reverse:  make(map[string][]Edge),
 		facts:    ff,
-		factIdx:  make(map[string]int, len(ff)),
+		factIdx:  make(map[string][]int, len(ff)),
 		edgeSeen: make(map[string]struct{}),
 	}
 
@@ -109,9 +116,10 @@ func NewGraph(ff []Fact) *Graph {
 	modulePaths := make(map[string]struct{}) // Go module paths for cross-repo normalisation
 	for i, f := range ff {
 		if f.Name != "" {
-			if _, exists := g.factIdx[f.Name]; !exists {
-				g.factIdx[f.Name] = i
-			}
+			// Every fact declaring the name is recorded, not just the first: which
+			// one a node means depends on the edge that reaches it, and that is not
+			// known until traversal time.
+			g.factIdx[f.Name] = append(g.factIdx[f.Name], i)
 		}
 		if f.Kind == KindModule {
 			moduleNames[f.Name] = true
@@ -194,8 +202,10 @@ func (g *Graph) methodOwner(name string) string {
 		return ""
 	}
 	owner := name[:dot]
-	idx, ok := g.factIdx[owner]
-	if !ok || idx >= len(g.facts) {
+	// A method's owner is a symbol, so resolve with that context rather than the
+	// bare name — a type sharing a name with a module must still find the type.
+	idx, ok := g.factIndexFor(owner, RelHasMethod)
+	if !ok {
 		return ""
 	}
 	of := g.facts[idx]
@@ -281,7 +291,7 @@ func (g *Graph) traverseFrom(starts []string, direction string, relKinds, nodeKi
 		}
 		visited[start] = true
 		queue = append(queue, queueItem{name: start, depth: 0})
-		result.Nodes = append(result.Nodes, g.nodeFor(start, 0))
+		result.Nodes = append(result.Nodes, g.nodeFor(start, 0, ""))
 	}
 
 	truncated := false
@@ -331,7 +341,7 @@ func (g *Graph) traverseFrom(starts []string, direction string, relKinds, nodeKi
 				maxDepthReached = newDepth
 			}
 
-			node := g.nodeFor(e.Target, newDepth)
+			node := g.nodeFor(e.Target, newDepth, e.RelKind)
 
 			// Apply node kind filter
 			if kindSet != nil {
@@ -398,7 +408,7 @@ func (g *Graph) FindPath(from, to string, relKinds []string, maxDepth int) PathR
 			From:  from,
 			To:    to,
 			Found: true,
-			Path:  []TraversalNode{g.nodeFor(from, 0)},
+			Path:  []TraversalNode{g.nodeFor(from, 0, "")},
 		}
 	}
 
@@ -464,7 +474,9 @@ func (g *Graph) FindPath(from, to string, relKinds []string, maxDepth int) PathR
 	}
 
 	for i, name := range path {
-		result.Path = append(result.Path, g.nodeFor(name, i))
+		// The origin has no incoming edge; every later hop is identified by the
+		// relation that reached it.
+		result.Path = append(result.Path, g.nodeFor(name, i, parentEdge[name].RelKind))
 	}
 
 	// Reconstruct edges along the path
@@ -557,7 +569,7 @@ func (g *Graph) ImpactSet(target string, maxDepth, maxNodes int, includeForward 
 func (g *Graph) repoOf(name string) string {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	if idx, ok := g.factIdx[name]; ok && idx < len(g.facts) {
+	if idx, ok := g.factIndexFor(name, ""); ok {
 		return g.facts[idx].Repo
 	}
 	return ""
@@ -574,8 +586,11 @@ func (g *Graph) impactSeeds(target string) []string {
 	defer g.mu.RUnlock()
 
 	seeds := []string{target}
-	idx, ok := g.factIdx[target]
-	if !ok || idx >= len(g.facts) {
+	// Seed expansion only applies to type symbols, so resolve with symbol context:
+	// a type sharing a name with a module or service must still expand its methods.
+	// When no symbol declares the name the kind check below returns the bare target.
+	idx, ok := g.factIndexFor(target, RelHasMethod)
+	if !ok {
 		return seeds
 	}
 	if g.facts[idx].Kind != KindSymbol {
@@ -689,7 +704,7 @@ func (g *Graph) ReverseFacts(targetName, relKind string) []Fact {
 			continue
 		}
 		seen[sourceName] = struct{}{}
-		if idx, ok := g.factIdx[sourceName]; ok && idx < len(g.facts) {
+		if idx, ok := g.factIndexFor(sourceName, e.RelKind); ok {
 			result = append(result, g.facts[idx])
 		}
 	}
@@ -755,7 +770,7 @@ func (g *Graph) ArchitecturalReverse() map[string][]Edge {
 				continue
 			}
 			// In a reverse edge, e.Target holds the SOURCE fact name.
-			if idx, ok := g.factIdx[e.Target]; ok && idx < len(g.facts) &&
+			if idx, ok := g.factIndexFor(e.Target, e.RelKind); ok &&
 				isReferenceOnlyKind(g.facts[idx].Kind) {
 				continue
 			}
@@ -786,14 +801,113 @@ func (g *Graph) EdgeCount() int {
 	return count
 }
 
-func (g *Graph) nodeFor(name string, depth int) TraversalNode {
+// kindForRel maps the relation that reached a node to the fact kind that relation
+// naturally targets. A node's name alone cannot identify it when several facts share
+// that name — module names are repo-root-relative, so any top-level directory whose
+// name matches a repo label collides with that repo's service node — but the edge used
+// to arrive says which one was meant: only a service is the target of depends_on, only
+// a module of imports.
+var kindForRel = map[string]string{
+	RelDependsOn:    KindService,
+	RelImports:      KindModule,
+	RelCalls:        KindSymbol,
+	RelImplements:   KindSymbol,
+	RelHasMethod:    KindSymbol,
+	RelInstantiates: KindSymbol,
+	RelInjects:      KindSymbol,
+	RelDeclares:     KindSymbol,
+	RelHandledBy:    KindRoute,
+}
+
+// kindRank orders fact kinds for picking among same-named facts when there is no edge
+// context — a traversal origin, or a relation whose natural kind is absent. Lower wins.
+// Services rank first because they are synthetic whole-repo nodes: if a name is both a
+// repo label and something else, the repo is the more meaningful node in the graph
+// queries (traverse/find_path/impact) that reach it.
+var kindRank = map[string]int{
+	KindService:    0,
+	KindModule:     1,
+	KindSymbol:     2,
+	KindRoute:      3,
+	KindStorage:    4,
+	KindDependency: 5,
+}
+
+func rankOf(kind string) int {
+	if r, ok := kindRank[kind]; ok {
+		return r
+	}
+	return len(kindRank) // unknown kinds sort last, deterministically
+}
+
+// factIndexFor picks which of the facts named name represents the node, preferring the
+// kind natural for viaRel (the relation that reached the node; "" when there is none)
+// and otherwise falling back to kindRank. Returns false when no fact backs the name.
+func (g *Graph) factIndexFor(name, viaRel string) (int, bool) {
+	idxs := g.factIdx[name]
+	if len(idxs) == 0 {
+		return 0, false
+	}
+	if len(idxs) == 1 {
+		if idxs[0] >= len(g.facts) {
+			return 0, false
+		}
+		return idxs[0], true
+	}
+
+	want := kindForRel[viaRel]
+	best, found := 0, false
+	for _, idx := range idxs {
+		if idx >= len(g.facts) {
+			continue
+		}
+		if want != "" && g.facts[idx].Kind == want {
+			return idx, true // exact edge-context match: nothing can beat it
+		}
+		if !found || rankOf(g.facts[idx].Kind) < rankOf(g.facts[best].Kind) {
+			best, found = idx, true
+		}
+	}
+	return best, found
+}
+
+// conflatedKinds returns the distinct kinds sharing name, sorted, when more than one
+// fact declares it — the honest signal that this graph node merges several facts and
+// their edges. Returns nil for the common single-fact case.
+func (g *Graph) conflatedKinds(name string) []string {
+	idxs := g.factIdx[name]
+	if len(idxs) < 2 {
+		return nil
+	}
+	seen := map[string]bool{}
+	for _, idx := range idxs {
+		if idx < len(g.facts) {
+			seen[g.facts[idx].Kind] = true
+		}
+	}
+	if len(seen) < 2 {
+		return nil // several facts, but all the same kind — not a cross-kind conflation
+	}
+	kinds := make([]string, 0, len(seen))
+	for k := range seen {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+// nodeFor builds the traversal node for name. viaRel is the relation kind that reached
+// it, or "" for a traversal/path origin; it disambiguates which fact the node means
+// when a name is shared.
+func (g *Graph) nodeFor(name string, depth int, viaRel string) TraversalNode {
 	node := TraversalNode{Name: name, Depth: depth}
-	if idx, ok := g.factIdx[name]; ok && idx < len(g.facts) {
+	if idx, ok := g.factIndexFor(name, viaRel); ok {
 		f := g.facts[idx]
 		node.Kind = f.Kind
 		node.File = f.File
 		node.Line = f.Line
 		node.Repo = f.Repo
+		node.Conflated = g.conflatedKinds(name)
 	} else {
 		// No backing fact: this is a dangling edge target (e.g. an inferred call
 		// into an unanalyzed package or an interface method). Mark it honestly

--- a/internal/facts/graph_test.go
+++ b/internal/facts/graph_test.go
@@ -1066,3 +1066,143 @@ func TestArchitecturalReverse_ExcludesInstantiate(t *testing.T) {
 		t.Errorf("Forward must keep the instantiate edge; got %v", g.Forward()["pkg.build"])
 	}
 }
+
+// --- name-collision disambiguation ---
+
+// buildCollisionGraph mirrors the real multi-repo shape that exposed the bug: a repo
+// labelled "svc" (a synthetic service node) and, in a DIFFERENT repo, a top-level
+// directory also called "svc". Module fact names are repo-root-relative and not
+// repo-prefixed, so the two collide on the name "svc".
+//
+// The service fact is added LAST on purpose: synthetic cross-repo facts are appended
+// after every repo's own facts, so a first-fact-wins index always picks the module and
+// never the service.
+func buildCollisionGraph() *Graph {
+	s := NewStore()
+	s.Add(
+		// "client" repo: a module that imports the colliding name.
+		Fact{Kind: KindModule, Name: "client/app", File: "client/app", Repo: "client",
+			Relations: []Relation{{Kind: RelImports, Target: "svc"}}},
+		// "other" repo: a top-level directory that happens to be named "svc".
+		Fact{Kind: KindModule, Name: "svc", File: "other/svc", Repo: "other"},
+		// Synthetic service nodes, appended last.
+		Fact{Kind: KindService, Name: "web", Relations: []Relation{
+			{Kind: RelDependsOn, Target: "svc"},
+		}},
+		Fact{Kind: KindService, Name: "svc", Relations: []Relation{
+			{Kind: RelDependsOn, Target: "db"},
+		}},
+		Fact{Kind: KindService, Name: "db"},
+	)
+	s.BuildGraph()
+	return s.Graph()
+}
+
+// TestNodeFor_PrefersKindMatchingIncomingRelation pins the core fix: the relation used
+// to reach a node decides which of the same-named facts it means. Reached by
+// depends_on it is the service; reached by imports it is the module.
+func TestNodeFor_PrefersKindMatchingIncomingRelation(t *testing.T) {
+	g := buildCollisionGraph()
+
+	svcNode := g.nodeFor("svc", 1, RelDependsOn)
+	if svcNode.Kind != KindService {
+		t.Errorf("via depends_on: kind = %q, want %q", svcNode.Kind, KindService)
+	}
+	if svcNode.File != "" || svcNode.Repo != "" {
+		t.Errorf("via depends_on: got file=%q repo=%q, want the service fact's empty metadata",
+			svcNode.File, svcNode.Repo)
+	}
+
+	modNode := g.nodeFor("svc", 1, RelImports)
+	if modNode.Kind != KindModule {
+		t.Errorf("via imports: kind = %q, want %q", modNode.Kind, KindModule)
+	}
+	if modNode.File != "other/svc" {
+		t.Errorf("via imports: file = %q, want other/svc", modNode.File)
+	}
+}
+
+// TestNodeFor_FallsBackToKindRank covers a node with no edge context (a traversal or
+// path origin): the choice must still be deterministic, and service outranks module.
+func TestNodeFor_FallsBackToKindRank(t *testing.T) {
+	g := buildCollisionGraph()
+	if got := g.nodeFor("svc", 0, "").Kind; got != KindService {
+		t.Errorf("no via-relation: kind = %q, want %q", got, KindService)
+	}
+	// An unknown relation has no natural kind and must fall back the same way.
+	if got := g.nodeFor("svc", 0, "no_such_relation").Kind; got != KindService {
+		t.Errorf("unknown via-relation: kind = %q, want %q", got, KindService)
+	}
+}
+
+// TestNodeFor_ConflatedReportsSharedKinds pins the honesty signal: a node whose name is
+// shared says so, and an ordinary node stays silent.
+func TestNodeFor_ConflatedReportsSharedKinds(t *testing.T) {
+	g := buildCollisionGraph()
+
+	got := g.nodeFor("svc", 1, RelDependsOn).Conflated
+	if want := []string{KindModule, KindService}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Conflated = %v, want %v (sorted)", got, want)
+	}
+	if got := g.nodeFor("db", 1, RelDependsOn).Conflated; got != nil {
+		t.Errorf("single-fact node Conflated = %v, want nil", got)
+	}
+}
+
+// TestNodeFor_UnresolvedStillMarked guards the pre-existing behaviour for a name with
+// no backing fact at all.
+func TestNodeFor_UnresolvedStillMarked(t *testing.T) {
+	g := buildCollisionGraph()
+	n := g.nodeFor("nowhere", 1, RelCalls)
+	if !n.Unresolved {
+		t.Error("expected Unresolved for a name with no backing fact")
+	}
+	if n.Kind != "" || n.Conflated != nil {
+		t.Errorf("unresolved node should carry no kind/conflation, got kind=%q conflated=%v",
+			n.Kind, n.Conflated)
+	}
+}
+
+// TestTraverse_ServiceFilterKeepsCollidingServiceNode is the regression test for the
+// user-visible symptom: filtering a service-to-service walk by node_kinds=["service"]
+// used to DROP the colliding hop, because it was labelled a module. The node must now
+// survive the filter and the walk must still reach the far side.
+func TestTraverse_ServiceFilterKeepsCollidingServiceNode(t *testing.T) {
+	g := buildCollisionGraph()
+	res := g.Traverse("web", "forward", []string{RelDependsOn}, []string{KindService}, 3, 100)
+
+	var names []string
+	for _, n := range res.Nodes {
+		if n.Depth > 0 {
+			names = append(names, n.Name)
+		}
+	}
+	want := []string{"svc", "db"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("service-filtered traversal = %v, want %v (the colliding hop must not be filtered out)", names, want)
+	}
+}
+
+// TestFindPath_LabelsHopsByTraversingRelation is the regression test for the reported
+// find_path output, where the middle hop of a service-to-service path was reported as
+// an unrelated module in another repo.
+func TestFindPath_LabelsHopsByTraversingRelation(t *testing.T) {
+	g := buildCollisionGraph()
+	res := g.FindPath("web", "db", nil, 5)
+	if !res.Found {
+		t.Fatalf("expected a path web -> svc -> db, got %+v", res)
+	}
+	if len(res.Path) != 3 {
+		t.Fatalf("path length = %d, want 3; path=%+v", len(res.Path), res.Path)
+	}
+	mid := res.Path[1]
+	if mid.Name != "svc" || mid.Kind != KindService {
+		t.Errorf("middle hop = %s (%s), want svc (service)", mid.Name, mid.Kind)
+	}
+	if mid.Repo != "" {
+		t.Errorf("middle hop repo = %q, want empty (it is the service, not the other repo's module)", mid.Repo)
+	}
+	if len(mid.Conflated) != 2 {
+		t.Errorf("middle hop should report conflation, got %v", mid.Conflated)
+	}
+}

--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/enola-labs/enola/internal/facts"
 )
@@ -676,6 +677,83 @@ var frameworkConventionNames = map[string]bool{
 	"Ability":                      true,
 }
 
+// genericComponentNames are the vocabulary of UI-component naming: words so many
+// components are built from that a type named only out of them identifies a role,
+// not a shared implementation. Two frontends each declaring a "FooterProps" or a
+// "ModalProps" is convention, not shared code — their field sets typically have no
+// overlap at all. Checked against the camelCase segments of an identity once its
+// convention suffix is stripped, so "FormHeaderProps" (all-generic) is rejected while
+// "PinMarkerProps" (Pin is not generic) survives.
+var genericComponentNames = map[string]bool{
+	"footer": true, "header": true, "layout": true, "modal": true, "card": true,
+	"button": true, "list": true, "container": true, "wrapper": true,
+	"panel": true, "page": true, "form": true, "icon": true, "badge": true,
+	"avatar": true, "banner": true, "dialog": true, "menu": true, "nav": true,
+	"sidebar": true, "tooltip": true, "spinner": true, "overlay": true,
+	"toast": true, "section": true, "row": true, "cell": true, "label": true,
+	"title": true,
+}
+
+// conventionSuffixes are the trailing words a framework's naming convention appends
+// to a component name to derive a companion type. They carry no information of their
+// own, so they are stripped before an identity's segments are judged.
+var conventionSuffixes = [...]string{"Props", "Types", "Type", "State"}
+
+// isConventionalComponentName reports whether an identity is built purely from the
+// generic UI-component vocabulary — a name every app of the framework produces for
+// its own unrelated component. It strips one convention suffix ("FooterProps" ->
+// "Footer"), splits the remainder on camelCase boundaries, and rejects the identity
+// only when EVERY segment is generic vocabulary.
+//
+// A single distinctive segment is enough to save a name, which is what keeps a
+// disambiguating prefix meaningful: "EListItem" splits to E/List/Item, and though
+// List and Item are generic, the deliberate "E" enum prefix is not — so the identity
+// survives, as it should, because such a name really is shared code rather than a
+// coincidence. The stripped core is also deliberately NOT re-checked against the
+// minimum-length rule: "LikeProps" reduces to a 4-character "Like" yet names real
+// shared code.
+func isConventionalComponentName(id string) bool {
+	core := id
+	for _, suffix := range conventionSuffixes {
+		if len(core) > len(suffix) && strings.HasSuffix(core, suffix) {
+			core = core[:len(core)-len(suffix)]
+			break
+		}
+	}
+	segments := splitCamelCase(core)
+	if len(segments) == 0 {
+		return false
+	}
+	for _, seg := range segments {
+		lower := strings.ToLower(seg)
+		if !genericComponentNames[lower] && !genericTypeNames[lower] {
+			return false
+		}
+	}
+	return true
+}
+
+// splitCamelCase breaks an identifier on lower-to-upper transitions, so "FormHeader"
+// yields ["Form", "Header"]. Runs of capitals stay together ("HTTPServer" -> ["HTTP",
+// "Server"]) so an acronym is not shredded into single letters.
+func splitCamelCase(s string) []string {
+	runes := []rune(s)
+	var out []string
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		boundary := unicode.IsUpper(runes[i]) &&
+			(!unicode.IsUpper(runes[i-1]) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])))
+		if boundary {
+			out = append(out, string(runes[start:i]))
+			start = i
+		}
+	}
+	if start < len(runes) {
+		out = append(out, string(runes[start:]))
+	}
+	return out
+}
+
 // linkSharedSymbols connects repos that declare enough of the same distinctive
 // types. The relationship is symmetric (shared/vendored code, not a one-way
 // dependency), so qualifying pairs get a bidirectional pair of edges.
@@ -737,13 +815,18 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 		}
 	}
 
-	// Materialize a bidirectional edge for each pair over the threshold.
+	// Materialize an edge for each pair over the threshold. Shared code is
+	// inherently symmetric, so the default is a bidirectional pair — but when an
+	// earlier linker has already established a DIRECTION for this pair (an import
+	// or HTTP call one way and not the other), that direction is authoritative and
+	// the reverse edge would contradict it. A library monorepo whose types a
+	// consuming app also declares must not come out depending on that app.
 	for key, ids := range pairShared {
 		if len(ids) < minSharedSymbols {
 			continue
 		}
 		a, b, _ := strings.Cut(key, "\x00")
-		for _, pair := range [2][2]string{{a, b}, {b, a}} {
+		for _, pair := range directedSharedPairs(edges, a, b) {
 			e := edgeFor(edges, pair[0], pair[1])
 			e.note("shared_symbols")
 			if e.symbols == nil {
@@ -753,6 +836,45 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 				e.symbols[id] = true
 			}
 		}
+	}
+}
+
+// directionalVias are the evidence kinds that establish a real one-way dependency:
+// consumer imports provider, or consumer calls provider over HTTP. "shared_symbols"
+// is deliberately absent — it is the symmetric signal this gate arbitrates.
+var directionalVias = [...]string{"import", "http-client", "http"}
+
+// hasDirectionalEvidence reports whether a consumer -> provider edge already exists
+// and is backed by directional (non-shared-symbol) evidence.
+func hasDirectionalEvidence(edges map[string]*edge, consumer, provider string) bool {
+	e, ok := edges[consumer+"\x00"+provider]
+	if !ok {
+		return false
+	}
+	for _, via := range directionalVias {
+		if e.via[via] {
+			return true
+		}
+	}
+	return false
+}
+
+// directedSharedPairs returns the (consumer, provider) orderings a shared-symbol
+// signal between repos a and b should be recorded against. When exactly one
+// direction already carries directional evidence, only that direction is returned,
+// so the shared symbols annotate the established edge instead of fabricating its
+// inverse. When both or neither direction is directional the signal stays symmetric,
+// which is the correct reading for sibling forks and vendored code.
+func directedSharedPairs(edges map[string]*edge, a, b string) [][2]string {
+	abDirectional := hasDirectionalEvidence(edges, a, b)
+	baDirectional := hasDirectionalEvidence(edges, b, a)
+	switch {
+	case abDirectional && !baDirectional:
+		return [][2]string{{a, b}}
+	case baDirectional && !abDirectional:
+		return [][2]string{{b, a}}
+	default:
+		return [][2]string{{a, b}, {b, a}}
 	}
 }
 
@@ -820,16 +942,40 @@ func isDistinctiveIdentity(id string) bool {
 	if len(id) < 5 {
 		return false
 	}
-	return !genericTypeNames[strings.ToLower(id)]
+	if genericTypeNames[strings.ToLower(id)] {
+		return false
+	}
+	// A name assembled purely from generic component vocabulary ("FooterProps",
+	// "FormHeaderProps") is naming convention rather than shared code.
+	return !isConventionalComponentName(id)
 }
 
-// isNonContractSharedFile reports whether a file holds auto-generated classes that
-// are not portable contract surface for the shared-symbol signal. Rails migrations
-// (db/migrate/) get generator-derived class names (InitSchema, CreateFooBars) that
-// coincide across apps that ran the same migration — parallel schema history, not
-// shared code — so they must not fabricate or inflate a cross-repo edge.
+// nonContractPathMarkers are path fragments identifying files whose declarations are
+// scaffolding rather than portable contract surface: Rails migrations (generator-
+// derived names like InitSchema/CreateFooBars that coincide across apps that ran the
+// same migration), and the test/story/mock/fixture tree, where a throwaway local type
+// is routinely declared with the same obvious name in every repo.
+var nonContractPathMarkers = [...]string{
+	"/db/migrate/",
+	"/spec/support/", "/__mocks__/", "/__tests__/", "/fixtures/", "/factories/",
+	".stories.", ".test.", ".spec.", "_test.", "_spec.",
+}
+
+// isNonContractSharedFile reports whether a file holds declarations that are not
+// portable contract surface for the shared-symbol signal, so they must not fabricate
+// or inflate a cross-repo edge. Directory markers are matched against a
+// leading-slash-normalised path so they also hit a repo-root-relative path.
 func isNonContractSharedFile(file string) bool {
-	return strings.Contains(file, "/db/migrate/") || strings.HasPrefix(file, "db/migrate/")
+	rooted := file
+	if !strings.HasPrefix(rooted, "/") {
+		rooted = "/" + rooted
+	}
+	for _, marker := range nonContractPathMarkers {
+		if strings.Contains(rooted, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // isNamespaceQualified reports whether a type identity carries a namespace (only

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -1131,3 +1131,233 @@ func TestUnmatchedReasonConstants(t *testing.T) {
 		}
 	}
 }
+
+// --- (C2) shared-symbol direction and convention-name gating ---
+
+// TestComputeLinks_SharedSymbolsRespectsImportDirection covers the library-monorepo
+// false positive: an app declares copies of types its published library also declares
+// (a vendored/migrated component), so the symmetric shared-symbol signal fires — but
+// the app's npm dependency on the library already fixed the direction. Materializing
+// the reverse edge would make the library depend on its own consumer, which then
+// fabricates paths like library -> app -> app's backend.
+func TestComputeLinks_SharedSymbolsRespectsImportDirection(t *testing.T) {
+	in := []facts.Fact{
+		module("app", "client"),
+		importDep("app", "@lib/ui"),
+		typeSym("app", "client.PinMarkerProps", facts.SymbolClass),
+		typeSym("app", "client.LikeProps", facts.SymbolClass),
+		typeSym("app", "client.AdSlot", facts.SymbolClass),
+		module("lib", "libs/ui"),
+		typeSym("lib", "libs/ui.PinMarkerProps", facts.SymbolClass),
+		typeSym("lib", "libs/ui.LikeProps", facts.SymbolClass),
+		typeSym("lib", "libs/ui.AdSlot", facts.SymbolClass),
+	}
+	out := ComputeLinks(in)
+
+	e := findEdge(out, "app", "lib")
+	if e == nil {
+		t.Fatalf("missing app -> lib edge; out=%+v", out)
+	}
+	if via, _ := e.Props["via"].([]string); !reflect.DeepEqual(via, []string{"import", "shared_symbols"}) {
+		t.Errorf("via = %v, want [import shared_symbols]", e.Props["via"])
+	}
+	if c, _ := e.Props["symbol_count"].(int); c != 3 {
+		t.Errorf("symbol_count = %v, want 3 (shared symbols annotate the directional edge)", c)
+	}
+	if rev := findEdge(out, "lib", "app"); rev != nil {
+		t.Errorf("library must not depend on its consumer; got reverse edge %+v", rev)
+	}
+	if hasServiceEdge(out, "lib", "app") {
+		t.Errorf("lib service node must not carry depends_on app")
+	}
+}
+
+// TestComputeLinks_SharedSymbolsRespectsHTTPDirection is the same gate for the other
+// directional signal: a frontend calling a backend's HTTP API while also sharing type
+// names with it must not make the backend depend on the frontend.
+func TestComputeLinks_SharedSymbolsRespectsHTTPDirection(t *testing.T) {
+	in := []facts.Fact{
+		module("web", "client"),
+		clientRoute("web", "/api/widgets/registry", "GET", nil),
+		typeSym("web", "client.WidgetRegistry", facts.SymbolClass),
+		typeSym("web", "client.PaymentLedger", facts.SymbolClass),
+		typeSym("web", "client.RetryPolicy", facts.SymbolClass),
+		module("api", "app"),
+		serverRoute("api", "/api/widgets/registry", "GET"),
+		typeSym("api", "app.WidgetRegistry", facts.SymbolClass),
+		typeSym("api", "app.PaymentLedger", facts.SymbolClass),
+		typeSym("api", "app.RetryPolicy", facts.SymbolClass),
+	}
+	out := ComputeLinks(in)
+
+	if e := findEdge(out, "web", "api"); e == nil {
+		t.Fatalf("missing web -> api edge; out=%+v", out)
+	}
+	if rev := findEdge(out, "api", "web"); rev != nil {
+		t.Errorf("backend must not depend on its client; got reverse edge %+v", rev)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsStaySymmetricWithoutDirection pins that the gate only
+// fires when a direction is actually known. Sibling forks and vendored code have no
+// import or HTTP edge either way, and for them the symmetric reading is correct.
+func TestComputeLinks_SharedSymbolsStaySymmetricWithoutDirection(t *testing.T) {
+	in := []facts.Fact{
+		module("fork-a", "client"),
+		typeSym("fork-a", "client.WidgetRegistry", facts.SymbolClass),
+		typeSym("fork-a", "client.PaymentLedger", facts.SymbolClass),
+		typeSym("fork-a", "client.RetryPolicy", facts.SymbolClass),
+		module("fork-b", "client"),
+		typeSym("fork-b", "client.WidgetRegistry", facts.SymbolClass),
+		typeSym("fork-b", "client.PaymentLedger", facts.SymbolClass),
+		typeSym("fork-b", "client.RetryPolicy", facts.SymbolClass),
+	}
+	out := ComputeLinks(in)
+	for _, pair := range [][2]string{{"fork-a", "fork-b"}, {"fork-b", "fork-a"}} {
+		if findEdge(out, pair[0], pair[1]) == nil {
+			t.Errorf("missing symmetric edge %s -> %s; out=%+v", pair[0], pair[1], out)
+		}
+	}
+}
+
+// TestComputeLinks_SharedSymbolsComponentConventionIgnored covers the React/TS analog
+// of the Rails-boilerplate false positive: "<Component>Props" is a naming convention,
+// so when the component name is itself generic vocabulary the identity says nothing
+// about shared code. The three names here were confirmed false positives with zero
+// field overlap between their declarations.
+func TestComputeLinks_SharedSymbolsComponentConventionIgnored(t *testing.T) {
+	in := []facts.Fact{
+		module("web-a", "client"),
+		typeSym("web-a", "client.FooterProps", facts.SymbolInterface),
+		typeSym("web-a", "client.ModalProps", facts.SymbolInterface),
+		typeSym("web-a", "client.FormHeaderProps", facts.SymbolInterface),
+		typeSym("web-a", "client.Layout", facts.SymbolClass),
+		module("web-b", "libs"),
+		typeSym("web-b", "libs.FooterProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.ModalProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.FormHeaderProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.Layout", facts.SymbolClass),
+	}
+	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+		t.Errorf("component-convention names should not link: %+v", edges)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsDistinctiveComponentNamesSurvive is the guard against
+// over-filtering: a "<Component>Props" name whose component is NOT generic vocabulary
+// still names real shared code and must keep linking. Each case here was verified to
+// be genuinely migrated/vendored between the repos.
+func TestComputeLinks_SharedSymbolsDistinctiveComponentNamesSurvive(t *testing.T) {
+	in := []facts.Fact{
+		module("web-a", "client"),
+		typeSym("web-a", "client.PinMarkerProps", facts.SymbolInterface), // Pin is distinctive
+		typeSym("web-a", "client.LikeProps", facts.SymbolInterface),      // core "Like" is only 4 chars
+		typeSym("web-a", "client.EListItem", facts.SymbolEnum),           // single-char prefix + generic words
+		typeSym("web-a", "client.AdSlot", facts.SymbolInterface),
+		module("web-b", "libs"),
+		typeSym("web-b", "libs.PinMarkerProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.LikeProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.EListItem", facts.SymbolEnum),
+		typeSym("web-b", "libs.AdSlot", facts.SymbolInterface),
+	}
+	out := ComputeLinks(in)
+	e := findEdge(out, "web-a", "web-b")
+	if e == nil {
+		t.Fatalf("distinctive component names must still link; out=%+v", out)
+	}
+	if c, _ := e.Props["symbol_count"].(int); c != 4 {
+		t.Errorf("symbol_count = %v, want 4", c)
+	}
+}
+
+func TestIsConventionalComponentName(t *testing.T) {
+	for _, tc := range []struct {
+		id   string
+		want bool
+	}{
+		{"FooterProps", true},
+		{"ModalProps", true},
+		{"FormHeaderProps", true}, // every segment generic
+		{"Layout", true},
+		{"CardHeaderState", true},
+		{"LikeProps", false},      // core shorter than the length floor, still meaningful
+		{"PinMarkerProps", false}, // "Pin" is not generic vocabulary
+		{"AdSlot", false},
+		{"EListItem", false}, // single-char prefix must not be read as generic
+		{"TestNames", false}, // "Names" is not generic vocabulary
+		{"WidgetRegistry", false},
+		{"HTTPServerProps", false}, // acronym segment kept intact
+	} {
+		if got := isConventionalComponentName(tc.id); got != tc.want {
+			t.Errorf("isConventionalComponentName(%q) = %v, want %v", tc.id, got, tc.want)
+		}
+	}
+}
+
+func TestSplitCamelCase(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want []string
+	}{
+		{"FormHeader", []string{"Form", "Header"}},
+		{"Footer", []string{"Footer"}},
+		{"EListItem", []string{"E", "List", "Item"}},
+		{"HTTPServer", []string{"HTTP", "Server"}},
+		{"", nil},
+	} {
+		if got := splitCamelCase(tc.in); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("splitCamelCase(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsNonContractSharedFile(t *testing.T) {
+	for _, tc := range []struct {
+		file string
+		want bool
+	}{
+		{"db/migrate/20230101_create_widgets.rb", true},
+		{"svc/db/migrate/20230101_create_widgets.rb", true},
+		{"libs/ui/src/lib/Gallery/Gallery.stories.tsx", true},
+		{"client/components/feed/feed.test.tsx", true},
+		{"client/components/feed/feed.spec.ts", true},
+		{"internal/linkers/crossrepo/crossrepo_test.go", true},
+		{"spec/support/matchers/jwt_including_matcher.rb", true},
+		{"app/__mocks__/api.ts", true},
+		{"app/__tests__/feed.tsx", true},
+		{"spec/factories/users.rb", true},
+		{"test/fixtures/payload.json", true},
+		{"libs/ui/src/lib/Gallery/Gallery.tsx", false},
+		{"app/models/widget.rb", false},
+		{"client/components/latest/index.tsx", false}, // "test" inside a word must not match
+		{"", false},
+	} {
+		if got := isNonContractSharedFile(tc.file); got != tc.want {
+			t.Errorf("isNonContractSharedFile(%q) = %v, want %v", tc.file, got, tc.want)
+		}
+	}
+}
+
+// TestComputeLinks_SharedSymbolsStoryAndTestFilesIgnored pins that declarations in
+// stories/tests/mocks are not portable contract surface: a throwaway local type in a
+// Storybook story is routinely given the same obvious name in every repo.
+func TestComputeLinks_SharedSymbolsStoryAndTestFilesIgnored(t *testing.T) {
+	storySym := func(repo, name, file string) facts.Fact {
+		f := typeSym(repo, name, facts.SymbolInterface)
+		f.File = file
+		return f
+	}
+	in := []facts.Fact{
+		module("web-a", "libs"),
+		storySym("web-a", "libs.AdSlot", "libs/Gallery/Gallery.stories.tsx"),
+		storySym("web-a", "libs.WidgetRegistry", "libs/widget/widget.test.ts"),
+		storySym("web-a", "libs.PaymentLedger", "libs/__mocks__/ledger.ts"),
+		module("web-b", "client"),
+		storySym("web-b", "client.AdSlot", "client/Gallery/Gallery.stories.tsx"),
+		storySym("web-b", "client.WidgetRegistry", "client/widget/widget.test.ts"),
+		storySym("web-b", "client.PaymentLedger", "client/__mocks__/ledger.ts"),
+	}
+	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+		t.Errorf("story/test/mock declarations should not link: %+v", edges)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3214,6 +3214,18 @@ func writeCandidateList(sb *strings.Builder, res *nameResolution) {
 	}
 }
 
+// otherKinds returns the conflated kinds except the one already displayed, so the
+// annotation adds information instead of repeating the node's own kind.
+func otherKinds(conflated []string, shown string) []string {
+	out := make([]string, 0, len(conflated))
+	for _, k := range conflated {
+		if k != shown {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
 // compactNodeLine formats a single traversal node as a markdown list item.
 func compactNodeLine(n facts.TraversalNode) string {
 	s := "- " + n.Name
@@ -3222,6 +3234,11 @@ func compactNodeLine(n facts.TraversalNode) string {
 	}
 	if n.Unresolved {
 		s += " [unresolved]"
+	}
+	if len(n.Conflated) > 1 {
+		// The node's name is shared by facts of several kinds, so it merges them.
+		// Say so rather than letting the single kind above read as precise.
+		s += " [also: " + strings.Join(otherKinds(n.Conflated, n.Kind), ", ") + "]"
 	}
 	if n.File != "" {
 		s += " — " + n.File


### PR DESCRIPTION
Shared-symbol links were materialized in both directions, so a library whose types a consumer also declares came out depending on that consumer. They now annotate the existing edge when an import or HTTP call already fixed the direction, and stay symmetric only when nothing else did. Two identity filters go with it: names built purely from generic component vocabulary ("<Component>Props"), and declarations in stories/tests/mocks/fixtures, no longer count as shared.

Graph nodes are keyed by name, so same-named facts merge and the earliest-stored one supplied the label — and node_kinds filters on that label, so a service node could vanish from a service-filtered traversal. nodeFor now picks the fact whose kind matches the relation that reached it; TraversalNode.Conflated reports names that still merge several facts.