### PR TITLE
fix: stop shared type names alone forming cross-repo dependency edges

### DIFF
--- a/internal/explainers/crossrepo/crossrepo.go
+++ b/internal/explainers/crossrepo/crossrepo.go
@@ -28,17 +28,35 @@ func (e *CrossRepoExplainer) Name() string {
 // store and emits one summarizing insight describing how the repositories
 // depend on each other. It returns nothing for single-repo snapshots.
 func (e *CrossRepoExplainer) Explain(ctx context.Context, store *facts.Store) ([]facts.Insight, error) {
-	deps, _ := store.QueryAdvanced(facts.QueryOpts{
+	var out []facts.Insight
+	if in := dependencyInsight(store); in != nil {
+		out = append(out, *in)
+	}
+	if in := sharedCodeInsight(store); in != nil {
+		out = append(out, *in)
+	}
+	return out, nil
+}
+
+// queryByType fetches the cross-repo dependency facts of one type, name-sorted.
+func queryByType(store *facts.Store, typ string) []facts.Fact {
+	ff, _ := store.QueryAdvanced(facts.QueryOpts{
 		Kind:      facts.KindDependency,
 		Prop:      "type",
-		PropValue: "cross_repo",
+		PropValue: typ,
 		Limit:     500,
 	})
-	if len(deps) == 0 {
-		return nil, nil
-	}
+	sort.Slice(ff, func(i, j int) bool { return ff[i].Name < ff[j].Name })
+	return ff
+}
 
-	sort.Slice(deps, func(i, j int) bool { return deps[i].Name < deps[j].Name })
+// dependencyInsight summarizes the real, directional cross-repo edges — the ones whose
+// depends_on relations traversal can follow.
+func dependencyInsight(store *facts.Store) *facts.Insight {
+	deps := queryByType(store, facts.TypeCrossRepo)
+	if len(deps) == 0 {
+		return nil
+	}
 
 	evidence := make([]facts.Evidence, 0, len(deps))
 	var lines []string
@@ -51,7 +69,7 @@ func (e *CrossRepoExplainer) Explain(ctx context.Context, store *facts.Store) ([
 		lines = append(lines, d.Name+" ("+detail+")")
 	}
 
-	insight := facts.Insight{
+	return &facts.Insight{
 		Title: fmt.Sprintf("Cross-repo dependencies (%d edges)", len(deps)),
 		Description: "These service-to-service dependencies span repositories: " +
 			strings.Join(lines, "; ") + ". Traverse from a repo label (service node) " +
@@ -59,7 +77,39 @@ func (e *CrossRepoExplainer) Explain(ctx context.Context, store *facts.Store) ([
 		Confidence: 0.9,
 		Evidence:   evidence,
 	}
-	return []facts.Insight{insight}, nil
+}
+
+// sharedCodeInsight reports repo pairs that declare many of the same distinctive type
+// names without any import or call between them. Confidence is deliberately moderate
+// and the wording deliberately hedged: the linker compares NAMES, never file contents,
+// so it cannot tell code copied and kept in sync from code that has since diverged, or
+// from two teams independently modelling one domain with the same vocabulary.
+func sharedCodeInsight(store *facts.Store) *facts.Insight {
+	pairs := queryByType(store, facts.TypeCrossRepoSharedCode)
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	evidence := make([]facts.Evidence, 0, len(pairs))
+	var lines []string
+	for _, p := range pairs {
+		detail := fmt.Sprintf("%d shared type name(s)", propInt(p, "symbol_count"))
+		evidence = append(evidence, facts.Evidence{Fact: p.Name, Detail: detail})
+		lines = append(lines, p.Name+" ("+detail+")")
+	}
+
+	return &facts.Insight{
+		Title: fmt.Sprintf("Shared code between repos (%d pair(s))", len(pairs)),
+		Description: "These repo pairs declare many of the same distinctive type names, " +
+			"which usually means copied or vendored code, or a common ancestor: " +
+			strings.Join(lines, "; ") + ". This is NOT a dependency — neither repo imports " +
+			"or calls the other — so these pairs carry no graph edge and do not appear in " +
+			"traverse, find_path or impact_analysis. Treat it as a maintenance signal: a fix " +
+			"in one may be needed in the other. Matching names do not prove the code is still " +
+			"shared, so diff the declarations before relying on it.",
+		Confidence: 0.5,
+		Evidence:   evidence,
+	}
 }
 
 // edgeDetail renders a short description of what justifies a cross-repo edge.

--- a/internal/explainers/crossrepo/crossrepo_test.go
+++ b/internal/explainers/crossrepo/crossrepo_test.go
@@ -138,3 +138,77 @@ func TestExplain_AllZeroCountsFallback(t *testing.T) {
 		t.Errorf("expected generic fallback detail, got %q", insights[0].Description)
 	}
 }
+
+func TestExplain_SharedCodeIsSeparateHedgedInsight(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "svc-alpha -> svc-beta", Repo: "svc-alpha",
+			Props: map[string]any{
+				"type": facts.TypeCrossRepo, "synthetic": "crossrepo",
+				"via": []string{"http"}, "endpoint_count": 3,
+			},
+		},
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "fork-a <-> fork-b", Repo: "fork-a",
+			Props: map[string]any{
+				"type": facts.TypeCrossRepoSharedCode, "synthetic": "crossrepo",
+				"via": []string{"shared_symbols"}, "repos": []string{"fork-a", "fork-b"},
+				"symbol_count": 39,
+			},
+		},
+	)
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain error: %v", err)
+	}
+	if len(insights) != 2 {
+		t.Fatalf("insights = %d, want 2 (dependencies + shared code)", len(insights))
+	}
+
+	// The dependency insight must count ONLY real edges: a shared-code pair is not one.
+	dep := insights[0]
+	if !strings.Contains(dep.Title, "1 edges") {
+		t.Errorf("dependency title = %q, want it to count only the 1 real edge", dep.Title)
+	}
+	if strings.Contains(dep.Description, "fork-a") {
+		t.Errorf("shared-code pair leaked into the dependency insight: %q", dep.Description)
+	}
+
+	shared := insights[1]
+	if !strings.Contains(shared.Title, "1 pair(s)") {
+		t.Errorf("shared-code title = %q, want it to mention 1 pair", shared.Title)
+	}
+	if !strings.Contains(shared.Description, "39 shared type name(s)") {
+		t.Errorf("shared-code description should carry the symbol count: %q", shared.Description)
+	}
+	// The wording must state plainly that this is not a dependency and not traversable,
+	// since that is the whole reason it is reported separately.
+	for _, want := range []string{"NOT a dependency", "no graph edge", "find_path"} {
+		if !strings.Contains(shared.Description, want) {
+			t.Errorf("shared-code description missing %q: %q", want, shared.Description)
+		}
+	}
+	if shared.Confidence >= dep.Confidence {
+		t.Errorf("shared-code confidence (%v) must be lower than dependency confidence (%v): names alone cannot confirm shared code",
+			shared.Confidence, dep.Confidence)
+	}
+}
+
+func TestExplain_NoSharedCodeInsightWhenNonePresent(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{
+		Kind: facts.KindDependency, Name: "svc-alpha -> svc-beta", Repo: "svc-alpha",
+		Props: map[string]any{
+			"type": facts.TypeCrossRepo, "synthetic": "crossrepo", "via": []string{"http"},
+		},
+	})
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain error: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("insights = %d, want 1 (no shared-code pairs, so no second insight)", len(insights))
+	}
+}

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -46,6 +46,22 @@ const (
 	KindFileRef = "file_ref"
 )
 
+// Cross-repo dependency-fact "type" prop values. Both the linker that writes these
+// facts and every reader (explainers, renderers, the MCP server) key off them, so they
+// live here rather than being duplicated as literals on each side.
+const (
+	// TypeCrossRepo marks a real, DIRECTIONAL cross-repo edge: one repo imports or
+	// calls the other. Only these attach a depends_on relation to the consumer's
+	// service node, so only these are traversable.
+	TypeCrossRepo = "cross_repo"
+	// TypeCrossRepoSharedCode marks a SYMMETRIC shared-code coupling: two repos declare
+	// many of the same distinctive type names but neither imports or calls the other.
+	// It is queryable evidence with no relation attached, so it never appears in
+	// traverse/find_path/impact_analysis — shared code is not a dependency, and unlike
+	// a dependency it does not compose across hops.
+	TypeCrossRepoSharedCode = "cross_repo_shared_code"
+)
+
 // Relation kind constants.
 const (
 	RelDeclares     = "declares"

--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -15,14 +15,21 @@
 //   - Shared symbol surface: when two repos declare enough of the same
 //     distinctive types (a vendored/shared protocol header, e.g. the onelab
 //     GmshClient/GmshServer classes copied between repos), they are coupled.
-//     This signal is symmetric, so it is emitted as a bidirectional pair of
-//     edges marked via="shared_symbols".
+//     This signal is symmetric and says nothing about direction, so it only
+//     ANNOTATES an edge one of the signals above already established
+//     (via="shared_symbols"). On its own it is not a dependency: neither repo
+//     imports or calls the other, so such a pair is recorded as a symmetric
+//     coupling fact (type="cross_repo_shared_code") that carries no relation and
+//     stays out of the traversable graph.
 //
 // The result is expressed as synthetic facts: one KindService node per repo and
-// one KindDependency edge per (consumer -> provider) pair. Because these are
+// one KindDependency fact per pair. Only the directional ones (type="cross_repo")
+// attach a depends_on relation to the consumer's service node; because these are
 // ordinary facts, they flow into Store.BuildGraph and make every traversal tool
 // (traverse, find_path, impact_analysis, query_facts) cross-repo aware with no
-// per-tool changes.
+// per-tool changes. Keeping the symmetric signal out of that relation matters:
+// traversal composes depends_on across hops, and shared code does not compose —
+// a repo calling one side of a copy-paste pair does not thereby reach the other.
 package crossrepo
 
 import (
@@ -58,6 +65,20 @@ type edge struct {
 	imports    map[string]bool // sample import targets
 	symbols    map[string]bool // sample shared type identities
 	confidence string          // "verified" or "probable" — max over HTTP endpoints
+}
+
+// coupling records a SYMMETRIC shared-code relationship between two repos that have
+// no directional evidence in either direction. It is deliberately not an edge: neither
+// repo imports, calls, or reaches the other, so a depends_on relation would assert a
+// dependency that does not exist — and, because traversal composes depends_on across
+// hops, would let an unrelated repo appear to reach one of these through the other.
+// Shared type names are also only a proxy for shared code: the linker sees names, never
+// file contents, so it cannot tell copied code from a shared vocabulary. The pair is
+// reported as a coupling finding instead, where that uncertainty can be stated.
+type coupling struct {
+	repoA   string // lexicographically first, so the pair has one canonical form
+	repoB   string
+	symbols map[string]bool
 }
 
 // httpCoverage tallies, per consumer repo, how many HTTP-client call sites were
@@ -99,12 +120,15 @@ func ComputeLinks(all []facts.Fact) []facts.Fact {
 	}
 
 	edges := map[string]*edge{}
+	couplings := map[string]*coupling{}
 	cov := map[string]*httpCoverage{}
 	linkHTTP(all, edges, cov)
 	linkImports(all, normToLabel, edges)
-	linkSharedSymbols(all, edges)
+	// Runs last: it consults the edges the directional linkers have already drawn to
+	// decide whether a shared-symbol signal annotates a real dependency or stands alone.
+	linkSharedSymbols(all, edges, couplings)
 
-	return materialize(edges, repoLabels(normToLabel), cov)
+	return materialize(edges, couplings, repoLabels(normToLabel), cov)
 }
 
 // repoLabels returns the actual repo labels (the values of the
@@ -786,7 +810,7 @@ func splitCamelCase(s string) []string {
 // linkSharedSymbols connects repos that declare enough of the same distinctive
 // types. The relationship is symmetric (shared/vendored code, not a one-way
 // dependency), so qualifying pairs get a bidirectional pair of edges.
-func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
+func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[string]*coupling) {
 	repoModules := moduleNamesByRepo(all)
 	repoLang := primaryLanguageByRepo(all)
 	repoCount := len(repoLabelLookup(all))
@@ -862,9 +886,23 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 			continue
 		}
 		a, b, _ := strings.Cut(key, "\x00")
-		for _, pair := range directedSharedPairs(edges, a, b) {
+		pairs, directional := directedSharedPairs(edges, a, b)
+		if !directional {
+			// Nothing to annotate: the repos share type names and nothing else. Record
+			// a symmetric coupling rather than manufacturing a dependency edge.
+			c, ok := couplings[key]
+			if !ok {
+				c = &coupling{repoA: a, repoB: b, symbols: map[string]bool{}}
+				couplings[key] = c
+			}
+			for id := range ids {
+				c.symbols[id] = true
+			}
+			continue
+		}
+		for _, pair := range pairs {
 			e := edgeFor(edges, pair[0], pair[1])
-			e.note("shared_symbols")
+			e.note(viaSharedSymbols)
 			if e.symbols == nil {
 				e.symbols = map[string]bool{}
 			}
@@ -875,20 +913,24 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge) {
 	}
 }
 
-// directionalVias are the evidence kinds that establish a real one-way dependency:
-// consumer imports provider, or consumer calls provider over HTTP. "shared_symbols"
-// is deliberately absent — it is the symmetric signal this gate arbitrates.
-var directionalVias = [...]string{"import", "http-client", "http"}
+// viaSharedSymbols is the one evidence kind that does NOT establish a direction:
+// two repos declaring the same type names says nothing about which depends on which.
+// Every other via — import, http, http-client, grpc, and any signal added later — is
+// directional by construction, so the gate below tests for "anything but this" rather
+// than enumerating the directional kinds. An enumeration silently mis-classified new
+// signals: it omitted "grpc", so a pair linked only by gRPC calls still got a
+// fabricated reverse edge.
+const viaSharedSymbols = "shared_symbols"
 
 // hasDirectionalEvidence reports whether a consumer -> provider edge already exists
-// and is backed by directional (non-shared-symbol) evidence.
+// and is backed by evidence that establishes a direction.
 func hasDirectionalEvidence(edges map[string]*edge, consumer, provider string) bool {
 	e, ok := edges[consumer+"\x00"+provider]
 	if !ok {
 		return false
 	}
-	for _, via := range directionalVias {
-		if e.via[via] {
+	for via := range e.via {
+		if via != viaSharedSymbols {
 			return true
 		}
 	}
@@ -896,21 +938,24 @@ func hasDirectionalEvidence(edges map[string]*edge, consumer, provider string) b
 }
 
 // directedSharedPairs returns the (consumer, provider) orderings a shared-symbol
-// signal between repos a and b should be recorded against. When exactly one
-// direction already carries directional evidence, only that direction is returned,
-// so the shared symbols annotate the established edge instead of fabricating its
-// inverse. When both or neither direction is directional the signal stays symmetric,
-// which is the correct reading for sibling forks and vendored code.
-func directedSharedPairs(edges map[string]*edge, a, b string) [][2]string {
+// signal between repos a and b should be recorded against, and whether the pair has
+// any direction at all. When exactly one direction carries directional evidence, only
+// that direction is returned, so the shared symbols annotate the established edge
+// instead of fabricating its inverse. When both directions are directional the signal
+// annotates both. When NEITHER is, there is no dependency to annotate: ok is false and
+// the caller records a symmetric coupling instead of inventing a pair of edges.
+func directedSharedPairs(edges map[string]*edge, a, b string) (pairs [][2]string, ok bool) {
 	abDirectional := hasDirectionalEvidence(edges, a, b)
 	baDirectional := hasDirectionalEvidence(edges, b, a)
 	switch {
 	case abDirectional && !baDirectional:
-		return [][2]string{{a, b}}
+		return [][2]string{{a, b}}, true
 	case baDirectional && !abDirectional:
-		return [][2]string{{b, a}}
+		return [][2]string{{b, a}}, true
+	case abDirectional && baDirectional:
+		return [][2]string{{a, b}, {b, a}}, true
 	default:
-		return [][2]string{{a, b}, {b, a}}
+		return nil, false
 	}
 }
 
@@ -1089,7 +1134,7 @@ func covFor(cov map[string]*httpCoverage, repo string) *httpCoverage {
 	return c
 }
 
-func materialize(edges map[string]*edge, allRepos []string, cov map[string]*httpCoverage) []facts.Fact {
+func materialize(edges map[string]*edge, couplings map[string]*coupling, allRepos []string, cov map[string]*httpCoverage) []facts.Fact {
 	// Stable order over edges.
 	keys := make([]string, 0, len(edges))
 	for k := range edges {
@@ -1113,7 +1158,7 @@ func materialize(edges map[string]*edge, allRepos []string, cov map[string]*http
 		providers[e.consumer] = append(providers[e.consumer], e.provider)
 
 		props := map[string]any{
-			"type":      "cross_repo",
+			"type":      facts.TypeCrossRepo,
 			"synthetic": SyntheticMarker,
 			"via":       sortedKeys(e.via),
 		}
@@ -1141,6 +1186,33 @@ func materialize(edges map[string]*edge, allRepos []string, cov map[string]*http
 			Name:  fmt.Sprintf("%s -> %s", e.consumer, e.provider),
 			Repo:  e.consumer,
 			Props: props,
+		})
+	}
+
+	// Shared-code couplings are emitted as evidence facts only. They are NOT added to
+	// providers, so no depends_on relation is created and they stay out of the
+	// traversable graph — the whole point of separating them from edges. The name uses
+	// "<->" because the relationship is symmetric; there is no consumer or provider.
+	couplingKeys := make([]string, 0, len(couplings))
+	for k := range couplings {
+		couplingKeys = append(couplingKeys, k)
+	}
+	sort.Strings(couplingKeys)
+	for _, k := range couplingKeys {
+		c := couplings[k]
+		syms := sortedKeys(c.symbols)
+		depFacts = append(depFacts, facts.Fact{
+			Kind: facts.KindDependency,
+			Name: fmt.Sprintf("%s <-> %s", c.repoA, c.repoB),
+			Repo: c.repoA,
+			Props: map[string]any{
+				"type":           facts.TypeCrossRepoSharedCode,
+				"synthetic":      SyntheticMarker,
+				"via":            []string{viaSharedSymbols},
+				"repos":          []string{c.repoA, c.repoB},
+				"symbol_count":   len(syms),
+				"symbol_samples": cap25(syms),
+			},
 		})
 	}
 

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -83,13 +83,56 @@ func serviceNodes(out []facts.Fact) []string {
 // the actual cross-repo edges. Service nodes (which now exist for every loaded
 // repo) are excluded, so this measures "did a link form?".
 func crossRepoEdges(out []facts.Fact) []facts.Fact {
-	var edges []facts.Fact
+	return depFactsOfType(out, facts.TypeCrossRepo)
+}
+
+// sharedCodeFacts returns the symmetric shared-code coupling facts — pairs that share
+// type names with no import or call between them. These are deliberately NOT edges, so
+// they must be counted separately from crossRepoEdges: lumping them together would let
+// a "must not link" test pass while the linker was in fact emitting a coupling.
+func sharedCodeFacts(out []facts.Fact) []facts.Fact {
+	return depFactsOfType(out, facts.TypeCrossRepoSharedCode)
+}
+
+func depFactsOfType(out []facts.Fact, typ string) []facts.Fact {
+	var ff []facts.Fact
 	for _, f := range out {
-		if f.Kind == facts.KindDependency {
-			edges = append(edges, f)
+		if f.Kind == facts.KindDependency && f.Props["type"] == typ {
+			ff = append(ff, f)
 		}
 	}
-	return edges
+	return ff
+}
+
+// findSharedCode returns the coupling fact for the unordered pair {a, b}, or nil.
+func findSharedCode(out []facts.Fact, a, b string) *facts.Fact {
+	if a > b {
+		a, b = b, a
+	}
+	want := a + " <-> " + b
+	for i := range out {
+		if out[i].Kind == facts.KindDependency && out[i].Name == want &&
+			out[i].Props["type"] == facts.TypeCrossRepoSharedCode {
+			return &out[i]
+		}
+	}
+	return nil
+}
+
+// anyServiceEdge reports whether ANY service node carries a depends_on relation — the
+// check that a coupling stayed out of the traversable graph.
+func anyServiceEdge(out []facts.Fact) bool {
+	for _, f := range out {
+		if f.Kind != facts.KindService {
+			continue
+		}
+		for _, rel := range f.Relations {
+			if rel.Kind == facts.RelDependsOn {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // httpCoverageOf returns the http_client coverage counts attached to a service
@@ -619,8 +662,10 @@ func typeSym(repo, name, kind string) facts.Fact {
 
 func TestComputeLinks_SharedSymbolsMatch(t *testing.T) {
 	// getdp and gmsh both declare the vendored onelab/GmshSocket types, under
-	// different directory prefixes (src/common vs Common). Enough distinctive
-	// shared types must link them, bidirectionally and via shared_symbols.
+	// different directory prefixes (src/common vs Common). Enough distinctive shared
+	// types must record a SYMMETRIC coupling — but no dependency edge: neither repo
+	// imports or calls the other, and a depends_on relation would let traversal
+	// compose a path through the pair that does not exist.
 	in := []facts.Fact{
 		module("getdp", "src/common"),
 		typeSym("getdp", "src/common.GmshClient", facts.SymbolClass),
@@ -633,20 +678,24 @@ func TestComputeLinks_SharedSymbolsMatch(t *testing.T) {
 	}
 	out := ComputeLinks(in)
 
-	for _, pair := range [][2]string{{"getdp", "gmsh"}, {"gmsh", "getdp"}} {
-		e := findEdge(out, pair[0], pair[1])
-		if e == nil {
-			t.Fatalf("missing shared-symbol edge %s -> %s; out=%+v", pair[0], pair[1], out)
-		}
-		if via, _ := e.Props["via"].([]string); !reflect.DeepEqual(via, []string{"shared_symbols"}) {
-			t.Errorf("via = %v, want [shared_symbols]", e.Props["via"])
-		}
-		if c, _ := e.Props["symbol_count"].(int); c != 3 {
-			t.Errorf("symbol_count = %v, want 3", e.Props["symbol_count"])
-		}
-		if !hasServiceEdge(out, pair[0], pair[1]) {
-			t.Errorf("%s service node missing depends_on %s", pair[0], pair[1])
-		}
+	sc := findSharedCode(out, "getdp", "gmsh")
+	if sc == nil {
+		t.Fatalf("missing shared-code coupling for getdp/gmsh; out=%+v", out)
+	}
+	if via, _ := sc.Props["via"].([]string); !reflect.DeepEqual(via, []string{"shared_symbols"}) {
+		t.Errorf("via = %v, want [shared_symbols]", sc.Props["via"])
+	}
+	if c, _ := sc.Props["symbol_count"].(int); c != 3 {
+		t.Errorf("symbol_count = %v, want 3", sc.Props["symbol_count"])
+	}
+	if repos, _ := sc.Props["repos"].([]string); !reflect.DeepEqual(repos, []string{"getdp", "gmsh"}) {
+		t.Errorf("repos = %v, want [getdp gmsh] (canonical, lexicographic)", sc.Props["repos"])
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
+		t.Errorf("shared code alone must not create a dependency edge: %+v", edges)
+	}
+	if anyServiceEdge(out) {
+		t.Error("shared code alone must not attach a depends_on relation to any service node")
 	}
 }
 
@@ -658,7 +707,11 @@ func TestComputeLinks_SharedSymbolsBelowThreshold(t *testing.T) {
 		module("beta", "lib"),
 		typeSym("beta", "lib.WidgetRegistry", facts.SymbolClass),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("single shared type should not link: %+v", edges)
 	}
 }
@@ -678,7 +731,11 @@ func TestComputeLinks_SharedSymbolsGenericNamesIgnored(t *testing.T) {
 		typeSym("beta", "lib.Node", facts.SymbolClass),
 		typeSym("beta", "lib.Item", facts.SymbolClass),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("generic shared names should not link: %+v", edges)
 	}
 }
@@ -702,7 +759,11 @@ func TestComputeLinks_SharedSymbolsFrameworkConventionIgnored(t *testing.T) {
 		typeSym("svc-b", "app.Ability", facts.SymbolClass),
 		typeSym("svc-b", "app.ApplicationCable::Connection", facts.SymbolClass),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("framework-convention boilerplate should not link: %+v", edges)
 	}
 }
@@ -727,7 +788,11 @@ func TestComputeLinks_SharedSymbolsMigrationsIgnored(t *testing.T) {
 		migrationSym("svc-b", "AddIndexToWidgets"),
 		migrationSym("svc-b", "InitSchema"),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("shared migration class names should not link: %+v", edges)
 	}
 }
@@ -752,11 +817,11 @@ func TestComputeLinks_SharedSymbolsGenuineSurvivesBoilerplate(t *testing.T) {
 		typeSym("svc-b", "app.RetryPolicy", facts.SymbolClass),
 	}
 	out := ComputeLinks(in)
-	e := findEdge(out, "svc-a", "svc-b")
-	if e == nil {
-		t.Fatalf("genuine shared types should still link; out=%+v", out)
+	sc := findSharedCode(out, "svc-a", "svc-b")
+	if sc == nil {
+		t.Fatalf("genuine shared types should still couple the pair; out=%+v", out)
 	}
-	if c, _ := e.Props["symbol_count"].(int); c != 3 {
+	if c, _ := sc.Props["symbol_count"].(int); c != 3 {
 		t.Errorf("symbol_count = %v, want 3 (only genuine types, boilerplate/migrations excluded)", c)
 	}
 }
@@ -774,7 +839,11 @@ func TestComputeLinks_SharedSymbolsNonTypesIgnored(t *testing.T) {
 		typeSym("beta", "lib.parseHeader", facts.SymbolFunc),
 		typeSym("beta", "lib.computeChecksum", facts.SymbolFunc),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("shared non-type symbols should not link: %+v", edges)
 	}
 }
@@ -800,7 +869,11 @@ func TestComputeLinks_SharedSymbolsCrossLanguageUnqualifiedSkipped(t *testing.T)
 		typeSymLang("ios", "Sources.FeedItem", facts.SymbolClass, "swift"),
 		typeSymLang("ios", "Sources.AccountViewModel", facts.SymbolClass, "swift"),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("unqualified domain types shared across languages must not link: %+v", edges)
 	}
 }
@@ -819,8 +892,8 @@ func TestComputeLinks_SharedSymbolsSameLanguageUnqualifiedLinks(t *testing.T) {
 		typeSymLang("svc-b", "lib.PaymentLedger", facts.SymbolClass, "go"),
 		typeSymLang("svc-b", "lib.RetryPolicy", facts.SymbolClass, "go"),
 	}
-	if findEdge(ComputeLinks(in), "svc-a", "svc-b") == nil {
-		t.Errorf("same-language repos sharing distinctive types should still link")
+	if findSharedCode(ComputeLinks(in), "svc-a", "svc-b") == nil {
+		t.Errorf("same-language repos sharing distinctive types should still couple")
 	}
 }
 
@@ -838,8 +911,8 @@ func TestComputeLinks_SharedSymbolsQualifiedCrossLanguageLinks(t *testing.T) {
 		typeSymLang("repo-b", "vendor.onelab::clientB", facts.SymbolClass, "c"),
 		typeSymLang("repo-b", "vendor.onelab::clientC", facts.SymbolClass, "c"),
 	}
-	if findEdge(ComputeLinks(in), "repo-a", "repo-b") == nil {
-		t.Errorf("qualified shared identities should link even across languages")
+	if findSharedCode(ComputeLinks(in), "repo-a", "repo-b") == nil {
+		t.Errorf("qualified shared identities should couple even across languages")
 	}
 }
 
@@ -858,7 +931,11 @@ func TestComputeLinks_SharedSymbolsCrossLanguageNestedTypesSkipped(t *testing.T)
 		typeSymLang("ios", "Sources.HandicapAnalytics.DifferentialEntry", facts.SymbolClass, "swift"),
 		typeSymLang("ios", "Sources.FullAnalysisDataBuilder.TimeWindow", facts.SymbolClass, "swift"),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("nested types shared across languages must not link: %+v", edges)
 	}
 }
@@ -878,8 +955,8 @@ func TestComputeLinks_SharedSymbolsSameLanguageNestedTypesLink(t *testing.T) {
 		typeSymLang("app-b", "lib.HandicapAnalytics.DifferentialEntry", facts.SymbolClass, "kotlin"),
 		typeSymLang("app-b", "lib.FullAnalysisDataBuilder.TimeWindow", facts.SymbolClass, "kotlin"),
 	}
-	if findEdge(ComputeLinks(in), "app-a", "app-b") == nil {
-		t.Errorf("same-language repos sharing distinctive nested types should still link")
+	if findSharedCode(ComputeLinks(in), "app-a", "app-b") == nil {
+		t.Errorf("same-language repos sharing distinctive nested types should still couple")
 	}
 }
 
@@ -902,7 +979,11 @@ func TestComputeLinks_SharedSymbolsFleetVocabularyNotLinked(t *testing.T) {
 			in = append(in, typeSymLang(repo, "app."+name, facts.SymbolClass, "go"))
 		}
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("fleet-wide shared vocabulary must not link any pair: %+v", edges)
 	}
 }
@@ -927,17 +1008,17 @@ func TestComputeLinks_SharedSymbolsPairSpecificSurvivesFleetVocabulary(t *testin
 		in = append(in, typeSymLang("svc-2", "app."+name, facts.SymbolClass, "go"))
 	}
 	out := ComputeLinks(in)
-	e := findEdge(out, "svc-1", "svc-2")
-	if e == nil {
-		t.Fatalf("pair-specific distinctive types should link svc-1 <-> svc-2; edges=%+v", crossRepoEdges(out))
+	sc := findSharedCode(out, "svc-1", "svc-2")
+	if sc == nil {
+		t.Fatalf("pair-specific distinctive types should couple svc-1/svc-2; got=%+v", sharedCodeFacts(out))
 	}
-	if c, _ := e.Props["symbol_count"].(int); c != 3 {
+	if c, _ := sc.Props["symbol_count"].(int); c != 3 {
 		t.Errorf("symbol_count = %v, want 3 (only pair-specific types; fleet vocabulary dropped)", c)
 	}
-	// Shared code is symmetric, so the one real pair is two directed edges — and
+	// Shared code is symmetric, so the one real pair is a SINGLE coupling fact — and
 	// nothing else, since every other overlap is ubiquitous vocabulary.
-	if edges := crossRepoEdges(out); len(edges) != 2 {
-		t.Errorf("only the svc-1/svc-2 pair should link (2 directed edges), got %d: %+v", len(edges), edges)
+	if sc := sharedCodeFacts(out); len(sc) != 1 {
+		t.Errorf("only the svc-1/svc-2 pair should couple, got %d: %+v", len(sc), sc)
 	}
 }
 
@@ -956,7 +1037,7 @@ func TestComputeLinks_SharedSymbolsSmallRepoSetVocabularyFilterOff(t *testing.T)
 	}
 	out := ComputeLinks(in)
 	for _, pair := range [][2]string{{"svc-a", "svc-b"}, {"svc-a", "svc-c"}, {"svc-b", "svc-c"}} {
-		if findEdge(out, pair[0], pair[1]) == nil {
+		if findSharedCode(out, pair[0], pair[1]) == nil {
 			t.Errorf("with only 3 repos the vocabulary filter must stay off; missing %s <-> %s", pair[0], pair[1])
 		}
 	}
@@ -980,7 +1061,11 @@ func TestComputeLinks_SharedSymbolsGeneratedCodeIgnored(t *testing.T) {
 	for _, name := range []string{"GetCountersResponse", "CounterBatchRequest", "EventCounterModel", "CountersClientWithResponses"} {
 		in = append(in, genTypeSym("svc-a", name), genTypeSym("svc-b", name))
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("generated client structs from a shared API must not link consumers: %+v", edges)
 	}
 }
@@ -998,9 +1083,9 @@ func TestComputeLinks_SharedSymbolsGeneratedExcludedFromCount(t *testing.T) {
 			typeSymLang("svc-a", "internal."+name, facts.SymbolClass, "go"),
 			typeSymLang("svc-b", "internal."+name, facts.SymbolClass, "go"))
 	}
-	e := findEdge(ComputeLinks(in), "svc-a", "svc-b")
+	e := findSharedCode(ComputeLinks(in), "svc-a", "svc-b")
 	if e == nil {
-		t.Fatalf("hand-written distinctive shared types should still link")
+		t.Fatalf("hand-written distinctive shared types should still couple")
 	}
 	if c, _ := e.Props["symbol_count"].(int); c != 3 {
 		t.Errorf("symbol_count = %v, want 3 (generated stubs excluded)", c)
@@ -1322,10 +1407,12 @@ func TestComputeLinks_SharedSymbolsRespectsHTTPDirection(t *testing.T) {
 	}
 }
 
-// TestComputeLinks_SharedSymbolsStaySymmetricWithoutDirection pins that the gate only
-// fires when a direction is actually known. Sibling forks and vendored code have no
-// import or HTTP edge either way, and for them the symmetric reading is correct.
-func TestComputeLinks_SharedSymbolsStaySymmetricWithoutDirection(t *testing.T) {
+// TestComputeLinks_SharedSymbolsCoupleWithoutDirection pins what happens when no
+// direction is known at all. Sibling forks have no import or HTTP edge either way, so
+// there is nothing for the shared symbols to annotate: the pair is recorded as ONE
+// symmetric coupling fact, not as two directed edges asserting a mutual dependency
+// that does not exist.
+func TestComputeLinks_SharedSymbolsCoupleWithoutDirection(t *testing.T) {
 	in := []facts.Fact{
 		module("fork-a", "client"),
 		typeSym("fork-a", "client.WidgetRegistry", facts.SymbolClass),
@@ -1337,10 +1424,17 @@ func TestComputeLinks_SharedSymbolsStaySymmetricWithoutDirection(t *testing.T) {
 		typeSym("fork-b", "client.RetryPolicy", facts.SymbolClass),
 	}
 	out := ComputeLinks(in)
-	for _, pair := range [][2]string{{"fork-a", "fork-b"}, {"fork-b", "fork-a"}} {
-		if findEdge(out, pair[0], pair[1]) == nil {
-			t.Errorf("missing symmetric edge %s -> %s; out=%+v", pair[0], pair[1], out)
-		}
+	if findSharedCode(out, "fork-a", "fork-b") == nil {
+		t.Fatalf("missing shared-code coupling for the fork pair; out=%+v", out)
+	}
+	if sc := sharedCodeFacts(out); len(sc) != 1 {
+		t.Errorf("a symmetric pair must yield exactly one coupling fact, got %d: %+v", len(sc), sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
+		t.Errorf("a fork pair has no dependency in either direction: %+v", edges)
+	}
+	if anyServiceEdge(out) {
+		t.Error("a fork pair must not attach a depends_on relation to any service node")
 	}
 }
 
@@ -1362,15 +1456,19 @@ func TestComputeLinks_SharedSymbolsComponentConventionIgnored(t *testing.T) {
 		typeSym("web-b", "libs.FormHeaderProps", facts.SymbolInterface),
 		typeSym("web-b", "libs.Layout", facts.SymbolClass),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("component-convention names should not link: %+v", edges)
 	}
 }
 
 // TestComputeLinks_SharedSymbolsDistinctiveComponentNamesSurvive is the guard against
 // over-filtering: a "<Component>Props" name whose component is NOT generic vocabulary
-// still names real shared code and must keep linking. Each case here was verified to
-// be genuinely migrated/vendored between the repos.
+// still names real shared code and must keep coupling the pair. Each case here was
+// verified to be genuinely migrated/vendored between the repos.
 func TestComputeLinks_SharedSymbolsDistinctiveComponentNamesSurvive(t *testing.T) {
 	in := []facts.Fact{
 		module("web-a", "client"),
@@ -1385,9 +1483,9 @@ func TestComputeLinks_SharedSymbolsDistinctiveComponentNamesSurvive(t *testing.T
 		typeSym("web-b", "libs.AdSlot", facts.SymbolInterface),
 	}
 	out := ComputeLinks(in)
-	e := findEdge(out, "web-a", "web-b")
+	e := findSharedCode(out, "web-a", "web-b")
 	if e == nil {
-		t.Fatalf("distinctive component names must still link; out=%+v", out)
+		t.Fatalf("distinctive component names must still couple the pair; out=%+v", out)
 	}
 	if c, _ := e.Props["symbol_count"].(int); c != 4 {
 		t.Errorf("symbol_count = %v, want 4", c)
@@ -1481,7 +1579,88 @@ func TestComputeLinks_SharedSymbolsStoryAndTestFilesIgnored(t *testing.T) {
 		storySym("web-b", "client.WidgetRegistry", "client/widget/widget.test.ts"),
 		storySym("web-b", "client.PaymentLedger", "client/__mocks__/ledger.ts"),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	out := ComputeLinks(in)
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("must not couple the repos either: %+v", sc)
+	}
+	if edges := crossRepoEdges(out); len(edges) != 0 {
 		t.Errorf("story/test/mock declarations should not link: %+v", edges)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsRespectsGRPCDirection covers a gap the first version of
+// the direction gate had: it enumerated the directional evidence kinds and omitted
+// "grpc", so a pair whose only real dependency was a gRPC call still had the reverse
+// edge fabricated from shared symbols. The gate now tests for "any via that is not
+// shared_symbols", which cannot miss a signal added later.
+func TestComputeLinks_SharedSymbolsRespectsGRPCDirection(t *testing.T) {
+	in := []facts.Fact{
+		module("client", "internal"),
+		clientRoute("client", "/pkg.Svc/Method", "POST", map[string]any{"framework": "grpc"}),
+		typeSym("client", "internal.WidgetRegistry", facts.SymbolClass),
+		typeSym("client", "internal.PaymentLedger", facts.SymbolClass),
+		typeSym("client", "internal.RetryPolicy", facts.SymbolClass),
+		module("server", "internal"),
+		serverRoute("server", "/pkg.Svc/Method", "POST"),
+		typeSym("server", "internal.WidgetRegistry", facts.SymbolClass),
+		typeSym("server", "internal.PaymentLedger", facts.SymbolClass),
+		typeSym("server", "internal.RetryPolicy", facts.SymbolClass),
+	}
+	out := ComputeLinks(in)
+
+	e := findEdge(out, "client", "server")
+	if e == nil {
+		t.Fatalf("missing client -> server gRPC edge; out=%+v", out)
+	}
+	if via, _ := e.Props["via"].([]string); !reflect.DeepEqual(via, []string{"grpc", "shared_symbols"}) {
+		t.Errorf("via = %v, want [grpc shared_symbols] (shared symbols annotate the gRPC edge)", e.Props["via"])
+	}
+	if rev := findEdge(out, "server", "client"); rev != nil {
+		t.Errorf("gRPC direction is known, so no reverse edge may be fabricated: %+v", rev)
+	}
+	// Direction was established, so this is a real dependency — not a coupling.
+	if sc := sharedCodeFacts(out); len(sc) != 0 {
+		t.Errorf("a directional pair must not also be reported as shared-code coupling: %+v", sc)
+	}
+}
+
+// TestComputeLinks_SharedCodeDoesNotCompose is the regression test for the failure that
+// motivated demoting this signal. A caller reaching one side of a copy-paste pair must
+// NOT thereby reach the other side: dependency edges compose across hops, shared code
+// does not. Concretely this is the shape "web --(http)--> api" alongside "api <shares
+// code with> twin"; web must gain no route to twin.
+func TestComputeLinks_SharedCodeDoesNotCompose(t *testing.T) {
+	in := []facts.Fact{
+		module("web", "client"),
+		clientRoute("web", "/api/widgets/registry", "GET", nil),
+		module("api", "app"),
+		serverRoute("api", "/api/widgets/registry", "GET"),
+		typeSym("api", "app.WidgetRegistry", facts.SymbolClass),
+		typeSym("api", "app.PaymentLedger", facts.SymbolClass),
+		typeSym("api", "app.RetryPolicy", facts.SymbolClass),
+		// A sibling fork of api: same distinctive types, no import and no route.
+		module("twin", "app"),
+		typeSym("twin", "app.WidgetRegistry", facts.SymbolClass),
+		typeSym("twin", "app.PaymentLedger", facts.SymbolClass),
+		typeSym("twin", "app.RetryPolicy", facts.SymbolClass),
+	}
+	out := ComputeLinks(in)
+
+	if findEdge(out, "web", "api") == nil {
+		t.Fatalf("the real HTTP dependency must survive; out=%+v", out)
+	}
+	if findSharedCode(out, "api", "twin") == nil {
+		t.Errorf("the api/twin shared code should still be reported as a coupling")
+	}
+	// The only edge in the graph is web -> api. If api <-> twin were edges, "twin"
+	// would become reachable from "web" in two hops.
+	edges := crossRepoEdges(out)
+	if len(edges) != 1 {
+		t.Errorf("expected exactly one dependency edge (web -> api), got %d: %+v", len(edges), edges)
+	}
+	for _, r := range []string{"api", "twin"} {
+		if hasServiceEdge(out, r, "twin") {
+			t.Errorf("%s must not carry a depends_on to twin — shared code is not a dependency", r)
+		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -691,7 +691,7 @@ func (s *Server) registerTools() {
 
 			// Report the cross-repo "graph of graphs" links derived from this set.
 			crossEdges, _ := s.eng.Store().QueryAdvanced(facts.QueryOpts{
-				Kind: facts.KindDependency, Prop: "type", PropValue: "cross_repo", Limit: 500,
+				Kind: facts.KindDependency, Prop: "type", PropValue: facts.TypeCrossRepo, Limit: 500,
 			})
 			services := s.eng.Store().ByKind(facts.KindService)
 			summary += fmt.Sprintf(
@@ -700,6 +700,20 @@ func (s *Server) registerTools() {
 					"query_facts(kind=\"service\") or query_facts(prop=\"type\", prop_value=\"cross_repo\").",
 				len(services), len(crossEdges), repoLabel,
 			)
+			// Shared-code pairs are NOT edges (no depends_on relation, so traversal never
+			// follows them). Surfaced separately so the signal is discoverable without
+			// being mistaken for a dependency.
+			sharedCode, _ := s.eng.Store().QueryAdvanced(facts.QueryOpts{
+				Kind: facts.KindDependency, Prop: "type", PropValue: facts.TypeCrossRepoSharedCode, Limit: 500,
+			})
+			if len(sharedCode) > 0 {
+				summary += fmt.Sprintf(
+					"\n- **Shared code:** %d repo pair(s) declare many of the same type names with no "+
+						"import or call between them — a maintenance signal, not a dependency, so they carry "+
+						"no graph edge. List them with query_facts(prop=\"type\", prop_value=%q).",
+					len(sharedCode), facts.TypeCrossRepoSharedCode,
+				)
+			}
 		} else {
 			// Single-repo edit-verify loop guidance, tailored to whether a baseline
 			// is already pinned: nudge set_baseline before the agent edits, then


### PR DESCRIPTION
Two repos declaring the same distinctive types were linked with depends_on, but neither imports nor calls the other — delete one and the other still builds. The linker also cannot substantiate the claim: it sees names, never file contents. Measured across the identities behind these edges, ~45% were entirely different code sharing a name, and the only truly identical ones came from a single vendored file. Every filter added over time was a proxy for a measurement that is structurally out of reach.

It also broke composition: depends_on composes across hops, shared code does not, so a caller of one side of a copy-paste pair appeared to reach the other.

Such a pair now yields one symmetric fact (type=cross_repo_shared_code, "a <-> b") that carries no relation — queryable, but never in the traversable graph — plus a separate insight at lower confidence. Shared symbols still annotate an edge that an import or call already established; that case is unchanged.

Also fixes the direction gate, which enumerated the directional via kinds and omitted "grpc". It now tests for "any via except shared_symbols", so signals added later cannot be missed.