### PR TITLE
feat(crossrepo): link services by Kafka topic producer/consumer

### DIFF
--- a/internal/extractors/goextractor/go.go
+++ b/internal/extractors/goextractor/go.go
@@ -259,6 +259,9 @@ func (e *GoExtractor) extractFile(fset *token.FileSet, f *ast.File, relFile, pkg
 	// Extract storage patterns
 	result = append(result, extractStorage(fset, f, relFile, pkgDir)...)
 
+	// Extract Kafka topic references (produced/consumed), for async cross-repo links
+	result = append(result, extractKafkaFacts(fset, f, relFile, pkgDir)...)
+
 	return result
 }
 

--- a/internal/extractors/goextractor/kafka.go
+++ b/internal/extractors/goextractor/kafka.go
@@ -1,0 +1,112 @@
+package goextractor
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// extractKafkaFacts emits a topic-reference fact (KindStorage, storage_kind=topic)
+// for every Kafka topic a Go file names. It does not try to classify producer vs
+// consumer — topic names are conventionally prefixed with the owning service, so the
+// cross-repo async linker derives direction from ownership (a repo referencing
+// another service's topic is a consumer of it). It resolves the two ways a topic
+// string reaches the code without a bare literal at the call site:
+//
+//   - a config struct field whose name ends in "Topic" carrying an envconfig
+//     `default:"<topic>"` tag (the value used unless the env var overrides it), and
+//   - an `env.Get("<KEY>_TOPIC", "<topic>")` lookup, whose second argument is the
+//     default topic.
+//
+// Both anchor on an explicit "topic" marker (field-name suffix / env-key substring),
+// so an in-process event bus — whose Subscribe takes a Go event symbol, not a topic
+// string — never produces a fact here, and is thereby excluded by construction.
+func extractKafkaFacts(fset *token.FileSet, f *ast.File, relFile, pkgDir string) []facts.Fact {
+	var out []facts.Fact
+	seen := map[string]bool{}
+
+	emit := func(topic string, line int, source string) {
+		topic = strings.TrimSpace(topic)
+		if topic == "" || seen[topic] {
+			return
+		}
+		seen[topic] = true
+		out = append(out, facts.Fact{
+			Kind: facts.KindStorage,
+			Name: topic,
+			File: relFile,
+			Line: line,
+			Props: map[string]any{
+				"storage_kind": facts.StorageKindTopic,
+				"messaging":    "kafka",
+				"language":     "go",
+				"source":       source,
+			},
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: pkgDir}},
+		})
+	}
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.Field:
+			// A config field whose name ends in "Topic" with a default tag: the
+			// default is the topic used absent an env override.
+			if node.Tag == nil || !fieldNameHasTopicSuffix(node.Names) {
+				return true
+			}
+			tag, err := strconv.Unquote(node.Tag.Value)
+			if err != nil {
+				return true
+			}
+			if def := reflect.StructTag(tag).Get("default"); def != "" {
+				emit(def, fset.Position(node.Pos()).Line, "config_default")
+			}
+		case *ast.CallExpr:
+			// env.Get("<...>_TOPIC", "<default topic>")
+			if topic, ok := envGetTopicDefault(node); ok {
+				emit(topic, fset.Position(node.Pos()).Line, "env_default")
+			}
+		}
+		return true
+	})
+
+	return out
+}
+
+// fieldNameHasTopicSuffix reports whether any of a struct field's names ends in
+// "Topic" (e.g. AttributeEventTopic), the marker that its string value is a topic.
+func fieldNameHasTopicSuffix(names []*ast.Ident) bool {
+	for _, n := range names {
+		if strings.HasSuffix(n.Name, "Topic") {
+			return true
+		}
+	}
+	return false
+}
+
+// envGetTopicDefault recognizes env.Get("<KEY>", "<default>") where the key names a
+// topic (contains "TOPIC"), returning the default-topic literal. The env-var default
+// is what the running service uses unless overridden, so it is the topic to bind on.
+func envGetTopicDefault(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Get" || len(call.Args) != 2 {
+		return "", false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "env" {
+		return "", false
+	}
+	key, ok := stringLitValue(call.Args[0])
+	if !ok || !strings.Contains(strings.ToUpper(key), "TOPIC") {
+		return "", false
+	}
+	def, ok := stringLitValue(call.Args[1])
+	if !ok {
+		return "", false
+	}
+	return def, true
+}

--- a/internal/extractors/goextractor/kafka_test.go
+++ b/internal/extractors/goextractor/kafka_test.go
@@ -1,0 +1,100 @@
+package goextractor
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func kafkaTopics(t *testing.T, src string) map[string]facts.Fact {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]facts.Fact{}
+	for _, ff := range extractKafkaFacts(fset, f, "internal/config/config.go", "internal/config") {
+		if ff.Kind == facts.KindStorage && ff.Props["storage_kind"] == facts.StorageKindTopic {
+			byName[ff.Name] = ff
+		}
+	}
+	return byName
+}
+
+func TestExtractKafkaFacts_ConfigDefaultTag(t *testing.T) {
+	// A config struct field whose name ends in Topic, with an envconfig default: the
+	// default value is the topic to bind on.
+	src := `package config
+
+type Config struct {
+	AttributeEventTopic      string ` + "`" + `envconfig:"ATTRIBUTE_EVENT_TOPIC" default:"svc-other.attributes"` + "`" + `
+	CacheInvalidationTopic   string ` + "`" + `envconfig:"CACHE_TOPIC" default:"svc-self.cache.v1.invalidation"` + "`" + `
+	SomeOtherField           string ` + "`" + `envconfig:"OTHER" default:"not-a-topic"` + "`" + `
+}
+`
+	got := kafkaTopics(t, src)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 topic facts (only *Topic fields), got %d: %v", len(got), keys(got))
+	}
+	for _, want := range []string{"svc-other.attributes", "svc-self.cache.v1.invalidation"} {
+		f, ok := got[want]
+		if !ok {
+			t.Errorf("missing topic %q; got %v", want, keys(got))
+			continue
+		}
+		if f.Props["messaging"] != "kafka" || f.Props["source"] != "config_default" {
+			t.Errorf("%s props = %v", want, f.Props)
+		}
+	}
+	if _, ok := got["not-a-topic"]; ok {
+		t.Errorf("non-Topic field must not produce a topic fact")
+	}
+}
+
+func TestExtractKafkaFacts_EnvGetDefault(t *testing.T) {
+	// env.Get("X_TOPIC", "default") — the second arg is the default topic.
+	src := `package config
+
+func wire() {
+	p := Publisher{Topic: env.Get("EVENTS_TOPIC", "svc-self.events")}
+	_ = p
+}
+`
+	got := kafkaTopics(t, src)
+	f, ok := got["svc-self.events"]
+	if !ok {
+		t.Fatalf("expected topic svc-self.events from env.Get default; got %v", keys(got))
+	}
+	if f.Props["source"] != "env_default" {
+		t.Errorf("source = %v, want env_default", f.Props["source"])
+	}
+}
+
+func TestExtractKafkaFacts_IgnoresInProcessEventBus(t *testing.T) {
+	// An in-process event bus subscribes on a Go symbol, not a topic string, and its
+	// env lookups are not topics — nothing here is a Kafka topic reference.
+	src := `package app
+
+func wire(bus EventBus) {
+	bus.Subscribe(event.CampaignBudgetSpent, handleSpent)
+	bus.Subscribe(event.CampaignEnded, handleEnded)
+	timeout := env.Get("REQUEST_TIMEOUT", "30s")
+	_ = timeout
+}
+`
+	got := kafkaTopics(t, src)
+	if len(got) != 0 {
+		t.Errorf("in-process event bus / non-topic env.Get must not produce topic facts, got %v", keys(got))
+	}
+}
+
+func keys(m map[string]facts.Fact) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -75,6 +75,23 @@ const (
 	RelHandledBy    = "handled_by"   // A route/endpoint is served by target (e.g. a gRPC RPC route → its Go handler method). Added post-extraction.
 )
 
+// StorageKindTopic is the storage_kind prop value for a KindStorage fact that
+// represents a messaging topic reference (e.g. a Kafka topic a service produces to
+// or consumes from), as opposed to a database table or object store. The cross-repo
+// async linker keys producer/consumer binding on it. The topic name is the fact's
+// Name; the messaging_role prop (MessagingRole*) records the side when known, and is
+// otherwise inferred by the linker from topic-name ownership.
+const StorageKindTopic = "topic"
+
+// Messaging role property values (the messaging_role prop) for a topic storage fact:
+// which side of a topic a reference represents. Left unset when only a bare topic
+// reference is seen, in which case the linker infers direction from the topic name's
+// owning-service prefix.
+const (
+	MessagingRoleProducer = "producer"
+	MessagingRoleConsumer = "consumer"
+)
+
 // MethodAny is the HTTP-method value for a server route that handles every verb
 // rather than one specific method — a raw servlet (doGet/doPost/…) or a mapping
 // declared without a verb. The cross-repo HTTP linker treats it as a wildcard that

--- a/internal/linkers/crossrepo/crossrepo.go
+++ b/internal/linkers/crossrepo/crossrepo.go
@@ -61,9 +61,10 @@ const minSharedSegments = 2
 type edge struct {
 	consumer   string
 	provider   string
-	via        map[string]bool // "http", "http-client", "import", "shared_symbols"
+	via        map[string]bool // "http", "http-client", "import", "kafka", "shared_symbols"
 	endpoints  map[string]bool // "METHOD /path"
 	imports    map[string]bool // sample import targets
+	topics     map[string]bool // shared Kafka topic names (consumer references producer's topic)
 	symbols    map[string]bool // shared type identities, verified against source when available
 	confidence string          // "verified" or "probable" — max over HTTP endpoints
 	// nameMatches is how many identities matched by NAME before source verification
@@ -139,6 +140,7 @@ func ComputeLinks(all []facts.Fact, src SourceReader) []facts.Fact {
 	cov := map[string]*httpCoverage{}
 	linkHTTP(all, edges, cov)
 	linkImports(all, normToLabel, edges)
+	linkKafka(all, normToLabel, edges)
 	// Runs last: it consults the edges the directional linkers have already drawn to
 	// decide whether a shared-symbol signal annotates a real dependency or stands alone.
 	linkSharedSymbols(all, edges, couplings, src)
@@ -573,6 +575,54 @@ func repoFromIdentity(id string) string {
 		return id[:i]
 	}
 	return id
+}
+
+// --- signal (D): Kafka topic producer/consumer binding ---
+
+// topicOwner returns the owning-service segment of a Kafka topic name: the part
+// before the first ".". By convention a topic is named "<owning-service>.<...>"
+// (e.g. "svc-orders.order_placed" -> "svc-orders",
+// "core.items.item_uploaded" -> "core"), so the leading segment identifies the
+// producer even when that repo's producer code cannot be parsed.
+func topicOwner(topic string) string {
+	topic = strings.TrimSpace(topic)
+	if i := strings.IndexByte(topic, '.'); i >= 0 {
+		return topic[:i]
+	}
+	return topic
+}
+
+// linkKafka binds asynchronous coupling: a repo that references a Kafka topic owned
+// by ANOTHER loaded repo consumes that repo's events, so it depends on it. The edge
+// is drawn consumer -> producer (mirroring HTTP client -> server), keyed on the
+// topic name's owning-service prefix — the same leading-segment-to-repo resolution
+// linkImports uses, and robust to the producer side being unparsed. A repo's
+// reference to its OWN topic (owner == repo) is intra-repo and draws no edge, and a
+// topic owned by no loaded repo (an export sink, a third-party service) is simply
+// left unlinked.
+func linkKafka(all []facts.Fact, normToLabel map[string]string, edges map[string]*edge) {
+	for _, f := range all {
+		if f.Repo == "" || f.Kind != facts.KindStorage {
+			continue
+		}
+		if propString(f, "storage_kind") != facts.StorageKindTopic {
+			continue
+		}
+		owner := topicOwner(f.Name)
+		if owner == "" {
+			continue
+		}
+		label, ok := normToLabel[normalizeLabel(owner)]
+		if !ok || label == f.Repo {
+			continue // owner not loaded, or the repo's own topic (it is the producer)
+		}
+		e := edgeFor(edges, f.Repo, label)
+		e.note("kafka")
+		if e.topics == nil {
+			e.topics = map[string]bool{}
+		}
+		e.topics[f.Name] = true
+	}
 }
 
 // --- signal (B): import / shared-lib references ---
@@ -1342,6 +1392,11 @@ func materialize(edges map[string]*edge, couplings map[string]*coupling, allRepo
 			imps := sortedKeys(e.imports)
 			props["import_count"] = len(imps)
 			props["import_samples"] = cap25(imps)
+		}
+		if len(e.topics) > 0 {
+			tps := sortedKeys(e.topics)
+			props["topic_count"] = len(tps)
+			props["topic_samples"] = cap25(tps)
 		}
 		if len(e.symbols) > 0 {
 			syms := sortedKeys(e.symbols)

--- a/internal/linkers/crossrepo/crossrepo_test.go
+++ b/internal/linkers/crossrepo/crossrepo_test.go
@@ -597,6 +597,48 @@ func TestComputeLinks_HTTPWildcardServerMethod(t *testing.T) {
 	}
 }
 
+// topicFact builds a Kafka topic-reference fact as the extractors emit it.
+func topicFact(repo, topic string) facts.Fact {
+	return facts.Fact{
+		Kind: facts.KindStorage,
+		Name: topic,
+		Repo: repo,
+		Props: map[string]any{
+			"storage_kind": facts.StorageKindTopic,
+			"messaging":    "kafka",
+		},
+	}
+}
+
+// TestComputeLinks_Kafka covers async binding: a repo referencing another loaded
+// repo's topic (identified by the topic name's owning-service prefix) depends on it;
+// a repo's own topic and a topic owned by no loaded repo draw no edge.
+func TestComputeLinks_Kafka(t *testing.T) {
+	in := []facts.Fact{
+		module("svc-alpha", "app"), // consumer
+		module("svc-beta", "app"),  // producer / owner
+		topicFact("svc-alpha", "svc-beta.things_updated"),       // alpha consumes beta's topic
+		topicFact("svc-alpha", "svc-alpha.cache.v1.evictions"),  // alpha's own topic — no edge
+		topicFact("svc-alpha", "sink.third_party.user_state"),   // owner not loaded — no edge
+	}
+	out := ComputeLinks(in, nil)
+
+	e := findEdge(out, "svc-alpha", "svc-beta")
+	if e == nil {
+		t.Fatalf("svc-alpha should depend on svc-beta via kafka; edges=%+v", crossRepoEdges(out))
+	}
+	if via, _ := e.Props["via"].([]string); len(via) == 0 || via[0] != "kafka" {
+		t.Errorf("via = %v, want [kafka]", e.Props["via"])
+	}
+	if !hasServiceEdge(out, "svc-alpha", "svc-beta") {
+		t.Errorf("svc-alpha service node missing depends_on svc-beta")
+	}
+	// Only svc-alpha -> svc-beta: the self-topic and unloaded-owner topic draw nothing.
+	if edges := crossRepoEdges(out); len(edges) != 1 {
+		t.Errorf("expected exactly 1 kafka edge, got %d: %+v", len(edges), edges)
+	}
+}
+
 func TestComputeLinks_HTTPSuffixMatch(t *testing.T) {
 	// golf serves the full /api/settings path; consumers call it with varying
 	// prefixes (Swift base-relative, Kotlin/TS with /api). All must link to golf.


### PR DESCRIPTION
Async coupling was invisible: topic references were never extracted, so a service consuming another's events showed no dependency. Add a topic fact (KindStorage, storage_kind=topic) emitted from the two ways a topic string reaches Go code without a literal at the call site — an envconfig `default:` tag on a *Topic field, and env.Get("..._TOPIC", "default"). An in-process event bus names a symbol, not a topic string, so it is excluded by construction.

Add a linkKafka signal to the cross-repo linker that binds consumer -> producer via the topic name's owning-service prefix (the same leading-segment-to-repo resolution the import linker uses), so the edge resolves from the consumer side alone and is robust to the producer being unparsed. A repo's own topic and a topic owned by no loaded repo draw no edge.