### PR TITLE
fix(crossrepo): stop shared-symbol false edges from generated code an…

### DIFF
--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -647,6 +647,35 @@ func importCandidates(target string) []string {
 // between repos) shares many.
 const minSharedSymbols = 3
 
+// maxVocabRepoShare bounds how widely an unqualified type identity may be
+// declared before it is read as shared domain vocabulary rather than evidence
+// that any specific pair shares code. Vendored/shared source (an onelab protocol
+// header) lands in the handful of repos that copied it; a domain type every
+// service in a fleet independently models ("Translation", "Category", "Filter")
+// lands in most of them. An identity declared in more than this fraction of all
+// loaded repos is the latter, so it is dropped as a pairwise coupling signal —
+// otherwise a fleet of same-language services fabricates a near-complete mesh of
+// edges from parallel modeling alone.
+const maxVocabRepoShare = 0.5
+
+// minReposForVocabFilter guards the vocabulary filter so it only applies once
+// enough repos are loaded that "a majority of repos" is a meaningful bar. With
+// two or three repos a genuinely vendored header can legitimately appear in most
+// of them, so below this count the filter stays off and the small-repo-set
+// behavior (including every 2-repo test fixture) is preserved unchanged.
+const minReposForVocabFilter = 4
+
+// isUbiquitousIdentity reports whether an unqualified identity declared in
+// declaringRepos of totalRepos loaded repos is too widespread to be a pairwise
+// coupling signal — see maxVocabRepoShare. Namespace-qualified identities never
+// reach here: "::" is a strong shared-source marker and bypasses the filter.
+func isUbiquitousIdentity(declaringRepos, totalRepos int) bool {
+	if totalRepos < minReposForVocabFilter {
+		return false
+	}
+	return float64(declaringRepos) > maxVocabRepoShare*float64(totalRepos)
+}
+
 // genericTypeNames are common unqualified type names too generic to link on by
 // themselves. Namespaced identities (e.g. "onelab::number") bypass this list —
 // sharing a namespace across repos is itself meaningful.
@@ -760,6 +789,7 @@ func splitCamelCase(s string) []string {
 func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 	repoModules := moduleNamesByRepo(all)
 	repoLang := primaryLanguageByRepo(all)
+	repoCount := len(repoLabelLookup(all))
 
 	// identity -> set of repos that declare a type with that identity.
 	idToRepos := map[string]map[string]bool{}
@@ -788,7 +818,10 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 	// apps written in different languages sharing a plain domain type name (e.g.
 	// Kotlin and Swift both declaring "LoginViewModel", or both nesting
 	// "RegisterUseCase.ValidationError") is parallel modeling of the same product,
-	// not shared code, and must not fabricate a dependency.
+	// not shared code, and must not fabricate a dependency. A bare name is dropped
+	// entirely when it is declared across too much of the fleet (isUbiquitousIdentity):
+	// a distinctive type most services in a large multi-repo set independently model
+	// is shared vocabulary, not evidence that any specific pair shares code.
 	// pairShared["a\x00b"] (a<b) -> set of shared identities.
 	pairShared := map[string]map[string]bool{}
 	for id, repos := range idToRepos {
@@ -796,6 +829,9 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 			continue
 		}
 		qualified := isNamespaceQualified(id)
+		if !qualified && isUbiquitousIdentity(len(repos), repoCount) {
+			continue // shared domain vocabulary across the fleet, not pairwise coupling
+		}
 		rs := make([]string, 0, len(repos))
 		for r := range repos {
 			rs = append(rs, r)
@@ -953,12 +989,20 @@ func isDistinctiveIdentity(id string) bool {
 // nonContractPathMarkers are path fragments identifying files whose declarations are
 // scaffolding rather than portable contract surface: Rails migrations (generator-
 // derived names like InitSchema/CreateFooBars that coincide across apps that ran the
-// same migration), and the test/story/mock/fixture tree, where a throwaway local type
-// is routinely declared with the same obvious name in every repo.
+// same migration); the test/story/mock/fixture tree, where a throwaway local type
+// is routinely declared with the same obvious name in every repo; and generated
+// code — client/model/mock stubs a codegen tool (oapi-codegen, protoc, mockery)
+// derives from a shared contract. Two services that consume the SAME upstream API
+// each generate identically-named client and model types, so those coincide across
+// every consumer of that API. That is shared upstream contract, not shared code
+// between the consumers, and the real dependency (each consumer -> that API) is
+// already captured by HTTP/import linking; counting the generated stubs only
+// fabricates a spurious edge between the consumers themselves.
 var nonContractPathMarkers = [...]string{
 	"/db/migrate/",
-	"/spec/support/", "/__mocks__/", "/__tests__/", "/fixtures/", "/factories/",
+	"/spec/support/", "/__mocks__/", "/__tests__/", "/fixtures/", "/factories/", "/mocks/",
 	".stories.", ".test.", ".spec.", "_test.", "_spec.",
+	".gen.", ".pb.", "_pb2.", ".generated.",
 }
 
 // isNonContractSharedFile reports whether a file holds declarations that are not

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -883,6 +883,130 @@ func TestComputeLinks_SharedSymbolsSameLanguageNestedTypesLink(t *testing.T) {
 	}
 }
 
+// fleetRepos is a set of same-language repo labels large enough (>=
+// minReposForVocabFilter) to trigger the shared-vocabulary filter.
+var fleetRepos = []string{"svc-1", "svc-2", "svc-3", "svc-4", "svc-5", "svc-6", "svc-7", "svc-8"}
+
+// TestComputeLinks_SharedSymbolsFleetVocabularyNotLinked covers the multi-repo
+// fleet false positive: a set of same-language services that each independently
+// model the same distinctive domain types (TranslationBundle, CategoryTree,
+// FilterFacet) share those names across most of the fleet. That is parallel
+// modeling, not shared code, so no pair may be linked on ubiquitous vocabulary
+// alone — even though each name is distinctive enough to link a bare 2-repo pair.
+func TestComputeLinks_SharedSymbolsFleetVocabularyNotLinked(t *testing.T) {
+	vocab := []string{"TranslationBundle", "CategoryTree", "FilterFacet"}
+	var in []facts.Fact
+	for _, repo := range fleetRepos {
+		in = append(in, module(repo, "app"))
+		for _, name := range vocab {
+			in = append(in, typeSymLang(repo, "app."+name, facts.SymbolClass, "go"))
+		}
+	}
+	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+		t.Errorf("fleet-wide shared vocabulary must not link any pair: %+v", edges)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsPairSpecificSurvivesFleetVocabulary confirms the
+// vocabulary filter is surgical: amid fleet-wide vocabulary (dropped), two
+// services that additionally share distinctive types declared by no other repo
+// are still linked, the symbol_count reflects only those pair-specific types, and
+// no other pair is fabricated.
+func TestComputeLinks_SharedSymbolsPairSpecificSurvivesFleetVocabulary(t *testing.T) {
+	vocab := []string{"TranslationBundle", "CategoryTree", "FilterFacet"}
+	pairOnly := []string{"InvoiceReconciler", "ShipmentManifest", "LoyaltyLedger"}
+	var in []facts.Fact
+	for _, repo := range fleetRepos {
+		in = append(in, module(repo, "app"))
+		for _, name := range vocab {
+			in = append(in, typeSymLang(repo, "app."+name, facts.SymbolClass, "go"))
+		}
+	}
+	for _, name := range pairOnly {
+		in = append(in, typeSymLang("svc-1", "app."+name, facts.SymbolClass, "go"))
+		in = append(in, typeSymLang("svc-2", "app."+name, facts.SymbolClass, "go"))
+	}
+	out := ComputeLinks(in)
+	e := findEdge(out, "svc-1", "svc-2")
+	if e == nil {
+		t.Fatalf("pair-specific distinctive types should link svc-1 <-> svc-2; edges=%+v", crossRepoEdges(out))
+	}
+	if c, _ := e.Props["symbol_count"].(int); c != 3 {
+		t.Errorf("symbol_count = %v, want 3 (only pair-specific types; fleet vocabulary dropped)", c)
+	}
+	// Shared code is symmetric, so the one real pair is two directed edges — and
+	// nothing else, since every other overlap is ubiquitous vocabulary.
+	if edges := crossRepoEdges(out); len(edges) != 2 {
+		t.Errorf("only the svc-1/svc-2 pair should link (2 directed edges), got %d: %+v", len(edges), edges)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsSmallRepoSetVocabularyFilterOff confirms the guard:
+// below minReposForVocabFilter the filter never fires, so a type shared across all
+// of a small repo set still links (a vendored header may legitimately appear in
+// every one of just three repos).
+func TestComputeLinks_SharedSymbolsSmallRepoSetVocabularyFilterOff(t *testing.T) {
+	types := []string{"WidgetRegistry", "PaymentLedger", "RetryPolicy"}
+	var in []facts.Fact
+	for _, repo := range []string{"svc-a", "svc-b", "svc-c"} {
+		in = append(in, module(repo, "app"))
+		for _, name := range types {
+			in = append(in, typeSymLang(repo, "app."+name, facts.SymbolClass, "go"))
+		}
+	}
+	out := ComputeLinks(in)
+	for _, pair := range [][2]string{{"svc-a", "svc-b"}, {"svc-a", "svc-c"}, {"svc-b", "svc-c"}} {
+		if findEdge(out, pair[0], pair[1]) == nil {
+			t.Errorf("with only 3 repos the vocabulary filter must stay off; missing %s <-> %s", pair[0], pair[1])
+		}
+	}
+}
+
+// genTypeSym is a struct declared in a generated client/model file (the stub a
+// codegen tool emits from an upstream contract).
+func genTypeSym(repo, name string) facts.Fact {
+	f := typeSymLang(repo, "internal."+name, facts.SymbolClass, "go")
+	f.File = repo + "/internal/clients/eventcountersapi/event_counters_client.gen.go"
+	return f
+}
+
+// TestComputeLinks_SharedSymbolsGeneratedCodeIgnored covers the shared-upstream-
+// contract false positive: two services that generate a client for the SAME API
+// each emit identically-named generated structs. Those coincide across every
+// consumer of that API but are not shared code between the consumers, so they must
+// not fabricate a cross-repo edge — even many of them, in the same language.
+func TestComputeLinks_SharedSymbolsGeneratedCodeIgnored(t *testing.T) {
+	in := []facts.Fact{module("svc-a", "internal"), module("svc-b", "internal")}
+	for _, name := range []string{"GetCountersResponse", "CounterBatchRequest", "EventCounterModel", "CountersClientWithResponses"} {
+		in = append(in, genTypeSym("svc-a", name), genTypeSym("svc-b", name))
+	}
+	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+		t.Errorf("generated client structs from a shared API must not link consumers: %+v", edges)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsGeneratedExcludedFromCount confirms the exclusion is
+// surgical: generated stubs are dropped, but hand-written distinctive shared types in
+// the same repos still link, and symbol_count reflects only those hand-written types.
+func TestComputeLinks_SharedSymbolsGeneratedExcludedFromCount(t *testing.T) {
+	in := []facts.Fact{module("svc-a", "internal"), module("svc-b", "internal")}
+	for _, name := range []string{"GetCountersResponse", "CounterBatchRequest", "EventCounterModel"} {
+		in = append(in, genTypeSym("svc-a", name), genTypeSym("svc-b", name))
+	}
+	for _, name := range []string{"WidgetRegistry", "PaymentLedger", "RetryPolicy"} {
+		in = append(in,
+			typeSymLang("svc-a", "internal."+name, facts.SymbolClass, "go"),
+			typeSymLang("svc-b", "internal."+name, facts.SymbolClass, "go"))
+	}
+	e := findEdge(ComputeLinks(in), "svc-a", "svc-b")
+	if e == nil {
+		t.Fatalf("hand-written distinctive shared types should still link")
+	}
+	if c, _ := e.Props["symbol_count"].(int); c != 3 {
+		t.Errorf("symbol_count = %v, want 3 (generated stubs excluded)", c)
+	}
+}
+
 // --- via: http-client tag and confidence ---
 
 func TestComputeLinks_HTTPClientViaTag(t *testing.T) {


### PR DESCRIPTION
…d fleet vocabulary

Exclude generated stubs (.gen/.pb/_pb2/.generated, /mocks/) and drop unqualified type names shared across more than half of loaded repos from the shared_symbols signal. Services that generate clients for the same API, or independently model the same domain vocabulary, no longer fabricate a cross-repo dependency. Real HTTP/import edges are unaffected.