### PR TITLE
feat: verify shared type names against the files that declare them

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -358,7 +358,7 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 	// synthetic facts are dropped first) so it stays idempotent across appends.
 	tStage = time.Now()
 	e.resolvePyGRPCClientRoutes()
-	e.linkCrossRepo()
+	e.linkCrossRepo(workRepoPaths)
 	e.flagUnmatchedRoutes()
 	e.bindGRPCHandlers()
 	e.bindHTTPHandlers()
@@ -481,10 +481,53 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 	return snapshot, nil
 }
 
+// sourceReaderFor builds the crossrepo.SourceReader used to verify shared type names
+// against the code behind them. It mirrors ResolveFactFile's repo-prefix-strip-and-join,
+// but reads from the passed-in map rather than the published bundle (see linkCrossRepo).
+// Returns nil when no repo paths are known, which turns verification off rather than
+// silently comparing nothing. Files are read at most once per snapshot.
+func sourceReaderFor(repoPaths map[string]string) crossrepo.SourceReader {
+	if len(repoPaths) == 0 {
+		return nil
+	}
+	cache := map[string]string{}
+	missing := map[string]bool{}
+	return func(f facts.Fact) (string, bool) {
+		if f.File == "" || f.Repo == "" {
+			return "", false
+		}
+		if text, ok := cache[f.File]; ok {
+			return text, true
+		}
+		if missing[f.File] {
+			return "", false
+		}
+		root, ok := repoPaths[f.Repo]
+		if !ok {
+			missing[f.File] = true
+			return "", false
+		}
+		abs := filepath.Join(root, strings.TrimPrefix(f.File, f.Repo+"/"))
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			missing[f.File] = true
+			return "", false
+		}
+		cache[f.File] = string(data)
+		return cache[f.File], true
+	}
+}
+
 // linkCrossRepo drops any previously-synthesized cross-repo facts and recomputes
 // them over the full fact set, adding service nodes and consumer→provider edges.
 // It is a no-op for single-repo snapshots (no cross-repo matches exist).
-func (e *Engine) linkCrossRepo() {
+//
+// repoPaths must be the IN-FLIGHT label -> absolute path map, not the published
+// bundle's: this runs mid-snapshot, before the new bundle is stored, so
+// ResolveFactFile would not yet know the repo currently being appended. It is used to
+// read source for shared-symbol verification; a nil or incomplete map degrades that
+// check to name-only matching rather than failing.
+func (e *Engine) linkCrossRepo(repoPaths map[string]string) {
 	e.store.RemoveWhere(func(f facts.Fact) bool {
 		if f.Props == nil {
 			return false
@@ -492,7 +535,7 @@ func (e *Engine) linkCrossRepo() {
 		return f.Props["synthetic"] == crossrepo.SyntheticMarker
 	})
 
-	links := crossrepo.ComputeLinks(e.store.All())
+	links := crossrepo.ComputeLinks(e.store.All(), sourceReaderFor(repoPaths))
 	if len(links) == 0 {
 		return
 	}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -358,7 +359,7 @@ func TestLinkCrossRepo_ConnectsServicesInGraph(t *testing.T) {
 		},
 	)
 
-	eng.linkCrossRepo()
+	eng.linkCrossRepo(nil)
 
 	if got := eng.Store().ByKind(facts.KindService); len(got) != 2 {
 		t.Fatalf("service nodes = %d, want 2", len(got))
@@ -390,7 +391,7 @@ func TestLinkCrossRepo_ConnectsServicesInGraph(t *testing.T) {
 
 	// Idempotent: re-running linking keeps exactly one service node per repo
 	// and one edge (no duplicates).
-	eng.linkCrossRepo()
+	eng.linkCrossRepo(nil)
 	if got := eng.Store().ByKind(facts.KindService); len(got) != 2 {
 		t.Errorf("after relink, service nodes = %d, want 2", len(got))
 	}
@@ -419,7 +420,7 @@ func TestLinkCrossRepo_CoverageGapInsight(t *testing.T) {
 			Props: map[string]any{"method": "GET", "role": "server"},
 		},
 	)
-	eng.linkCrossRepo()
+	eng.linkCrossRepo(nil)
 
 	// The svc-alpha service node carries edge_coverage with an unresolved call site.
 	var alpha *facts.Fact
@@ -478,5 +479,47 @@ func TestGenerateSnapshot_ConcurrentCallsSerialized(t *testing.T) {
 		if err != nil {
 			t.Logf("goroutine %d error (expected): %v", i, err)
 		}
+	}
+}
+
+// TestSourceReaderFor_ResolvesRepoPrefixedPaths covers the timing trap in
+// linkCrossRepo: it runs mid-snapshot, before the new bundle is published, so the
+// reader must resolve paths from the in-flight map rather than ResolveFactFile. Facts
+// carry repo-prefixed paths in append mode, which the reader has to strip.
+func TestSourceReaderFor_ResolvesRepoPrefixedPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := "class Widget\nend\n"
+	if err := os.WriteFile(filepath.Join(root, "app", "widget.rb"), []byte(want), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	read := sourceReaderFor(map[string]string{"svc": root})
+	if read == nil {
+		t.Fatal("expected a reader for a non-empty repo path map")
+	}
+
+	got, ok := read(facts.Fact{Repo: "svc", File: "svc/app/widget.rb"})
+	if !ok || got != want {
+		t.Errorf("read(repo-prefixed) = %q, %v; want %q, true", got, ok, want)
+	}
+	if _, ok := read(facts.Fact{Repo: "svc", File: "svc/app/missing.rb"}); ok {
+		t.Error("missing file should report not-ok, not an empty success")
+	}
+	if _, ok := read(facts.Fact{Repo: "unknown", File: "unknown/app/widget.rb"}); ok {
+		t.Error("unknown repo label should report not-ok")
+	}
+}
+
+// TestSourceReaderFor_NilWithoutRepoPaths: no known paths means verification is off,
+// not that every comparison silently sees empty files.
+func TestSourceReaderFor_NilWithoutRepoPaths(t *testing.T) {
+	if sourceReaderFor(nil) != nil {
+		t.Error("nil repo paths should yield a nil reader (verification disabled)")
+	}
+	if sourceReaderFor(map[string]string{}) != nil {
+		t.Error("empty repo paths should yield a nil reader (verification disabled)")
 	}
 }

--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -231,7 +231,7 @@ var rubyFrameworkBaseClasses = map[string]bool{
 }
 
 // rubyBaseClassSuffixes are naming conventions for user-defined base classes
-// (NotifierBase, ApiBaseController, Pusher::Base, ...). A class named like this is
+// (MessengerBase, ApiBaseController, Widget::Base, ...). A class named like this is
 // a base others inherit from, so its inbound degree is inheritance, not coupling.
 var rubyBaseClassSuffixes = []string{
 	"BaseController", "BaseJob", "BaseService", "BaseMailer", "BaseSerializer",

--- a/internal/explainers/crossrepo/crossrepo.go
+++ b/internal/explainers/crossrepo/crossrepo.go
@@ -92,22 +92,38 @@ func sharedCodeInsight(store *facts.Store) *facts.Insight {
 
 	evidence := make([]facts.Evidence, 0, len(pairs))
 	var lines []string
+	verified := false
 	for _, p := range pairs {
-		detail := fmt.Sprintf("%d shared type name(s)", propInt(p, "symbol_count"))
+		count := propInt(p, "symbol_count")
+		detail := fmt.Sprintf("%d shared type(s)", count)
+		// name_match_count is only set when source verification narrowed the set, so
+		// its presence is what tells us the counts were measured rather than inferred.
+		if names := propInt(p, "name_match_count"); names > count {
+			detail = fmt.Sprintf("%d of %d shared type name(s) backed by near-identical files", count, names)
+			verified = true
+		}
 		evidence = append(evidence, facts.Evidence{Fact: p.Name, Detail: detail})
 		lines = append(lines, p.Name+" ("+detail+")")
 	}
 
+	// A verified count is a measurement of the files, not an inference from names, so
+	// it earns materially higher confidence than the name-only fallback.
+	confidence, caveat := 0.5, "Matching names do not prove the code is still shared, so diff the declarations before relying on it."
+	if verified {
+		confidence = 0.8
+		caveat = "Counts are verified by comparing the declaring files, not by name alone; " +
+			"names that matched without matching code were dropped."
+	}
+
 	return &facts.Insight{
 		Title: fmt.Sprintf("Shared code between repos (%d pair(s))", len(pairs)),
-		Description: "These repo pairs declare many of the same distinctive type names, " +
+		Description: "These repo pairs declare the same distinctive types, " +
 			"which usually means copied or vendored code, or a common ancestor: " +
 			strings.Join(lines, "; ") + ". This is NOT a dependency — neither repo imports " +
 			"or calls the other — so these pairs carry no graph edge and do not appear in " +
 			"traverse, find_path or impact_analysis. Treat it as a maintenance signal: a fix " +
-			"in one may be needed in the other. Matching names do not prove the code is still " +
-			"shared, so diff the declarations before relying on it.",
-		Confidence: 0.5,
+			"in one may be needed in the other. " + caveat,
+		Confidence: confidence,
 		Evidence:   evidence,
 	}
 }

--- a/internal/explainers/crossrepo/crossrepo_test.go
+++ b/internal/explainers/crossrepo/crossrepo_test.go
@@ -180,8 +180,16 @@ func TestExplain_SharedCodeIsSeparateHedgedInsight(t *testing.T) {
 	if !strings.Contains(shared.Title, "1 pair(s)") {
 		t.Errorf("shared-code title = %q, want it to mention 1 pair", shared.Title)
 	}
-	if !strings.Contains(shared.Description, "39 shared type name(s)") {
+	if !strings.Contains(shared.Description, "39 shared type(s)") {
 		t.Errorf("shared-code description should carry the symbol count: %q", shared.Description)
+	}
+	// Without name_match_count nothing was verified, so the wording must stay cautious
+	// and the confidence low.
+	if !strings.Contains(shared.Description, "do not prove") {
+		t.Errorf("unverified shared code must keep the cautious caveat: %q", shared.Description)
+	}
+	if shared.Confidence != 0.5 {
+		t.Errorf("unverified confidence = %v, want 0.5", shared.Confidence)
 	}
 	// The wording must state plainly that this is not a dependency and not traversable,
 	// since that is the whole reason it is reported separately.
@@ -210,5 +218,39 @@ func TestExplain_NoSharedCodeInsightWhenNonePresent(t *testing.T) {
 	}
 	if len(insights) != 1 {
 		t.Fatalf("insights = %d, want 1 (no shared-code pairs, so no second insight)", len(insights))
+	}
+}
+
+// TestExplain_SharedCodeVerifiedRaisesConfidence pins the difference between a count
+// inferred from names and one measured against the files: when the linker recorded a
+// name_match_count larger than the verified symbol_count, the insight must say so and
+// carry higher confidence.
+func TestExplain_SharedCodeVerifiedRaisesConfidence(t *testing.T) {
+	s := facts.NewStore()
+	s.Add(facts.Fact{
+		Kind: facts.KindDependency, Name: "fork-a <-> fork-b", Repo: "fork-a",
+		Props: map[string]any{
+			"type": facts.TypeCrossRepoSharedCode, "synthetic": "crossrepo",
+			"via": []string{"shared_symbols"}, "repos": []string{"fork-a", "fork-b"},
+			"symbol_count": 11, "name_match_count": 39,
+		},
+	})
+
+	insights, err := New().Explain(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Explain error: %v", err)
+	}
+	if len(insights) != 1 {
+		t.Fatalf("insights = %d, want 1", len(insights))
+	}
+	got := insights[0]
+	if !strings.Contains(got.Description, "11 of 39 shared type name(s) backed by near-identical files") {
+		t.Errorf("verified description should report both counts: %q", got.Description)
+	}
+	if got.Confidence != 0.8 {
+		t.Errorf("verified confidence = %v, want 0.8 (measured, not inferred)", got.Confidence)
+	}
+	if strings.Contains(got.Description, "do not prove") {
+		t.Errorf("verified insight must drop the name-only caveat: %q", got.Description)
 	}
 }

--- a/internal/explainers/hotspots/hotspots_test.go
+++ b/internal/explainers/hotspots/hotspots_test.go
@@ -105,7 +105,7 @@ func TestExplain_RubyBaseClassExcluded(t *testing.T) {
 				File: "caller.rb", Relations: []facts.Relation{{Kind: facts.RelCalls, Target: name}}})
 		}
 	}
-	addHub("NotifierBase", "app/notifiers/notifier_base.rb")
+	addHub("MessengerBase", "app/messengers/messenger_base.rb")
 	addHub("User", "app/models/user.rb")
 	s.BuildGraph()
 
@@ -115,7 +115,7 @@ func TestExplain_RubyBaseClassExcluded(t *testing.T) {
 	}
 	var sawBase, sawUser bool
 	for _, in := range insights {
-		if strings.Contains(in.Title, "NotifierBase") {
+		if strings.Contains(in.Title, "MessengerBase") {
 			sawBase = true
 		}
 		if strings.Contains(in.Title, "User") {

--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -35,6 +35,7 @@ package crossrepo
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -63,8 +64,12 @@ type edge struct {
 	via        map[string]bool // "http", "http-client", "import", "shared_symbols"
 	endpoints  map[string]bool // "METHOD /path"
 	imports    map[string]bool // sample import targets
-	symbols    map[string]bool // sample shared type identities
+	symbols    map[string]bool // shared type identities, verified against source when available
 	confidence string          // "verified" or "probable" — max over HTTP endpoints
+	// nameMatches is how many identities matched by NAME before source verification
+	// narrowed them. Reported alongside the verified count so the difference between
+	// repos that share code and repos that merely share a vocabulary stays visible.
+	nameMatches int
 }
 
 // coupling records a SYMMETRIC shared-code relationship between two repos that have
@@ -78,8 +83,16 @@ type edge struct {
 type coupling struct {
 	repoA   string // lexicographically first, so the pair has one canonical form
 	repoB   string
-	symbols map[string]bool
+	symbols map[string]bool // verified against source when a SourceReader was available
+	// nameMatches is the pre-verification count — see edge.nameMatches.
+	nameMatches int
 }
+
+// SourceReader returns the text of the file a fact was extracted from, and whether it
+// could be read. It is how the linker — which otherwise only ever sees facts — gets at
+// source, so a shared type NAME can be checked against the actual code behind it.
+// Callers that cannot supply source pass nil, and matching falls back to names alone.
+type SourceReader func(f facts.Fact) (string, bool)
 
 // httpCoverage tallies, per consumer repo, how many HTTP-client call sites were
 // detected and how many resolved to a loaded service. The difference is the
@@ -113,7 +126,9 @@ func (e *edge) noteConfidence(c string) {
 // connect repositories. It is pure and deterministic: the same input always
 // yields the same output in a stable, sorted order, so callers may recompute it
 // idempotently after removing the prior synthetic facts.
-func ComputeLinks(all []facts.Fact) []facts.Fact {
+// src supplies file contents so shared type names can be verified against the code
+// behind them; pass nil to match on names alone.
+func ComputeLinks(all []facts.Fact, src SourceReader) []facts.Fact {
 	normToLabel := repoLabelLookup(all)
 	if len(normToLabel) < 2 {
 		return nil // need at least two repos to have a cross-repo edge
@@ -126,7 +141,7 @@ func ComputeLinks(all []facts.Fact) []facts.Fact {
 	linkImports(all, normToLabel, edges)
 	// Runs last: it consults the edges the directional linkers have already drawn to
 	// decide whether a shared-symbol signal annotates a real dependency or stands alone.
-	linkSharedSymbols(all, edges, couplings)
+	linkSharedSymbols(all, edges, couplings, src)
 
 	return materialize(edges, couplings, repoLabels(normToLabel), cov)
 }
@@ -732,11 +747,11 @@ var frameworkConventionNames = map[string]bool{
 
 // genericComponentNames are the vocabulary of UI-component naming: words so many
 // components are built from that a type named only out of them identifies a role,
-// not a shared implementation. Two frontends each declaring a "FooterProps" or a
-// "ModalProps" is convention, not shared code — their field sets typically have no
+// not a shared implementation. Two frontends each declaring a "SidebarProps" or a
+// "DialogProps" is convention, not shared code — their field sets typically have no
 // overlap at all. Checked against the camelCase segments of an identity once its
-// convention suffix is stripped, so "FormHeaderProps" (all-generic) is rejected while
-// "PinMarkerProps" (Pin is not generic) survives.
+// convention suffix is stripped, so "PanelSectionProps" (all-generic) is rejected while
+// "GaugePanelProps" (Gauge is not generic) survives.
 var genericComponentNames = map[string]bool{
 	"footer": true, "header": true, "layout": true, "modal": true, "card": true,
 	"button": true, "list": true, "container": true, "wrapper": true,
@@ -754,16 +769,16 @@ var conventionSuffixes = [...]string{"Props", "Types", "Type", "State"}
 
 // isConventionalComponentName reports whether an identity is built purely from the
 // generic UI-component vocabulary — a name every app of the framework produces for
-// its own unrelated component. It strips one convention suffix ("FooterProps" ->
+// its own unrelated component. It strips one convention suffix ("SidebarProps" ->
 // "Footer"), splits the remainder on camelCase boundaries, and rejects the identity
 // only when EVERY segment is generic vocabulary.
 //
 // A single distinctive segment is enough to save a name, which is what keeps a
-// disambiguating prefix meaningful: "EListItem" splits to E/List/Item, and though
-// List and Item are generic, the deliberate "E" enum prefix is not — so the identity
+// disambiguating prefix meaningful: "TListRow" splits to T/List/Row, and though
+// List and Row are generic, the deliberate "T" type prefix is not — so the identity
 // survives, as it should, because such a name really is shared code rather than a
 // coincidence. The stripped core is also deliberately NOT re-checked against the
-// minimum-length rule: "LikeProps" reduces to a 4-character "Like" yet names real
+// minimum-length rule: "TileProps" reduces to a 4-character "Like" yet names real
 // shared code.
 func isConventionalComponentName(id string) bool {
 	core := id
@@ -786,7 +801,7 @@ func isConventionalComponentName(id string) bool {
 	return true
 }
 
-// splitCamelCase breaks an identifier on lower-to-upper transitions, so "FormHeader"
+// splitCamelCase breaks an identifier on lower-to-upper transitions, so "PanelSection"
 // yields ["Form", "Header"]. Runs of capitals stay together ("HTTPServer" -> ["HTTP",
 // "Server"]) so an acronym is not shredded into single letters.
 func splitCamelCase(s string) []string {
@@ -807,16 +822,142 @@ func splitCamelCase(s string) []string {
 	return out
 }
 
-// linkSharedSymbols connects repos that declare enough of the same distinctive
-// types. The relationship is symmetric (shared/vendored code, not a one-way
-// dependency), so qualifying pairs get a bidirectional pair of edges.
-func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[string]*coupling) {
+// minFileSimilarity is the least line-set overlap the two files declaring a shared type
+// name must have for that name to count as evidence of shared CODE. Measured on real
+// repo pairs, file-level overlap separates the two populations cleanly: genuinely
+// vendored files score at or near 1.0, while same-name-different-code declarations sit
+// far below — so the threshold sits between them rather than near either.
+//
+// Comparing FILES rather than declaration bodies is deliberate: copied code travels as
+// whole files, and facts carry no end line, so a body would have to be guessed. The
+// tradeoff is a missed match when a genuinely shared declaration sits inside an
+// otherwise-different file.
+const minFileSimilarity = 0.5
+
+// maxComparedFileBytes skips files too large to be worth hashing line-by-line; a
+// vendored bundle or generated blob should not dominate link time.
+const maxComparedFileBytes = 1 << 20 // 1 MiB
+
+// maxFactsPerIdentityRepo bounds how many declaring facts are kept per (identity,
+// repo). A class can be reopened across several files; keeping a few lets verification
+// pick the best-matching pair without letting a widely-reopened name explode the
+// comparison count.
+const maxFactsPerIdentityRepo = 3
+
+// fileComparer scores how similar two source files are, memoizing both the per-file
+// line sets and the per-pair score. Several shared identities usually resolve to the
+// same file pair, and every file is read at most once.
+type fileComparer struct {
+	src   SourceReader
+	lines map[string]map[string]bool // fact file path -> normalized line set (nil = unreadable)
+	score map[string]float64         // "fileA\x00fileB" -> similarity
+}
+
+func newFileComparer(src SourceReader) *fileComparer {
+	return &fileComparer{
+		src:   src,
+		lines: map[string]map[string]bool{},
+		score: map[string]float64{},
+	}
+}
+
+// linesOf returns the normalized line set of a fact's file, or nil when unreadable.
+func (fc *fileComparer) linesOf(f facts.Fact) map[string]bool {
+	if set, ok := fc.lines[f.File]; ok {
+		return set
+	}
+	var set map[string]bool
+	if text, ok := fc.src(f); ok && len(text) <= maxComparedFileBytes {
+		set = tokenSet(text)
+	}
+	fc.lines[f.File] = set
+	return set
+}
+
+// similar reports whether the files declaring a and b are alike enough to treat the
+// shared name as shared code.
+func (fc *fileComparer) similar(a, b facts.Fact) bool {
+	key := a.File + "\x00" + b.File
+	if b.File < a.File {
+		key = b.File + "\x00" + a.File
+	}
+	if s, ok := fc.score[key]; ok {
+		return s >= minFileSimilarity
+	}
+	s := jaccard(fc.linesOf(a), fc.linesOf(b))
+	fc.score[key] = s
+	return s >= minFileSimilarity
+}
+
+// tokenSet reduces source to the set of identifiers and punctuation it contains.
+//
+// Tokens rather than lines: a copy that drifted usually keeps its structure but edits
+// something inside many lines — a renamed constant, a changed argument — and whole-line
+// comparison scores that as a near-total mismatch. Calibrated against a
+// character-diff ratio over real repo pairs, line-set overlap disagreed on 4 of 13
+// sampled declarations (every one a false negative, including two files ~95% identical),
+// while token-set overlap agreed on all 13. Comments are deliberately NOT stripped —
+// that would need per-language syntax, and a copied file carries its comments anyway.
+func tokenSet(text string) map[string]bool {
+	set := map[string]bool{}
+	for _, tok := range tokenPattern.FindAllString(text, -1) {
+		set[tok] = true
+	}
+	return set
+}
+
+// tokenPattern matches an identifier (letters, digits, underscore, not leading with a
+// digit) or any single non-space character, so operators and punctuation count too.
+var tokenPattern = regexp.MustCompile(`[A-Za-z_][A-Za-z_0-9]*|[^\sA-Za-z_0-9]`)
+
+// jaccard is the intersection-over-union of two token sets, 0 when either is empty. Set
+// overlap (rather than a diff) makes the score independent of how the code was
+// reordered, which is what a drifted copy usually looks like.
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for line := range a {
+		if b[line] {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// verifyIdentity reports whether any pairing of the files declaring id in repos a and b
+// is similar enough to count. A class reopened across files gives several candidates;
+// the best pairing wins, since one shared file is enough to evidence shared code.
+func verifyIdentity(byRepo map[string][]facts.Fact, a, b string, fc *fileComparer) bool {
+	for _, fa := range byRepo[a] {
+		for _, fb := range byRepo[b] {
+			if fc.similar(fa, fb) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// linkSharedSymbols connects repos that declare enough of the same distinctive types.
+// Name matching alone only produces CANDIDATES: two repos declaring the same domain class may
+// share code or may merely share a domain vocabulary, and the name cannot tell them
+// apart. When src is non-nil each candidate is verified by comparing the files that
+// declare it, and only verified identities count toward the threshold. A nil src skips
+// verification and falls back to name-only matching.
+func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[string]*coupling, src SourceReader) {
 	repoModules := moduleNamesByRepo(all)
 	repoLang := primaryLanguageByRepo(all)
 	repoCount := len(repoLabelLookup(all))
 
-	// identity -> set of repos that declare a type with that identity.
-	idToRepos := map[string]map[string]bool{}
+	// identity -> repo -> the facts declaring it there. The facts (not just a repo
+	// set) are kept so verification can reach the declaring file.
+	idToRepos := map[string]map[string][]facts.Fact{}
 	for _, f := range all {
 		if f.Kind != facts.KindSymbol || f.Repo == "" || !isTypeSymbol(f) {
 			continue
@@ -829,9 +970,11 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[s
 			continue
 		}
 		if idToRepos[id] == nil {
-			idToRepos[id] = map[string]bool{}
+			idToRepos[id] = map[string][]facts.Fact{}
 		}
-		idToRepos[id][f.Repo] = true
+		if len(idToRepos[id][f.Repo]) < maxFactsPerIdentityRepo {
+			idToRepos[id][f.Repo] = append(idToRepos[id][f.Repo], f)
+		}
 	}
 
 	// For each identity shared by 2+ repos, record it against every repo pair — but
@@ -875,9 +1018,32 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[s
 		}
 	}
 
-	// Materialize an edge for each pair over the threshold. Shared code is
-	// inherently symmetric, so the default is a bidirectional pair — but when an
-	// earlier linker has already established a DIRECTION for this pair (an import
+	// Verify the candidates against source. Up to here a match means only that both
+	// repos declare the name; now the files behind it decide whether that name is
+	// evidence of shared code. nameMatches keeps the pre-verification tally so the
+	// gap between "shares code" and "shares a vocabulary" stays reportable.
+	nameMatches := map[string]int{}
+	for key, ids := range pairShared {
+		nameMatches[key] = len(ids)
+	}
+	if src != nil {
+		fc := newFileComparer(src)
+		for key, ids := range pairShared {
+			a, b, _ := strings.Cut(key, "\x00")
+			verified := map[string]bool{}
+			for id := range ids {
+				if verifyIdentity(idToRepos[id], a, b, fc) {
+					verified[id] = true
+				}
+			}
+			pairShared[key] = verified
+		}
+	}
+
+	// Materialize an edge for each pair over the threshold — counted in VERIFIED
+	// identities, so a pair sharing many names but no code drops out entirely. Shared
+	// code is inherently symmetric, so the default is a bidirectional pair — but when
+	// an earlier linker has already established a DIRECTION for this pair (an import
 	// or HTTP call one way and not the other), that direction is authoritative and
 	// the reverse edge would contradict it. A library monorepo whose types a
 	// consuming app also declares must not come out depending on that app.
@@ -895,6 +1061,7 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[s
 				c = &coupling{repoA: a, repoB: b, symbols: map[string]bool{}}
 				couplings[key] = c
 			}
+			c.nameMatches = nameMatches[key]
 			for id := range ids {
 				c.symbols[id] = true
 			}
@@ -903,6 +1070,7 @@ func linkSharedSymbols(all []facts.Fact, edges map[string]*edge, couplings map[s
 		for _, pair := range pairs {
 			e := edgeFor(edges, pair[0], pair[1])
 			e.note(viaSharedSymbols)
+			e.nameMatches = nameMatches[key]
 			if e.symbols == nil {
 				e.symbols = map[string]bool{}
 			}
@@ -1026,8 +1194,8 @@ func isDistinctiveIdentity(id string) bool {
 	if genericTypeNames[strings.ToLower(id)] {
 		return false
 	}
-	// A name assembled purely from generic component vocabulary ("FooterProps",
-	// "FormHeaderProps") is naming convention rather than shared code.
+	// A name assembled purely from generic component vocabulary ("SidebarProps",
+	// "PanelSectionProps") is naming convention rather than shared code.
 	return !isConventionalComponentName(id)
 }
 
@@ -1179,6 +1347,9 @@ func materialize(edges map[string]*edge, couplings map[string]*coupling, allRepo
 			syms := sortedKeys(e.symbols)
 			props["symbol_count"] = len(syms)
 			props["symbol_samples"] = cap25(syms)
+			if e.nameMatches > len(syms) {
+				props["name_match_count"] = e.nameMatches
+			}
 		}
 
 		depFacts = append(depFacts, facts.Fact{
@@ -1201,18 +1372,24 @@ func materialize(edges map[string]*edge, couplings map[string]*coupling, allRepo
 	for _, k := range couplingKeys {
 		c := couplings[k]
 		syms := sortedKeys(c.symbols)
+		props := map[string]any{
+			"type":           facts.TypeCrossRepoSharedCode,
+			"synthetic":      SyntheticMarker,
+			"via":            []string{viaSharedSymbols},
+			"repos":          []string{c.repoA, c.repoB},
+			"symbol_count":   len(syms),
+			"symbol_samples": cap25(syms),
+		}
+		// Only meaningful when verification actually narrowed the set; without a
+		// SourceReader the two counts are equal and the extra prop is noise.
+		if c.nameMatches > len(syms) {
+			props["name_match_count"] = c.nameMatches
+		}
 		depFacts = append(depFacts, facts.Fact{
-			Kind: facts.KindDependency,
-			Name: fmt.Sprintf("%s <-> %s", c.repoA, c.repoB),
-			Repo: c.repoA,
-			Props: map[string]any{
-				"type":           facts.TypeCrossRepoSharedCode,
-				"synthetic":      SyntheticMarker,
-				"via":            []string{viaSharedSymbols},
-				"repos":          []string{c.repoA, c.repoB},
-				"symbol_count":   len(syms),
-				"symbol_samples": cap25(syms),
-			},
+			Kind:  facts.KindDependency,
+			Name:  fmt.Sprintf("%s <-> %s", c.repoA, c.repoB),
+			Repo:  c.repoA,
+			Props: props,
 		})
 	}
 

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -3,6 +3,7 @@ package crossrepo
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -210,7 +211,7 @@ func TestComputeLinks_HTTPMatch(t *testing.T) {
 		serverRoute("svc-beta", "/api/items/{itemId}", "GET"),
 		serverRoute("svc-beta", "/api/items/{itemId}", "POST"), // method mismatch — ignored
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	if got, want := serviceNodes(out), []string{"svc-alpha", "svc-beta"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("service nodes = %v, want %v", got, want)
@@ -243,7 +244,7 @@ func TestComputeLinks_ExternalClientBucketed(t *testing.T) {
 		clientRoute("svc-alpha", "/api/unknown/{id}", "GET", nil),                               // internal, no server -> unresolved
 		serverRoute("svc-beta", "/api/items/{itemId}", "GET"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	ec := edgeCoverageOf(out, "svc-alpha")
 	if ec == nil {
@@ -317,7 +318,7 @@ func TestComputeLinks_HTTPGatewayPath(t *testing.T) {
 		clientRoute("svc-alpha", "/api/catalogue/items/{id}", "GET", nil),
 		server,
 	}
-	if findEdge(ComputeLinks(in), "svc-alpha", "svc-beta") == nil {
+	if findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta") == nil {
 		t.Errorf("expected gateway-path match to produce an edge")
 	}
 }
@@ -330,7 +331,7 @@ func TestComputeLinks_HTTPClientPrefixMatch(t *testing.T) {
 		clientRoute("golf-ui", "/api/settings/tickets/{id}/resolve", "POST", nil),
 		serverRoute("golf", "/tickets/{id:[0-9]+}/resolve", "POST"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if !hasServiceEdge(out, "golf-ui", "golf") {
 		t.Fatalf("client prefix path did not resolve to server; got %+v", out)
 	}
@@ -347,7 +348,7 @@ func TestComputeLinks_HTTPNextjsDynamicSegment(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/{id}", "GET", nil),
 		serverRoute("svc-beta", "/api/items/[id]", "GET"),
 	}
-	if !hasServiceEdge(ComputeLinks(in), "svc-alpha", "svc-beta") {
+	if !hasServiceEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta") {
 		t.Errorf("Next.js [id] server segment did not match client {} placeholder")
 	}
 }
@@ -360,7 +361,7 @@ func TestComputeLinks_HTTPFormatSuffixMatch(t *testing.T) {
 		clientRoute("android", "v2/devices/{id}.json", "DELETE", nil),
 		serverRoute("golf", "/devices/:id", "DELETE"),
 	}
-	if !hasServiceEdge(ComputeLinks(in), "android", "golf") {
+	if !hasServiceEdge(ComputeLinks(in, nil), "android", "golf") {
 		t.Errorf("client .json path did not match server route without the suffix")
 	}
 }
@@ -370,7 +371,7 @@ func TestComputeLinks_HTTPGenericPathSkipped(t *testing.T) {
 		clientRoute("svc-alpha", "/health", "GET", nil),
 		serverRoute("svc-beta", "/health", "GET"),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	if edges := crossRepoEdges(ComputeLinks(in, nil)); len(edges) != 0 {
 		t.Errorf("generic path produced edges: %+v", edges)
 	}
 }
@@ -380,7 +381,7 @@ func TestComputeLinks_HTTPSelfLinkSkipped(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/{id}", "GET", nil),
 		serverRoute("svc-alpha", "/api/items/{id}", "GET"),
 	}
-	if out := ComputeLinks(in); len(out) != 0 {
+	if out := ComputeLinks(in, nil); len(out) != 0 {
 		t.Errorf("self-link produced links: %+v", out)
 	}
 }
@@ -391,7 +392,7 @@ func TestComputeLinks_HTTPAmbiguousResolvedByHint(t *testing.T) {
 		serverRoute("svc-beta", "/api/items/{id}", "GET"),
 		serverRoute("svc-other", "/api/items/{id}", "GET"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if findEdge(out, "svc-alpha", "svc-beta") == nil {
 		t.Errorf("hint did not resolve to svc-beta: %+v", out)
 	}
@@ -406,7 +407,7 @@ func TestComputeLinks_HTTPAmbiguousNoHintSkipped(t *testing.T) {
 		serverRoute("svc-beta", "/api/items/{id}", "GET"),
 		serverRoute("svc-other", "/api/items/{id}", "GET"),
 	}
-	for _, f := range ComputeLinks(in) {
+	for _, f := range ComputeLinks(in, nil) {
 		if f.Kind == facts.KindDependency {
 			t.Errorf("ambiguous match without hint produced edge: %+v", f)
 		}
@@ -425,7 +426,7 @@ func TestComputeLinks_CoverageBlindSpot(t *testing.T) {
 		clientRoute("svc-gamma", "/api/items/{id}", "GET", nil),
 		serverRoute("svc-beta", "/api/items/{id}", "GET"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	// svc-alpha: detected but unresolved, and no outbound edge formed.
 	if hasServiceEdge(out, "svc-alpha", "svc-beta") {
@@ -461,7 +462,7 @@ func TestComputeLinks_ImportMatch(t *testing.T) {
 		importDep("app-web-app", "@app-web/lib-api/api-client-util"),
 		facts.Fact{Kind: facts.KindModule, Name: "lib-api", Repo: "app-web"},
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	e := findEdge(out, "app-web-app", "app-web")
 	if e == nil {
 		t.Fatalf("missing import edge; got %+v", out)
@@ -479,7 +480,7 @@ func TestComputeLinks_ImportRubyStyle(t *testing.T) {
 		importDep("svc-alpha", "lib-core/money/converter"),
 		facts.Fact{Kind: facts.KindModule, Name: "money", Repo: "lib-core"},
 	}
-	if findEdge(ComputeLinks(in), "svc-alpha", "lib-core") == nil {
+	if findEdge(ComputeLinks(in, nil), "svc-alpha", "lib-core") == nil {
 		t.Errorf("expected svc-alpha -> lib-core import edge")
 	}
 }
@@ -490,7 +491,7 @@ func TestComputeLinks_ImportRelativeAndSelfIgnored(t *testing.T) {
 		importDep("svc-alpha", "svc-alpha/inner"), // self — skip
 		facts.Fact{Kind: facts.KindModule, Name: "x", Repo: "lib-core"},
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	if edges := crossRepoEdges(ComputeLinks(in, nil)); len(edges) != 0 {
 		t.Errorf("relative/self imports produced edges: %+v", edges)
 	}
 }
@@ -512,7 +513,7 @@ func TestComputeLinks_ImportIntraRepoNamespaceSkipped(t *testing.T) {
 		importDep("mobile", "github.com/x/go-auth/adapters"),
 		module("go-auth", "adapters"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if findEdge(out, "mobile", "backend") != nil {
 		t.Errorf("intra-repo namespace path must not link to a same-named repo; got edge to backend")
 	}
@@ -531,7 +532,7 @@ func TestComputeLinks_ImportSelfNamedTargetSkipped(t *testing.T) {
 		importDep("app-ios", "acme"),
 		serverRoute("acme", "/api/items/{id}", "GET"),
 	}
-	if findEdge(ComputeLinks(in), "app-ios", "acme") != nil {
+	if findEdge(ComputeLinks(in, nil), "app-ios", "acme") != nil {
 		t.Errorf("importing the app's own same-named module must not link to the backend repo")
 	}
 }
@@ -545,7 +546,7 @@ func TestComputeLinks_MergedViaAndDeterministic(t *testing.T) {
 		importDep("svc-alpha", "svc-beta/client"),
 		facts.Fact{Kind: facts.KindModule, Name: "client", Repo: "svc-beta"},
 	}
-	out1 := ComputeLinks(in)
+	out1 := ComputeLinks(in, nil)
 	e := findEdge(out1, "svc-alpha", "svc-beta")
 	if e == nil {
 		t.Fatalf("missing merged edge: %+v", out1)
@@ -555,7 +556,7 @@ func TestComputeLinks_MergedViaAndDeterministic(t *testing.T) {
 	}
 
 	// Deterministic: identical input yields identical output.
-	out2 := ComputeLinks(in)
+	out2 := ComputeLinks(in, nil)
 	if !reflect.DeepEqual(out1, out2) {
 		t.Errorf("ComputeLinks not deterministic:\n%+v\n%+v", out1, out2)
 	}
@@ -566,7 +567,7 @@ func TestComputeLinks_SingleRepoNoLinks(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/{id}", "GET", nil),
 		serverRoute("svc-alpha", "/api/items/{id}", "GET"),
 	}
-	if out := ComputeLinks(in); out != nil {
+	if out := ComputeLinks(in, nil); out != nil {
 		t.Errorf("single repo produced links: %+v", out)
 	}
 }
@@ -582,7 +583,7 @@ func TestComputeLinks_HTTPSuffixMatch(t *testing.T) {
 		clientRoute("android", "/api/settings/entitlements/definitions", "GET", nil),
 		clientRoute("golf-ui", "/settings/entitlements/definitions", "GET", nil), // leading slash, no /api
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	for _, consumer := range []string{"ios", "android", "golf-ui"} {
 		if findEdge(out, consumer, "golf") == nil {
 			t.Errorf("%s did not link to golf via suffix match; out=%+v", consumer, out)
@@ -599,7 +600,7 @@ func TestComputeLinks_HTTPSuffixMinSegments(t *testing.T) {
 		serverRoute("golf", "/api/settings/definitions", "GET"),
 		clientRoute("ios", "definitions", "GET", nil),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	if edges := crossRepoEdges(ComputeLinks(in, nil)); len(edges) != 0 {
 		t.Errorf("single-segment suffix should not link: %+v", edges)
 	}
 }
@@ -609,7 +610,7 @@ func TestComputeLinks_HTTPSuffixMethodMismatch(t *testing.T) {
 		serverRoute("golf", "/api/settings/feedback", "GET"),
 		clientRoute("golf-ui", "settings/feedback", "POST", nil),
 	}
-	if edges := crossRepoEdges(ComputeLinks(in)); len(edges) != 0 {
+	if edges := crossRepoEdges(ComputeLinks(in, nil)); len(edges) != 0 {
 		t.Errorf("method mismatch should not link: %+v", edges)
 	}
 }
@@ -627,7 +628,7 @@ func TestComputeLinks_PerRepoServiceNodes(t *testing.T) {
 		facts.Fact{Kind: facts.KindModule, Name: "app", Repo: "android"},
 		facts.Fact{Kind: facts.KindModule, Name: "App", Repo: "ios"},
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	got := serviceNodes(out)
 	want := []string{"android", "go-auth", "golf", "golf-ui", "ios"}
@@ -676,7 +677,7 @@ func TestComputeLinks_SharedSymbolsMatch(t *testing.T) {
 		typeSym("gmsh", "Common.GmshServer", facts.SymbolClass),
 		typeSym("gmsh", "Common.onelab::remoteNetworkClient", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	sc := findSharedCode(out, "getdp", "gmsh")
 	if sc == nil {
@@ -707,7 +708,7 @@ func TestComputeLinks_SharedSymbolsBelowThreshold(t *testing.T) {
 		module("beta", "lib"),
 		typeSym("beta", "lib.WidgetRegistry", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -731,7 +732,7 @@ func TestComputeLinks_SharedSymbolsGenericNamesIgnored(t *testing.T) {
 		typeSym("beta", "lib.Node", facts.SymbolClass),
 		typeSym("beta", "lib.Item", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -759,7 +760,7 @@ func TestComputeLinks_SharedSymbolsFrameworkConventionIgnored(t *testing.T) {
 		typeSym("svc-b", "app.Ability", facts.SymbolClass),
 		typeSym("svc-b", "app.ApplicationCable::Connection", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -788,7 +789,7 @@ func TestComputeLinks_SharedSymbolsMigrationsIgnored(t *testing.T) {
 		migrationSym("svc-b", "AddIndexToWidgets"),
 		migrationSym("svc-b", "InitSchema"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -816,7 +817,7 @@ func TestComputeLinks_SharedSymbolsGenuineSurvivesBoilerplate(t *testing.T) {
 		typeSym("svc-b", "app.PaymentLedger", facts.SymbolClass),
 		typeSym("svc-b", "app.RetryPolicy", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	sc := findSharedCode(out, "svc-a", "svc-b")
 	if sc == nil {
 		t.Fatalf("genuine shared types should still couple the pair; out=%+v", out)
@@ -839,7 +840,7 @@ func TestComputeLinks_SharedSymbolsNonTypesIgnored(t *testing.T) {
 		typeSym("beta", "lib.parseHeader", facts.SymbolFunc),
 		typeSym("beta", "lib.computeChecksum", facts.SymbolFunc),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -869,7 +870,7 @@ func TestComputeLinks_SharedSymbolsCrossLanguageUnqualifiedSkipped(t *testing.T)
 		typeSymLang("ios", "Sources.FeedItem", facts.SymbolClass, "swift"),
 		typeSymLang("ios", "Sources.AccountViewModel", facts.SymbolClass, "swift"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -892,7 +893,7 @@ func TestComputeLinks_SharedSymbolsSameLanguageUnqualifiedLinks(t *testing.T) {
 		typeSymLang("svc-b", "lib.PaymentLedger", facts.SymbolClass, "go"),
 		typeSymLang("svc-b", "lib.RetryPolicy", facts.SymbolClass, "go"),
 	}
-	if findSharedCode(ComputeLinks(in), "svc-a", "svc-b") == nil {
+	if findSharedCode(ComputeLinks(in, nil), "svc-a", "svc-b") == nil {
 		t.Errorf("same-language repos sharing distinctive types should still couple")
 	}
 }
@@ -911,7 +912,7 @@ func TestComputeLinks_SharedSymbolsQualifiedCrossLanguageLinks(t *testing.T) {
 		typeSymLang("repo-b", "vendor.onelab::clientB", facts.SymbolClass, "c"),
 		typeSymLang("repo-b", "vendor.onelab::clientC", facts.SymbolClass, "c"),
 	}
-	if findSharedCode(ComputeLinks(in), "repo-a", "repo-b") == nil {
+	if findSharedCode(ComputeLinks(in, nil), "repo-a", "repo-b") == nil {
 		t.Errorf("qualified shared identities should couple even across languages")
 	}
 }
@@ -931,7 +932,7 @@ func TestComputeLinks_SharedSymbolsCrossLanguageNestedTypesSkipped(t *testing.T)
 		typeSymLang("ios", "Sources.HandicapAnalytics.DifferentialEntry", facts.SymbolClass, "swift"),
 		typeSymLang("ios", "Sources.FullAnalysisDataBuilder.TimeWindow", facts.SymbolClass, "swift"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -955,7 +956,7 @@ func TestComputeLinks_SharedSymbolsSameLanguageNestedTypesLink(t *testing.T) {
 		typeSymLang("app-b", "lib.HandicapAnalytics.DifferentialEntry", facts.SymbolClass, "kotlin"),
 		typeSymLang("app-b", "lib.FullAnalysisDataBuilder.TimeWindow", facts.SymbolClass, "kotlin"),
 	}
-	if findSharedCode(ComputeLinks(in), "app-a", "app-b") == nil {
+	if findSharedCode(ComputeLinks(in, nil), "app-a", "app-b") == nil {
 		t.Errorf("same-language repos sharing distinctive nested types should still couple")
 	}
 }
@@ -979,7 +980,7 @@ func TestComputeLinks_SharedSymbolsFleetVocabularyNotLinked(t *testing.T) {
 			in = append(in, typeSymLang(repo, "app."+name, facts.SymbolClass, "go"))
 		}
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -1007,7 +1008,7 @@ func TestComputeLinks_SharedSymbolsPairSpecificSurvivesFleetVocabulary(t *testin
 		in = append(in, typeSymLang("svc-1", "app."+name, facts.SymbolClass, "go"))
 		in = append(in, typeSymLang("svc-2", "app."+name, facts.SymbolClass, "go"))
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	sc := findSharedCode(out, "svc-1", "svc-2")
 	if sc == nil {
 		t.Fatalf("pair-specific distinctive types should couple svc-1/svc-2; got=%+v", sharedCodeFacts(out))
@@ -1035,7 +1036,7 @@ func TestComputeLinks_SharedSymbolsSmallRepoSetVocabularyFilterOff(t *testing.T)
 			in = append(in, typeSymLang(repo, "app."+name, facts.SymbolClass, "go"))
 		}
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	for _, pair := range [][2]string{{"svc-a", "svc-b"}, {"svc-a", "svc-c"}, {"svc-b", "svc-c"}} {
 		if findSharedCode(out, pair[0], pair[1]) == nil {
 			t.Errorf("with only 3 repos the vocabulary filter must stay off; missing %s <-> %s", pair[0], pair[1])
@@ -1061,7 +1062,7 @@ func TestComputeLinks_SharedSymbolsGeneratedCodeIgnored(t *testing.T) {
 	for _, name := range []string{"GetCountersResponse", "CounterBatchRequest", "EventCounterModel", "CountersClientWithResponses"} {
 		in = append(in, genTypeSym("svc-a", name), genTypeSym("svc-b", name))
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -1083,7 +1084,7 @@ func TestComputeLinks_SharedSymbolsGeneratedExcludedFromCount(t *testing.T) {
 			typeSymLang("svc-a", "internal."+name, facts.SymbolClass, "go"),
 			typeSymLang("svc-b", "internal."+name, facts.SymbolClass, "go"))
 	}
-	e := findSharedCode(ComputeLinks(in), "svc-a", "svc-b")
+	e := findSharedCode(ComputeLinks(in, nil), "svc-a", "svc-b")
 	if e == nil {
 		t.Fatalf("hand-written distinctive shared types should still couple")
 	}
@@ -1099,7 +1100,7 @@ func TestComputeLinks_HTTPClientViaTag(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/list", "GET", map[string]any{"source": "go-http-client"}),
 		serverRoute("svc-beta", "/api/items/list", "GET"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil {
 		t.Fatal("missing svc-alpha -> svc-beta edge")
 	}
@@ -1113,7 +1114,7 @@ func TestComputeLinks_OpenAPIViaStaysHTTP(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/list", "GET", map[string]any{"source": "openapi"}),
 		serverRoute("svc-beta", "/api/items/list", "GET"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil {
 		t.Fatal("missing edge")
 	}
@@ -1128,7 +1129,7 @@ func TestComputeLinks_ConfidenceVerified(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/list", "GET", nil),
 		serverRoute("svc-beta", "/api/items/list", "GET"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil || e.Props["confidence"] != "verified" {
 		t.Errorf("confidence = %v, want verified", e.Props["confidence"])
 	}
@@ -1140,7 +1141,7 @@ func TestComputeLinks_ConfidenceProbableSuffixOnly(t *testing.T) {
 		clientRoute("svc-alpha", "settings/feedback", "POST", nil),
 		serverRoute("svc-beta", "/api/settings/feedback", "POST"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil || e.Props["confidence"] != "probable" {
 		t.Errorf("confidence = %v, want probable", e.Props["confidence"])
 	}
@@ -1151,7 +1152,7 @@ func TestComputeLinks_ConfidenceProbableInferred(t *testing.T) {
 		clientRoute("svc-alpha", "/api/items/{id}", "GET", nil),
 		serverRoute("svc-beta", "/api/items/{id}", "GET"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil || e.Props["confidence"] != "probable" {
 		t.Errorf("confidence = %v, want probable (inferred {})", e.Props["confidence"])
 	}
@@ -1164,14 +1165,14 @@ func TestComputeLinks_ConfidenceProbableHintDisambiguated(t *testing.T) {
 		serverRoute("svc-beta", "/api/items/list", "GET"),
 		serverRoute("svc-other", "/api/items/list", "GET"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil {
 		t.Fatal("missing svc-alpha -> svc-beta edge")
 	}
 	if e.Props["confidence"] != "probable" {
 		t.Errorf("confidence = %v, want probable", e.Props["confidence"])
 	}
-	if findEdge(ComputeLinks(in), "svc-alpha", "svc-other") != nil {
+	if findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-other") != nil {
 		t.Error("should not link to svc-other")
 	}
 }
@@ -1184,7 +1185,7 @@ func TestComputeLinks_ConfidenceMixedIsVerified(t *testing.T) {
 		serverRoute("svc-beta", "/api/items/list", "GET"),
 		serverRoute("svc-beta", "/api/settings/feedback", "POST"),
 	}
-	e := findEdge(ComputeLinks(in), "svc-alpha", "svc-beta")
+	e := findEdge(ComputeLinks(in, nil), "svc-alpha", "svc-beta")
 	if e == nil || e.Props["confidence"] != "verified" {
 		t.Errorf("confidence = %v, want verified", e.Props["confidence"])
 	}
@@ -1197,7 +1198,7 @@ func TestComputeLinks_TargetHintResolvesProvider(t *testing.T) {
 		serverRoute("svc-checkout", "/api/purchase/build", "POST"),
 		serverRoute("svc-other", "/api/purchase/build", "POST"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if findEdge(out, "core", "svc-checkout") == nil {
 		t.Error("target_hint should resolve provider svc-checkout")
 	}
@@ -1304,7 +1305,7 @@ func TestComputeLinks_ExternalClientStillMatchesLoadedServer(t *testing.T) {
 		// a genuinely third-party external call: no server serves it -> external bucket.
 		clientRoute("consumer", "/v1/widgets", "GET", map[string]any{"external": true, "host": "api.example.com"}),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	if !hasServiceEdge(out, "consumer", "api") {
 		t.Errorf("external-tagged client route to a loaded server must produce an edge; got %+v", serviceNodes(out))
@@ -1353,15 +1354,15 @@ func TestComputeLinks_SharedSymbolsRespectsImportDirection(t *testing.T) {
 	in := []facts.Fact{
 		module("app", "client"),
 		importDep("app", "@lib/ui"),
-		typeSym("app", "client.PinMarkerProps", facts.SymbolClass),
-		typeSym("app", "client.LikeProps", facts.SymbolClass),
-		typeSym("app", "client.AdSlot", facts.SymbolClass),
+		typeSym("app", "client.GaugePanelProps", facts.SymbolClass),
+		typeSym("app", "client.TileProps", facts.SymbolClass),
+		typeSym("app", "client.ProbeSlot", facts.SymbolClass),
 		module("lib", "libs/ui"),
-		typeSym("lib", "libs/ui.PinMarkerProps", facts.SymbolClass),
-		typeSym("lib", "libs/ui.LikeProps", facts.SymbolClass),
-		typeSym("lib", "libs/ui.AdSlot", facts.SymbolClass),
+		typeSym("lib", "libs/ui.GaugePanelProps", facts.SymbolClass),
+		typeSym("lib", "libs/ui.TileProps", facts.SymbolClass),
+		typeSym("lib", "libs/ui.ProbeSlot", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	e := findEdge(out, "app", "lib")
 	if e == nil {
@@ -1397,7 +1398,7 @@ func TestComputeLinks_SharedSymbolsRespectsHTTPDirection(t *testing.T) {
 		typeSym("api", "app.PaymentLedger", facts.SymbolClass),
 		typeSym("api", "app.RetryPolicy", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	if e := findEdge(out, "web", "api"); e == nil {
 		t.Fatalf("missing web -> api edge; out=%+v", out)
@@ -1423,7 +1424,7 @@ func TestComputeLinks_SharedSymbolsCoupleWithoutDirection(t *testing.T) {
 		typeSym("fork-b", "client.PaymentLedger", facts.SymbolClass),
 		typeSym("fork-b", "client.RetryPolicy", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if findSharedCode(out, "fork-a", "fork-b") == nil {
 		t.Fatalf("missing shared-code coupling for the fork pair; out=%+v", out)
 	}
@@ -1446,17 +1447,17 @@ func TestComputeLinks_SharedSymbolsCoupleWithoutDirection(t *testing.T) {
 func TestComputeLinks_SharedSymbolsComponentConventionIgnored(t *testing.T) {
 	in := []facts.Fact{
 		module("web-a", "client"),
-		typeSym("web-a", "client.FooterProps", facts.SymbolInterface),
-		typeSym("web-a", "client.ModalProps", facts.SymbolInterface),
-		typeSym("web-a", "client.FormHeaderProps", facts.SymbolInterface),
+		typeSym("web-a", "client.SidebarProps", facts.SymbolInterface),
+		typeSym("web-a", "client.DialogProps", facts.SymbolInterface),
+		typeSym("web-a", "client.PanelSectionProps", facts.SymbolInterface),
 		typeSym("web-a", "client.Layout", facts.SymbolClass),
 		module("web-b", "libs"),
-		typeSym("web-b", "libs.FooterProps", facts.SymbolInterface),
-		typeSym("web-b", "libs.ModalProps", facts.SymbolInterface),
-		typeSym("web-b", "libs.FormHeaderProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.SidebarProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.DialogProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.PanelSectionProps", facts.SymbolInterface),
 		typeSym("web-b", "libs.Layout", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -1472,17 +1473,17 @@ func TestComputeLinks_SharedSymbolsComponentConventionIgnored(t *testing.T) {
 func TestComputeLinks_SharedSymbolsDistinctiveComponentNamesSurvive(t *testing.T) {
 	in := []facts.Fact{
 		module("web-a", "client"),
-		typeSym("web-a", "client.PinMarkerProps", facts.SymbolInterface), // Pin is distinctive
-		typeSym("web-a", "client.LikeProps", facts.SymbolInterface),      // core "Like" is only 4 chars
-		typeSym("web-a", "client.EListItem", facts.SymbolEnum),           // single-char prefix + generic words
-		typeSym("web-a", "client.AdSlot", facts.SymbolInterface),
+		typeSym("web-a", "client.GaugePanelProps", facts.SymbolInterface), // Pin is distinctive
+		typeSym("web-a", "client.TileProps", facts.SymbolInterface),       // core "Like" is only 4 chars
+		typeSym("web-a", "client.TListRow", facts.SymbolEnum),             // single-char prefix + generic words
+		typeSym("web-a", "client.ProbeSlot", facts.SymbolInterface),
 		module("web-b", "libs"),
-		typeSym("web-b", "libs.PinMarkerProps", facts.SymbolInterface),
-		typeSym("web-b", "libs.LikeProps", facts.SymbolInterface),
-		typeSym("web-b", "libs.EListItem", facts.SymbolEnum),
-		typeSym("web-b", "libs.AdSlot", facts.SymbolInterface),
+		typeSym("web-b", "libs.GaugePanelProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.TileProps", facts.SymbolInterface),
+		typeSym("web-b", "libs.TListRow", facts.SymbolEnum),
+		typeSym("web-b", "libs.ProbeSlot", facts.SymbolInterface),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	e := findSharedCode(out, "web-a", "web-b")
 	if e == nil {
 		t.Fatalf("distinctive component names must still couple the pair; out=%+v", out)
@@ -1497,16 +1498,16 @@ func TestIsConventionalComponentName(t *testing.T) {
 		id   string
 		want bool
 	}{
-		{"FooterProps", true},
-		{"ModalProps", true},
-		{"FormHeaderProps", true}, // every segment generic
+		{"SidebarProps", true},
+		{"DialogProps", true},
+		{"PanelSectionProps", true}, // every segment generic
 		{"Layout", true},
 		{"CardHeaderState", true},
-		{"LikeProps", false},      // core shorter than the length floor, still meaningful
-		{"PinMarkerProps", false}, // "Pin" is not generic vocabulary
-		{"AdSlot", false},
-		{"EListItem", false}, // single-char prefix must not be read as generic
-		{"TestNames", false}, // "Names" is not generic vocabulary
+		{"TileProps", false},       // core shorter than the length floor, still meaningful
+		{"GaugePanelProps", false}, // "Pin" is not generic vocabulary
+		{"ProbeSlot", false},
+		{"TListRow", false},     // single-char prefix must not be read as generic
+		{"TestRegistry", false}, // "Names" is not generic vocabulary
 		{"WidgetRegistry", false},
 		{"HTTPServerProps", false}, // acronym segment kept intact
 	} {
@@ -1521,9 +1522,9 @@ func TestSplitCamelCase(t *testing.T) {
 		in   string
 		want []string
 	}{
-		{"FormHeader", []string{"Form", "Header"}},
+		{"PanelSection", []string{"Panel", "Section"}},
 		{"Footer", []string{"Footer"}},
-		{"EListItem", []string{"E", "List", "Item"}},
+		{"TListRow", []string{"T", "List", "Row"}},
 		{"HTTPServer", []string{"HTTP", "Server"}},
 		{"", nil},
 	} {
@@ -1571,15 +1572,15 @@ func TestComputeLinks_SharedSymbolsStoryAndTestFilesIgnored(t *testing.T) {
 	}
 	in := []facts.Fact{
 		module("web-a", "libs"),
-		storySym("web-a", "libs.AdSlot", "libs/Gallery/Gallery.stories.tsx"),
+		storySym("web-a", "libs.ProbeSlot", "libs/Gallery/Gallery.stories.tsx"),
 		storySym("web-a", "libs.WidgetRegistry", "libs/widget/widget.test.ts"),
 		storySym("web-a", "libs.PaymentLedger", "libs/__mocks__/ledger.ts"),
 		module("web-b", "client"),
-		storySym("web-b", "client.AdSlot", "client/Gallery/Gallery.stories.tsx"),
+		storySym("web-b", "client.ProbeSlot", "client/Gallery/Gallery.stories.tsx"),
 		storySym("web-b", "client.WidgetRegistry", "client/widget/widget.test.ts"),
 		storySym("web-b", "client.PaymentLedger", "client/__mocks__/ledger.ts"),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 	if sc := sharedCodeFacts(out); len(sc) != 0 {
 		t.Errorf("must not couple the repos either: %+v", sc)
 	}
@@ -1606,7 +1607,7 @@ func TestComputeLinks_SharedSymbolsRespectsGRPCDirection(t *testing.T) {
 		typeSym("server", "internal.PaymentLedger", facts.SymbolClass),
 		typeSym("server", "internal.RetryPolicy", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	e := findEdge(out, "client", "server")
 	if e == nil {
@@ -1644,7 +1645,7 @@ func TestComputeLinks_SharedCodeDoesNotCompose(t *testing.T) {
 		typeSym("twin", "app.PaymentLedger", facts.SymbolClass),
 		typeSym("twin", "app.RetryPolicy", facts.SymbolClass),
 	}
-	out := ComputeLinks(in)
+	out := ComputeLinks(in, nil)
 
 	if findEdge(out, "web", "api") == nil {
 		t.Fatalf("the real HTTP dependency must survive; out=%+v", out)
@@ -1661,6 +1662,273 @@ func TestComputeLinks_SharedCodeDoesNotCompose(t *testing.T) {
 	for _, r := range []string{"api", "twin"} {
 		if hasServiceEdge(out, r, "twin") {
 			t.Errorf("%s must not carry a depends_on to twin — shared code is not a dependency", r)
+		}
+	}
+}
+
+// --- (C3) source verification of shared type names ---
+
+// fakeSource serves file contents by fact file path, standing in for reading the repo.
+func fakeSource(files map[string]string) SourceReader {
+	return func(f facts.Fact) (string, bool) {
+		text, ok := files[f.File]
+		return text, ok
+	}
+}
+
+// symInFile is a type symbol that records which file declared it, so verification has
+// something to compare.
+func symInFile(repo, name, file string) facts.Fact {
+	f := typeSym(repo, name, facts.SymbolClass)
+	f.File = file
+	return f
+}
+
+const bodyAlpha = `class WidgetRegistry
+  def register(widget)
+    @widgets << widget
+    recompute_index
+  end
+  def recompute_index
+    @index = @widgets.group_by(&:kind)
+  end
+end`
+
+// bodyAlphaReformatted is the same code with blank lines and indentation churn: a copy
+// that drifted only in formatting must still verify.
+const bodyAlphaReformatted = `class WidgetRegistry
+
+    def register(widget)
+        @widgets << widget
+        recompute_index
+    end
+
+    def recompute_index
+        @index = @widgets.group_by(&:kind)
+    end
+end`
+
+// bodyBeta shares the class NAME with bodyAlpha and nothing else — the population the
+// verification exists to reject.
+const bodyBeta = `class WidgetRegistry
+  belongs_to :account
+  validates :slug, presence: true, uniqueness: { scope: :account_id }
+  scope :active, -> { where(archived_at: nil) }
+  def to_param
+    slug
+  end
+end`
+
+// TestComputeLinks_SharedSymbolsVerifiedAgainstSource is the core of the change: three
+// names match in both repos, but only the ones whose files actually match count. Here
+// one pair is genuinely copied and two merely share a name, so the verified total falls
+// below minSharedSymbols and no coupling is reported at all.
+func TestComputeLinks_SharedSymbolsVerifiedAgainstSource(t *testing.T) {
+	in := []facts.Fact{
+		module("svc-a", "app"),
+		symInFile("svc-a", "app.WidgetRegistry", "svc-a/app/widget_registry.rb"),
+		symInFile("svc-a", "app.PaymentLedger", "svc-a/app/payment_ledger.rb"),
+		symInFile("svc-a", "app.RetryPolicy", "svc-a/app/retry_policy.rb"),
+		module("svc-b", "app"),
+		symInFile("svc-b", "app.WidgetRegistry", "svc-b/app/widget_registry.rb"),
+		symInFile("svc-b", "app.PaymentLedger", "svc-b/app/payment_ledger.rb"),
+		symInFile("svc-b", "app.RetryPolicy", "svc-b/app/retry_policy.rb"),
+	}
+	src := fakeSource(map[string]string{
+		// Copied.
+		"svc-a/app/widget_registry.rb": bodyAlpha,
+		"svc-b/app/widget_registry.rb": bodyAlpha,
+		// Same name, unrelated code.
+		"svc-a/app/payment_ledger.rb": bodyAlpha,
+		"svc-b/app/payment_ledger.rb": bodyBeta,
+		"svc-a/app/retry_policy.rb":   bodyAlpha,
+		"svc-b/app/retry_policy.rb":   bodyBeta,
+	})
+
+	if sc := sharedCodeFacts(ComputeLinks(in, src)); len(sc) != 0 {
+		t.Errorf("only 1 of 3 names is backed by shared code, below the threshold — no coupling expected: %+v", sc)
+	}
+	// Without a reader the same input still couples on names alone, which is what the
+	// verification is an improvement over.
+	if sc := sharedCodeFacts(ComputeLinks(in, nil)); len(sc) != 1 {
+		t.Errorf("name-only matching (nil reader) should still couple the pair, got %+v", sc)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsVerifiedReportsBothCounts covers the surviving case:
+// enough names are backed by real shared code, and the fact records both the verified
+// count and how many matched by name alone.
+func TestComputeLinks_SharedSymbolsVerifiedReportsBothCounts(t *testing.T) {
+	in := []facts.Fact{
+		module("svc-a", "app"),
+		symInFile("svc-a", "app.WidgetRegistry", "svc-a/app/widget_registry.rb"),
+		symInFile("svc-a", "app.PaymentLedger", "svc-a/app/payment_ledger.rb"),
+		symInFile("svc-a", "app.RetryPolicy", "svc-a/app/retry_policy.rb"),
+		symInFile("svc-a", "app.InvoiceReconciler", "svc-a/app/invoice_reconciler.rb"),
+		module("svc-b", "app"),
+		symInFile("svc-b", "app.WidgetRegistry", "svc-b/app/widget_registry.rb"),
+		symInFile("svc-b", "app.PaymentLedger", "svc-b/app/payment_ledger.rb"),
+		symInFile("svc-b", "app.RetryPolicy", "svc-b/app/retry_policy.rb"),
+		symInFile("svc-b", "app.InvoiceReconciler", "svc-b/app/invoice_reconciler.rb"),
+	}
+	src := fakeSource(map[string]string{
+		"svc-a/app/widget_registry.rb": bodyAlpha,
+		"svc-b/app/widget_registry.rb": bodyAlpha,
+		"svc-a/app/payment_ledger.rb":  bodyAlpha,
+		// Reformatted copy: must still verify.
+		"svc-b/app/payment_ledger.rb": bodyAlphaReformatted,
+		"svc-a/app/retry_policy.rb":   bodyAlpha,
+		"svc-b/app/retry_policy.rb":   bodyAlpha,
+		// Name-only match: must be dropped from the count.
+		"svc-a/app/invoice_reconciler.rb": bodyAlpha,
+		"svc-b/app/invoice_reconciler.rb": bodyBeta,
+	})
+
+	sc := findSharedCode(ComputeLinks(in, src), "svc-a", "svc-b")
+	if sc == nil {
+		t.Fatalf("3 verified shared types should still couple the pair")
+	}
+	if c, _ := sc.Props["symbol_count"].(int); c != 3 {
+		t.Errorf("symbol_count = %v, want 3 (verified only)", sc.Props["symbol_count"])
+	}
+	if n, _ := sc.Props["name_match_count"].(int); n != 4 {
+		t.Errorf("name_match_count = %v, want 4 (pre-verification total)", sc.Props["name_match_count"])
+	}
+	if syms, _ := sc.Props["symbol_samples"].([]string); len(syms) != 3 {
+		t.Errorf("samples should list only verified identities, got %v", syms)
+	} else {
+		for _, s := range syms {
+			if s == "InvoiceReconciler" {
+				t.Errorf("name-only match leaked into samples: %v", syms)
+			}
+		}
+	}
+}
+
+// TestComputeLinks_SharedSymbolsNameMatchCountOmittedWhenEqual keeps the fact lean: with
+// no reader (or when nothing was filtered) the two counts are identical and the extra
+// prop would be noise.
+func TestComputeLinks_SharedSymbolsNameMatchCountOmittedWhenEqual(t *testing.T) {
+	in := []facts.Fact{
+		module("svc-a", "app"),
+		symInFile("svc-a", "app.WidgetRegistry", "svc-a/app/a.rb"),
+		symInFile("svc-a", "app.PaymentLedger", "svc-a/app/a.rb"),
+		symInFile("svc-a", "app.RetryPolicy", "svc-a/app/a.rb"),
+		module("svc-b", "app"),
+		symInFile("svc-b", "app.WidgetRegistry", "svc-b/app/a.rb"),
+		symInFile("svc-b", "app.PaymentLedger", "svc-b/app/a.rb"),
+		symInFile("svc-b", "app.RetryPolicy", "svc-b/app/a.rb"),
+	}
+	sc := findSharedCode(ComputeLinks(in, nil), "svc-a", "svc-b")
+	if sc == nil {
+		t.Fatalf("name-only matching should couple the pair")
+	}
+	if _, present := sc.Props["name_match_count"]; present {
+		t.Errorf("name_match_count must be omitted when verification did not narrow anything: %+v", sc.Props)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsUnreadableSourceDropsIdentity pins the failure mode: a
+// file that cannot be read is not evidence of shared code, so the identity does not
+// count. Silently trusting the name here would reintroduce exactly what verification
+// exists to prevent.
+func TestComputeLinks_SharedSymbolsUnreadableSourceDropsIdentity(t *testing.T) {
+	in := []facts.Fact{
+		module("svc-a", "app"),
+		symInFile("svc-a", "app.WidgetRegistry", "svc-a/app/widget_registry.rb"),
+		symInFile("svc-a", "app.PaymentLedger", "svc-a/app/payment_ledger.rb"),
+		symInFile("svc-a", "app.RetryPolicy", "svc-a/app/retry_policy.rb"),
+		module("svc-b", "app"),
+		symInFile("svc-b", "app.WidgetRegistry", "svc-b/app/widget_registry.rb"),
+		symInFile("svc-b", "app.PaymentLedger", "svc-b/app/payment_ledger.rb"),
+		symInFile("svc-b", "app.RetryPolicy", "svc-b/app/retry_policy.rb"),
+	}
+	// Only one side readable for every identity.
+	src := fakeSource(map[string]string{
+		"svc-a/app/widget_registry.rb": bodyAlpha,
+		"svc-a/app/payment_ledger.rb":  bodyAlpha,
+		"svc-a/app/retry_policy.rb":    bodyAlpha,
+	})
+	if sc := sharedCodeFacts(ComputeLinks(in, src)); len(sc) != 0 {
+		t.Errorf("unreadable source must not count as verified: %+v", sc)
+	}
+}
+
+// TestComputeLinks_SharedSymbolsVerificationAppliesToAnnotatedEdges confirms the same
+// filter governs the shared-symbol annotation on a real (directional) edge, so a
+// dependency edge cannot carry an inflated symbol count either. The import edge itself
+// must survive regardless — verification governs the annotation, not the dependency.
+func TestComputeLinks_SharedSymbolsVerificationAppliesToAnnotatedEdges(t *testing.T) {
+	in := []facts.Fact{
+		module("app", "client"),
+		importDep("app", "@lib/ui"),
+		symInFile("app", "client.WidgetRegistry", "app/client/widget_registry.ts"),
+		symInFile("app", "client.PaymentLedger", "app/client/payment_ledger.ts"),
+		symInFile("app", "client.RetryPolicy", "app/client/retry_policy.ts"),
+		module("lib", "libs/ui"),
+		symInFile("lib", "libs/ui.WidgetRegistry", "lib/libs/ui/widget_registry.ts"),
+		symInFile("lib", "libs/ui.PaymentLedger", "lib/libs/ui/payment_ledger.ts"),
+		symInFile("lib", "libs/ui.RetryPolicy", "lib/libs/ui/retry_policy.ts"),
+	}
+	src := fakeSource(map[string]string{
+		"app/client/widget_registry.ts":  bodyAlpha,
+		"lib/libs/ui/widget_registry.ts": bodyBeta, // name only
+		"app/client/payment_ledger.ts":   bodyAlpha,
+		"lib/libs/ui/payment_ledger.ts":  bodyBeta, // name only
+		"app/client/retry_policy.ts":     bodyAlpha,
+		"lib/libs/ui/retry_policy.ts":    bodyBeta, // name only
+	})
+
+	out := ComputeLinks(in, src)
+	e := findEdge(out, "app", "lib")
+	if e == nil {
+		t.Fatalf("the import edge must survive; out=%+v", out)
+	}
+	if via, _ := e.Props["via"].([]string); !reflect.DeepEqual(via, []string{"import"}) {
+		t.Errorf("via = %v, want [import] — no name-only shared_symbols annotation", e.Props["via"])
+	}
+	if _, present := e.Props["symbol_count"]; present {
+		t.Errorf("edge must carry no shared-symbol count when none verified: %+v", e.Props)
+	}
+}
+
+func TestJaccardAndTokenSet(t *testing.T) {
+	if got := jaccard(tokenSet(bodyAlpha), tokenSet(bodyAlphaReformatted)); got != 1.0 {
+		t.Errorf("reformatted copy similarity = %v, want 1.0 (whitespace normalized away)", got)
+	}
+	if got := jaccard(tokenSet(bodyAlpha), tokenSet(bodyBeta)); got >= minFileSimilarity {
+		t.Errorf("same-name-different-code similarity = %v, want < %v", got, minFileSimilarity)
+	}
+	if got := jaccard(tokenSet(""), tokenSet(bodyAlpha)); got != 0 {
+		t.Errorf("empty file similarity = %v, want 0", got)
+	}
+	// Tokens, not lines: a copy whose lines were each edited slightly is still a copy.
+	// Whole-line comparison scored this kind of drift as a near-total mismatch, which
+	// was the metric's main failure mode on real repos.
+	edited := strings.ReplaceAll(bodyAlpha, "widget", "item")
+	if got := jaccard(tokenSet(bodyAlpha), tokenSet(edited)); got < minFileSimilarity {
+		t.Errorf("within-line drift similarity = %v, want >= %v", got, minFileSimilarity)
+	}
+}
+
+// TestFileComparer_ReadsEachFileOnce pins the memoization: several shared identities
+// usually resolve to the same file pair, and link time should not scale with them.
+func TestFileComparer_ReadsEachFileOnce(t *testing.T) {
+	reads := map[string]int{}
+	fc := newFileComparer(func(f facts.Fact) (string, bool) {
+		reads[f.File]++
+		return bodyAlpha, true
+	})
+	a := symInFile("svc-a", "app.X", "svc-a/app/shared.rb")
+	b := symInFile("svc-b", "app.X", "svc-b/app/shared.rb")
+	for i := 0; i < 5; i++ {
+		if !fc.similar(a, b) {
+			t.Fatal("identical files should be similar")
+		}
+	}
+	for file, n := range reads {
+		if n != 1 {
+			t.Errorf("file %s read %d times, want 1", file, n)
 		}
 	}
 }


### PR DESCRIPTION
A shared type name only ever meant "both repos declare this"; it could equally be copied code or two teams naming the same concept alike. The linker now takes an optional source reader and, for each name-matched candidate, compares the two declaring files. Only verified names count toward the threshold; the fact keeps both figures (symbol_count and name_match_count) so the gap between shared code and shared vocabulary stays visible, and the insight moves to 0.8 confidence because the count is measured rather than inferred. A nil reader disables verification and falls back to name-only matching.

Similarity is token-set overlap, not line-set: a drifted copy keeps its shape but edits something inside many lines, which whole-line comparison scores as a near total mismatch. Calibrated against a character diff over real repo pairs, line-set disagreed on 4 of 13 sampled declarations — every one a false negative, including two files ~95% identical — while token-set agreed on all 13.

Comparison is file-level: facts carry no end line, so a declaration body cannot be sliced without touching every extractor. The cost is a miss when shared code sits inside an otherwise-different file.