### PR TITLE
feat(extractors): detect Kotlin on Maven and extract programmatic ser…

### DIFF
--- a/internal/extractors/kotlinextractor/kotlin.go
+++ b/internal/extractors/kotlinextractor/kotlin.go
@@ -28,10 +28,14 @@ func (e *KotlinExtractor) Name() string {
 }
 
 // Detect returns true if the repository looks like a Kotlin or Android project.
+// It recognizes Kotlin regardless of build tool: Gradle (build.gradle[.kts]) and
+// Maven (pom.xml declaring the Kotlin plugin/dependency). Build files pin the
+// language authoritatively; when none match, a Kotlin source tree under the
+// conventional src/main/kotlin root is a sufficient fallback so a repo with an
+// unrecognized build setup is still extracted rather than silently skipped.
 func (e *KotlinExtractor) Detect(repoPath string) (bool, error) {
 	for _, name := range []string{"build.gradle.kts", "build.gradle"} {
-		path := filepath.Join(repoPath, name)
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(filepath.Join(repoPath, name))
 		if err != nil {
 			continue
 		}
@@ -39,6 +43,21 @@ func (e *KotlinExtractor) Detect(repoPath string) (bool, error) {
 		if strings.Contains(content, "kotlin") || strings.Contains(content, "android") {
 			return true, nil
 		}
+	}
+	// Maven: a Kotlin project declares the kotlin-maven-plugin / org.jetbrains.kotlin
+	// dependency and typically a src/main/kotlin sourceDirectory in its pom.xml.
+	if data, err := os.ReadFile(filepath.Join(repoPath, "pom.xml")); err == nil {
+		content := string(data)
+		if strings.Contains(content, "org.jetbrains.kotlin") ||
+			strings.Contains(content, "kotlin-maven-plugin") ||
+			strings.Contains(content, "src/main/kotlin") {
+			return true, nil
+		}
+	}
+	// Fallback: a conventional Kotlin source root exists even without a recognized
+	// build file. Cheap stat, no directory walk.
+	if fi, err := os.Stat(filepath.Join(repoPath, "src", "main", "kotlin")); err == nil && fi.IsDir() {
+		return true, nil
 	}
 	return false, nil
 }
@@ -78,7 +97,8 @@ func (e *KotlinExtractor) Extract(ctx context.Context, repoPath string, files []
 			return nil
 		}
 		ff := extractFileAST(src, relFile, isAndroid, sourceRoot, basePackage, packageIndex)
-		return append(ff, extractRetrofitFacts(src, relFile)...)
+		ff = append(ff, extractRetrofitFacts(src, relFile)...)
+		return append(ff, extractServletRouteFacts(src, relFile)...)
 	})
 
 	modules := make(map[string]bool)

--- a/internal/extractors/kotlinextractor/kotlin_test.go
+++ b/internal/extractors/kotlinextractor/kotlin_test.go
@@ -25,6 +25,36 @@ func writeKotlinRepo(t *testing.T, files map[string]string) (string, []string) {
 	return dir, rel
 }
 
+// TestDetect covers build-tool-agnostic Kotlin detection: Gradle, Maven (the
+// regression that left a Kotlin-on-Maven service entirely unextracted), a bare
+// src/main/kotlin fallback, and a non-Kotlin repo.
+func TestDetect(t *testing.T) {
+	e := New()
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  bool
+	}{
+		{"gradle-kotlin", map[string]string{"build.gradle.kts": `plugins { kotlin("jvm") }`}, true},
+		{"maven-kotlin-plugin", map[string]string{"pom.xml": `<project><build><plugins><plugin><groupId>org.jetbrains.kotlin</groupId><artifactId>kotlin-maven-plugin</artifactId></plugin></plugins></build></project>`}, true},
+		{"maven-source-dir", map[string]string{"pom.xml": `<project><build><sourceDirectory>src/main/kotlin</sourceDirectory></build></project>`}, true},
+		{"source-root-fallback", map[string]string{"src/main/kotlin/App.kt": "package x"}, true},
+		{"plain-maven-java", map[string]string{"pom.xml": `<project><groupId>com.acme</groupId></project>`}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, _ := writeKotlinRepo(t, tc.files)
+			got, err := e.Detect(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("Detect = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDetectSourceRoot_IgnoresTestSourceSets is the regression guard for the
 // coupling-collapse bug: when a test-source-set file is walked first, source-root
 // detection must still pick the production (main) root, not the androidTest one.

--- a/internal/extractors/kotlinextractor/servletroute.go
+++ b/internal/extractors/kotlinextractor/servletroute.go
@@ -1,0 +1,72 @@
+package kotlinextractor
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// servletRegistration matches a programmatic route registration in a JVM fluent
+// builder DSL, capturing the path string literal and the handler expression:
+//
+//	.addServlet("/v1/things", thingsServlet)
+//	.addServletWithMapping("/v1/x", XServlet::class.java)
+//
+// Unlike Spring/JAX-RS annotations, these register routes at runtime through a
+// builder call, so the annotation-based route extractors never see them — the path
+// lives in an ordinary string-literal argument. Embedded servlet containers wire
+// their endpoints this way. One registration per line is the universal
+// shape (a fluent chain puts each .addServlet on its own line), so a line scan is
+// sufficient and avoids a full parse.
+var servletRegistration = regexp.MustCompile(`\.addServlet(?:WithMapping)?\s*\(\s*"([^"]+)"\s*,\s*([^,)]+)`)
+
+// extractServletRouteFacts emits a server-route fact for every programmatic servlet
+// registration in a Kotlin source file. role=server and method=facts.MethodAny (a
+// raw servlet serves every verb), so the cross-repo linker matches an inbound client
+// call of any method — from any repo — against the route that serves it. Path params
+// are left as written; the linker's normalizePath collapses {x}/:x/<x>/* forms.
+func extractServletRouteFacts(src []byte, relFile string) []facts.Fact {
+	var out []facts.Fact
+	dir := filepath.ToSlash(filepath.Dir(relFile))
+
+	for i, line := range strings.Split(string(src), "\n") {
+		m := servletRegistration.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		path := cleanServletPath(m[1])
+		if path == "" {
+			continue
+		}
+		out = append(out, facts.Fact{
+			Kind: facts.KindRoute,
+			Name: path,
+			File: relFile,
+			Line: i + 1,
+			Props: map[string]any{
+				"role":      "server",
+				"method":    facts.MethodAny,
+				"framework": "servlet",
+				"language":  "kotlin",
+				"handler":   strings.TrimSpace(m[2]),
+			},
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: dir}},
+		})
+	}
+	return out
+}
+
+// cleanServletPath trims a servlet mapping path to the form the cross-repo linker
+// matches on: drop a trailing servlet path-spec wildcard ("/v1/things/*" ->
+// "/v1/things") and any query string, keep the rest as written.
+func cleanServletPath(p string) string {
+	p = strings.TrimSpace(p)
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	p = strings.TrimSuffix(p, "/*")
+	p = strings.TrimSuffix(p, "*")
+	return strings.TrimRight(strings.TrimSpace(p), "/")
+}

--- a/internal/extractors/kotlinextractor/servletroute_test.go
+++ b/internal/extractors/kotlinextractor/servletroute_test.go
@@ -1,0 +1,57 @@
+package kotlinextractor
+
+import (
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func TestExtractServletRouteFacts(t *testing.T) {
+	// The fluent servlet-registration DSL used by embedded HTTP servers: each
+	// .addServlet("/path", handler) on its own line in a builder chain.
+	src := `package com.example.server.di
+
+class ServletRegistry {
+    fun registerWith(builder: HttpServer.Builder): HttpServer.Builder =
+        builder
+            .addServlet("/v1/widgets/details", widgetDetailsServlet)
+            .addServlet("/v1/gadgets", gadgetsServlet)
+            .addServlet("/v1/gizmos/*", gizmoValuesServlet)
+            .addServletAttribute(Server.attrMetricsProvider, provider())
+}
+`
+	ff := extractServletRouteFacts([]byte(src), "src/main/kotlin/com/example/server/di/ServletRegistry.kt")
+	if len(ff) != 3 {
+		t.Fatalf("expected 3 server routes (addServletAttribute must be ignored), got %d: %+v", len(ff), ff)
+	}
+
+	byName := map[string]map[string]any{}
+	for _, f := range ff {
+		if f.Kind != facts.KindRoute {
+			t.Errorf("kind = %q, want route", f.Kind)
+		}
+		if f.Props["role"] != "server" {
+			t.Errorf("%s role = %v, want server", f.Name, f.Props["role"])
+		}
+		if f.Props["method"] != facts.MethodAny {
+			t.Errorf("%s method = %v, want %q (servlet serves any verb)", f.Name, f.Props["method"], facts.MethodAny)
+		}
+		if f.Props["framework"] != "servlet" {
+			t.Errorf("%s framework = %v, want servlet", f.Name, f.Props["framework"])
+		}
+		byName[f.Name] = f.Props
+	}
+
+	for _, want := range []string{"/v1/widgets/details", "/v1/gadgets"} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("missing server route %q; got %+v", want, byName)
+		}
+	}
+	// Trailing path-spec wildcard is trimmed to the concrete prefix.
+	if _, ok := byName["/v1/gizmos"]; !ok {
+		t.Errorf("wildcard path /v1/gizmos/* should normalize to /v1/gizmos; got %+v", byName)
+	}
+	if p, ok := byName["/v1/gadgets"]; ok && p["handler"] != "gadgetsServlet" {
+		t.Errorf("/v1/gadgets handler = %v, want gadgetsServlet", p["handler"])
+	}
+}

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -75,6 +75,15 @@ const (
 	RelHandledBy    = "handled_by"   // A route/endpoint is served by target (e.g. a gRPC RPC route → its Go handler method). Added post-extraction.
 )
 
+// MethodAny is the HTTP-method value for a server route that handles every verb
+// rather than one specific method — a raw servlet (doGet/doPost/…) or a mapping
+// declared without a verb. The cross-repo HTTP linker treats it as a wildcard that
+// a client call of any concrete method matches. Extractors that cannot attribute a
+// route to a single verb emit this instead of guessing one (which would create a
+// spurious method mismatch) or omitting the method (which drops the route from
+// matching entirely).
+const MethodAny = "*"
+
 // Symbol kind property values.
 const (
 	SymbolFunc      = "function"

--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -1567,10 +1567,19 @@ func pathSuffixes(normPath string) []string {
 func lookupClientMatches(server map[string][]routeRef, clientPath, method string) ([]routeRef, string) {
 	sufs := pathSuffixes(clientPath)
 	if len(sufs) == 0 {
-		return server[routeKey(clientPath, method)], clientPath
+		if m := server[routeKey(clientPath, method)]; len(m) > 0 {
+			return m, clientPath
+		}
+		return server[routeKey(clientPath, facts.MethodAny)], clientPath
 	}
 	for _, suf := range sufs {
+		// Prefer an exact-verb server route at this suffix, then fall back to a
+		// wildcard route (facts.MethodAny — a servlet or verb-less mapping that serves
+		// every method), so a concrete client call still resolves to it.
 		if m := server[routeKey(suf, method)]; len(m) > 0 {
+			return m, suf
+		}
+		if m := server[routeKey(suf, facts.MethodAny)]; len(m) > 0 {
 			return m, suf
 		}
 	}

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -574,6 +574,29 @@ func TestComputeLinks_SingleRepoNoLinks(t *testing.T) {
 
 // --- (A) suffix-aware HTTP matching ---
 
+// TestComputeLinks_HTTPWildcardServerMethod covers a programmatic servlet (or verb-less
+// mapping) server route, emitted with method=facts.MethodAny because it serves every
+// verb: a concrete-method client call must resolve to it. This is the linker half of
+// the JVM programmatic-route fix — the Kotlin extractor emits such routes for the
+// .addServlet("/path", handler) DSL, and without this a GET caller would not bind.
+func TestComputeLinks_HTTPWildcardServerMethod(t *testing.T) {
+	in := []facts.Fact{
+		serverRoute("svc-beta", "/v1/widgets/details", facts.MethodAny),
+		clientRoute("svc-alpha", "v1/widgets/details", "GET", nil),
+	}
+	out := ComputeLinks(in, nil)
+	e := findEdge(out, "svc-alpha", "svc-beta")
+	if e == nil {
+		t.Fatalf("GET client should resolve to a wildcard-method server route; edges=%+v", crossRepoEdges(out))
+	}
+	if via, _ := e.Props["via"].([]string); len(via) == 0 || via[0] != "http" {
+		t.Errorf("via = %v, want [http]", e.Props["via"])
+	}
+	if !hasServiceEdge(out, "svc-alpha", "svc-beta") {
+		t.Errorf("svc-alpha service node missing depends_on svc-beta")
+	}
+}
+
 func TestComputeLinks_HTTPSuffixMatch(t *testing.T) {
 	// golf serves the full /api/settings path; consumers call it with varying
 	// prefixes (Swift base-relative, Kotlin/TS with /api). All must link to golf.


### PR DESCRIPTION
…vlet routes

Kotlin detection only recognized Gradle, so a Kotlin service built with Maven was skipped entirely — no symbols, routes, or client calls extracted. Detect now also reads pom.xml (kotlin plugin/dependency, src/main/kotlin sourceDir) and falls back to a src/main/kotlin source root, making JVM detection build-tool agnostic.

Add server-route extraction for the fluent .addServlet("/path", handler) registration DSL, which the annotation-based route extractors never saw. A raw servlet serves every verb, so these routes are emitted with a new facts.MethodAny ("*") method; the cross-repo HTTP linker treats it as a wildcard that a concrete-method client call resolves to, via a single probe in lookupClientMatches.

Together these let a programmatically-routed service's inbound endpoints be indexed and matched, so callers previously left unresolved now bind to the service that serves them.