### PR TITLE
Model running servers as instances

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -228,11 +228,30 @@ The shared module-graph construction and statistical-outlier helpers used by sev
 - `OSSTools()` is the `--list` catalogue: name plus a one-line summary. It is hand-written on purpose — the descriptions registered with `mcp.AddTool` are multi-paragraph agent prompts, unusable in a terminal. `TestE2E_ToolCatalogueMatchesRegisteredTools` ([`internal/server/e2e_test.go`](internal/server/e2e_test.go)) asserts set equality against the tools the running server actually registers, so the two cannot drift. `RenderToolList(ToolListSpec)` renders it; a wrapper passes its own tools in `Extra` (or an unlock note via `ExtraLocked`/`LockedNote`), and with a zero spec the output never mentions that a wrapper exists.
 - `DefaultHelp(Binary)` returns the `HelpSpec` shared by every enola binary — usage, flags, config path, examples, MCP configuration, build — with the binary's name, command package and version ldflag substituted in. A wrapper appends to `Commands`/`Flags`/`Sections`, qualifies a shared flag with `AppendFlagNote`, and places its own blocks precisely with `InsertSectionsBefore`. `RenderHelp` does the layout (a 22-column description gutter, with continuation lines aligned to it).
 
-**[`pkg/status`](pkg/status)** is the usage tracker behind `--status`. `Tracker.OnToolCall` is registered as the server's tool callback (`bootstrap.Server.SetToolCallback`) and attributes each call to the repo it actually operated on, not to a fixed one. Counters live in `~/.enola/usage/<repo-base>-<hash8>.json` — outside the repo, so they survive both a restart and deleting `.enola/` — and each file carries the lifetime total plus the current run's session counts. `AggregateServer` collapses every file into the one server view `PrintStatus` renders; `AggregateUsage` produces the per-repo breakdown for `--status --all`.
+**[`pkg/status`](pkg/status)** is the usage tracker behind `--status`. `Tracker.OnToolCall` is registered as the server's tool callback (`bootstrap.Server.SetToolCallback`) and attributes each call to the repo it actually operated on, not to a fixed one. Counters live in `~/.enola/usage/<repo-base>-<hash8>.json` — outside the repo, so they survive both a restart and deleting `.enola/`. `AggregateServer` collapses every file into the server view `PrintStatus` renders; `AggregateUsage` produces the per-repo breakdown for `--status --all`.
+
+### Many servers, one home directory
+
+Agent tooling starts one MCP server per session, so several run concurrently — different repos, sometimes the same repo, both binaries — and they all share `~/.enola`. Two mechanisms keep that from turning into cross-talk.
+
+**Shared files are merged, not overwritten.** A repo's usage file has many writers. `Tracker.flush` therefore holds a cross-process lock ([`filelock_unix.go`](pkg/status/filelock_unix.go) / [`filelock_windows.go`](pkg/status/filelock_windows.go)), re-reads the file, and adds only the increments this process has not yet flushed. Writing `baseline + ownSession` instead — as it once did — silently discarded whatever a sibling had recorded in between.
+
+**Per-process state lives in files with one writer.** Everything that describes a *process* rather than a repo — PID, uptime, dashboard port, the repos it holds, its own call counts — is published to `~/.enola/instances/<pid>-<startNano>.json` ([`instance.go`](pkg/status/instance.go)), refreshed on every tool call and by a 30s heartbeat, and removed by `Tracker.Close`. `LiveInstances` reads them, and reaps records whose process is gone (or whose PID is live but long unrefreshed — a PID-reuse guard), so a hard-killed server disappears at the next read. The start-time suffix means a recycled PID cannot resurrect a dead record.
+
+That registry is what lets `--status` list every running server with its own URL, and what lets a dashboard name the process serving it instead of guessing from the newest usage file — a guess that, with several terminals open, was usually a different process.
 
 The value estimate is a deliberately simple model in [`pkg/status/value.go`](pkg/status/value.go): one weight per tool (the number of manual lookups a call replaces) times two conversion constants (seconds and tokens per lookup). `RegisterToolWeights` lets a wrapper price the tools it adds instead of letting them fall through to the default weight; it is guarded by a mutex because registration happens at startup while reads come from the tool callback.
 
-**[`pkg/dashboard`](pkg/dashboard)** serves the read-only page described in the README, on a loopback port bound at startup (`--no-dashboard` skips it). It is **strictly a viewer**: `buildPage` runs per request and every source is read through an accessor the MCP tools already use — `status.ServerSnapshot()`, the engine's published store, and the receipt/insight artifacts (preferring the in-memory copy, falling back to the last-written file on disk, since `AutoLoadSnapshot` restores facts without full receipt metadata). Nothing it does mutates server state, and every source degrades to an explanatory note rather than an error page.
+**[`pkg/dashboard`](pkg/dashboard)** serves the read-only page described in the README, on a loopback port bound at startup (`--no-dashboard` skips it). It is **strictly a viewer**: `buildPage` runs per request and every source is read through an accessor the MCP tools already use — `Options.Tracker`, the engine's published store, and the receipt/insight artifacts (preferring the in-memory copy, falling back to the last-written file on disk, since `AutoLoadSnapshot` restores facts without full receipt metadata). Nothing it does mutates server state, and every source degrades to an explanatory note rather than an error page.
+
+**Whose data is on the page.** Each figure has exactly one legitimate source, and mixing them is what made the page misleading when several servers ran at once:
+
+- *This process* — PID, uptime, binary, workdir, repos loaded, calls served — comes from `Options.Tracker.Self()`. Never from `status.ServerSnapshot()`, whose scalar fields describe only one arbitrary instance.
+- *This process's graph* — the repo list and counts — comes from `bootstrap.Engine.GraphReceipt()`, assembled in memory. Reading the machine-wide `~/.enola/receipt.json` here (as it once did) let the repo list describe one server's graph while the services, insights and coverage panels below it described another's.
+- *Genuinely cross-process* figures — the lifetime tool totals and the tracked-repo count — still come from `ServerSnapshot()`, and the page labels them as such.
+- *The other servers* come from `status.LiveInstances()`, rendered as a table of links so any dashboard is an entry point to all of them.
+
+**The shared URL.** Each server binds its own ephemeral port, then competes for a fixed one (`DefaultStablePort`, overridable via `ENOLA_DASHBOARD_PORT` or `dashboard.port`; see `ResolveStablePort`). The winner serves the same mux from both and flags itself `FrontDoor` in the registry; the losers retry every few seconds, so when the holder exits another picks the port up and the bookmark survives. There is no coordination beyond the OS refusing the second bind.
 
 The page reads receipts into the engine's own `facts.Receipt` / `facts.GraphReceipt` types, re-exported from `pkg/facts` precisely so a consumer never hand-writes a JSON mirror that drifts.
 
@@ -538,6 +557,7 @@ The bundled [`mcp-arch.yaml`](mcp-arch.yaml) ships a much fuller `ignore` list (
 | `renderers` | Enabled renderers | `["llm_context"]` |
 | `output.dir` | Output directory for artifacts | `".enola"` |
 | `output.max_context_tokens` | Token budget for `llm_context.md` | `16000` |
+| `dashboard.port` | The fixed **shared URL** port every server competes for, in addition to its own ephemeral one. A negative value serves only the ephemeral port. `ENOLA_DASHBOARD_PORT` overrides it (`off` disables). | `7171` |
 | `incremental` | Reuse each extractor's cached facts across snapshots when its files are unchanged; set `false` to force full re-extraction every run | `true` |
 
 ---
@@ -624,6 +644,17 @@ After `generate_snapshot`, these are written to the output directory (default `.
   The two skip counters mean different things, and a bad ignore glob is usually a *directory* glob. `files_skipped` counts ignored files the walker **visited** and dropped — those matched by a file glob like `**/*.test.ts`. An ignored directory is pruned whole (`filepath.SkipDir`), so its contents are never visited and appear in no count: it is tallied once, as one entry in `dirs_skipped`. Each `skipped_sample` entry names the glob that matched it, so *"why is this file missing from the graph?"* is a lookup rather than an investigation; directories appear there with a trailing slash.
 
 Because the receipt fields live in `snapshot.meta.json`, they ride into every pinned/`previous` baseline, and `diff_snapshot` reads them to add a **comparability guard**: it warns (above the delta) when the baseline and current snapshots were *not* generated over equivalent inputs — a different repo, enola version, extractor set, or ignore-glob set — since a diff across a mismatched extractor set would report every one of that language's facts as spurious churn. `compare_receipts` surfaces the same verdict plus the metric deltas directly.
+
+#### The graph receipt, and why each workspace keeps its own
+
+Alongside the per-snapshot receipt in `.enola/`, a snapshot writes a **graph receipt** describing the whole graph the server holds — every repo in it, where each lives, its git state and fact count. That is what a restart reads (`bootstrap.AutoLoadSnapshot`) to reload a *multi-repo* graph without re-running any extractor: the per-repo `.enola/` dirs alone cannot say which repos were appended.
+
+It is written to two places ([`internal/engine/global_receipt.go`](internal/engine/global_receipt.go)):
+
+- `~/.enola/graphs/<repo-base>-<hash8>.json` — keyed by the repo the server was *launched for* (`cfg.Repo`), stable across appends.
+- `~/.enola/receipt.json` — the machine-wide copy, kept for tooling that already reads it.
+
+The machine-wide file necessarily describes only whichever server generated last, so with one server per agent terminal it is the wrong thing to restore from: a server launched in repo A would come back holding the repos another terminal had snapshotted, then answer every query about the wrong codebase. `AutoLoadSnapshot` therefore prefers this workspace's own receipt, falls back to the machine-wide one **only when it actually covers `cfg.Repo`** (`receiptCovers`), and otherwise restores just `cfg.Repo` — or nothing, leaving the agent to run `generate_snapshot`. Starting empty is recoverable and visible; starting with someone else's graph is neither.
 
 #### Relation to the issue #60 proposal
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Run `enola --help` for the full text. With no flags, enola starts the MCP server
 | `--generate [config_path]` | Generate a snapshot and exit — no MCP server. Artifacts go to `output.dir` (default `.enola/`). |
 | `--explain [repo_path]` | Print the statistics report above and exit. Read-only: nothing is written to `.enola/`. |
 | `--list` | List the MCP tools this build serves, with one-line summaries. |
-| `--status` | Show the MCP server's activity: uptime, per-tool call counts (this session and lifetime), and an estimate of the time and context those calls saved. |
+| `--status` | List every enola server running right now — PID, repos, uptime, calls, dashboard URL — plus per-tool call counts and an estimate of the time and context those calls saved. |
 | `--status --all` | The same usage, broken down per repository. |
 | `--no-dashboard` | Start the MCP server without the localhost dashboard. |
 | `--version` | Print the build version. |
@@ -483,13 +483,25 @@ Usage counters are recorded per repository under `~/.enola/usage/`, so they surv
 
 Starting the MCP server also starts a **read-only dashboard** on a free loopback port (`127.0.0.1`), printed to stderr on startup — run `enola --status` while the server is up to get the URL again. It refreshes every 30 seconds and shows, in one page:
 
-- the same activity and value data as `--status`;
+- **this server** — its PID, binary, uptime, the repos *it* has loaded, and the directory it was launched from;
+- **every enola server running right now**, with a link to each one's dashboard, so you can switch between them;
+- the same activity and value data as `--status`, split into what this server has served and the lifetime total across all of them;
 - the **snapshot receipt** — snapshot ID, enola version, git ref, extractors, fact/insight counts;
-- the **graph receipt** (`~/.enola/receipt.json`) with the repos currently in the graph, and clickable counters listing the services and cross-repo edges — the edges also render as a node-link diagram;
+- the **graph receipt** — the repos in this server's graph, and clickable counters listing the services and cross-repo edges (the edges also render as a node-link diagram);
 - the **insights** grouped by explainer, filterable by confidence band, so you can see what each finding is and how certain it is;
 - **extraction quality** — per-service coverage, unresolved routes, and samples of skipped files and parse errors, which is where you look when a snapshot seems thin.
 
 It is strictly a viewer: every request reads through the same concurrency-safe accessors the MCP tools use and never mutates server state. It binds loopback only and serves nothing but that one page. Pass `--no-dashboard` to skip it.
+
+#### Several servers at once
+
+Agent tooling starts one enola server per session, so opening four terminals means four servers — each with its own graph, its own dashboard, and its own ephemeral port. Two things keep that legible.
+
+**One bookmarkable URL.** Besides its own port, every server competes for a fixed **shared URL**, `http://127.0.0.1:7171` by default. The first to start wins it; when that one exits another takes over within a few seconds, so the address keeps working for as long as any server is up. Whichever server answers there lists all the others. Set `ENOLA_DASHBOARD_PORT` (or `dashboard.port` in the config) to move it, or `ENOLA_DASHBOARD_PORT=off` to keep only the ephemeral ports.
+
+**Every page describes its own server.** The PID, uptime, repos and per-server call counts on a page belong to the process serving it — never to whichever server happened to start last. If a page shows a graph you did not expect, the switcher tells you which server holds the one you want.
+
+Running servers register themselves under `~/.enola/instances/`; a record is removed on exit, and one left behind by a hard-killed process is cleaned up by the next reader. Each workspace also keeps its own graph receipt under `~/.enola/graphs/`, so restarting a server in one repo restores *that* repo's graph rather than whatever another terminal snapshotted last.
 
 ---
 

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/enola-labs/enola/internal/config"
@@ -22,7 +24,11 @@ func main() {
 	log.SetOutput(os.Stderr)
 	bootstrap.ConfigureRuntime()
 
-	ctx := context.Background()
+	// A terminated server must still tidy up after itself — remove its instance
+	// record and flush its counters — so cancel the server's context on a signal
+	// instead of dying mid-run. Run returns, and the deferred cleanup happens.
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
 
 	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
 		if err := upgrade.Run(ctx, version.Version); err != nil {
@@ -140,25 +146,49 @@ func main() {
 	repoPath, _ := filepath.Abs(cfg.Repo)
 	tracker := status.NewTracker(repoPath)
 	tracker.SetStartTime(time.Now())
+	// Identity + graph state make this process distinguishable in the instance
+	// registry — a user typically runs one server per agent terminal, and every
+	// dashboard and --status listing is built from these records.
+	wd, _ := os.Getwd()
+	tracker.SetIdentity(status.Identity{
+		Binary:     "enola",
+		Version:    version.Version,
+		ConfigPath: cfgPath,
+		WorkDir:    wd,
+	})
+	tracker.SetGraphFunc(bootstrap.GraphStateFunc(eng))
+	// Deregister on the way out so the registry reflects the shutdown at once
+	// rather than waiting for a reader to reap a dead PID.
+	defer tracker.Close()
 	srv.SetToolCallback(tracker.OnToolCall)
 
 	// Start the localhost HTTP dashboard alongside the MCP server. It binds a
-	// free loopback port and serves a read-only, auto-refreshing view of the same
-	// data as --status plus the snapshot/graph receipts. Non-fatal: a dashboard
+	// free loopback port — plus the shared, bookmarkable one if it can claim it —
+	// and serves a read-only, auto-refreshing view of THIS server's graph and
+	// activity, with links to every other server running. Non-fatal: a dashboard
 	// failure must never stop the MCP server. The port is recorded on the tracker
 	// BEFORE the startup write, so a separate --status invocation can print the
 	// URL even before the first tool call.
 	if !noDashboard {
-		if dash, err := dashboard.Start(eng, dashboard.Options{}); err != nil {
+		opts := dashboard.Options{
+			Tracker:    tracker,
+			StablePort: dashboard.ResolveStablePort(cfg.Dashboard.Port),
+		}
+		if dash, err := dashboard.Start(eng, opts); err != nil {
 			log.Printf("dashboard: not started: %v (continuing without it)", err)
 		} else {
 			tracker.SetDashboardPort(dash.Port())
 			fmt.Fprintf(os.Stderr, "Dashboard: %s (auto-refreshes every 30s)\n", dash.URL())
+			if opts.StablePort > 0 {
+				fmt.Fprintf(os.Stderr, "Shared URL: http://127.0.0.1:%d (whichever server holds it lists all the others)\n", opts.StablePort)
+			}
 		}
 	}
 	tracker.PersistStartup()
 
 	if err := srv.Run(ctx); err != nil {
+		// Deregister explicitly: log.Fatalf exits without running deferred calls.
+		tracker.Close()
 		log.Fatalf("server error: %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	Renderers  []string     `yaml:"renderers"`
 	Output     OutputConfig `yaml:"output"`
 
+	// Dashboard configures the localhost dashboard served alongside the MCP
+	// server. Optional: the zero value keeps the built-in defaults.
+	Dashboard DashboardConfig `yaml:"dashboard"`
+
 	// Incremental enables per-extractor caching: an extractor's facts are reused
 	// across snapshots when the files it owns (and the repo's shared config files)
 	// are unchanged. Defaults to true. Set `incremental: false` to force a full
@@ -35,6 +39,17 @@ type Config struct {
 // IncrementalEnabled reports whether per-extractor caching is on (the default).
 func (c *Config) IncrementalEnabled() bool {
 	return c.Incremental == nil || *c.Incremental
+}
+
+// DashboardConfig controls the localhost dashboard.
+//
+// Port is the fixed "shared URL" port every server competes for, so there is one
+// address worth bookmarking even though each server also listens on an ephemeral
+// port of its own. Zero means the built-in default; a negative value turns the
+// shared URL off, leaving only the ephemeral port. The ENOLA_DASHBOARD_PORT
+// environment variable overrides it.
+type DashboardConfig struct {
+	Port int `yaml:"port"`
 }
 
 // OutputConfig controls where and how output artifacts are generated.

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -1,12 +1,15 @@
 package engine
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/enola-labs/enola/internal/facts"
@@ -31,6 +34,87 @@ func globalReceiptPath() (string, error) {
 	return filepath.Join(home, globalReceiptDirName, globalReceiptFileName), nil
 }
 
+// A user commonly runs several enola servers at once, one per agent terminal,
+// each holding a different graph. ~/.enola/receipt.json can only ever describe
+// one of them — whichever process generated last — so each workspace also gets
+// its OWN receipt under ~/.enola/graphs/, keyed by the repo the server was
+// launched for. That is the file a restart reads, so a server started in repo A
+// restores A's graph instead of whatever a sibling terminal happened to load.
+const graphsDirName = "graphs"
+
+// workspaceKey derives a stable, human-readable filename stem for a workspace
+// from its absolute repo path: the sanitized base name plus a short hash of the
+// full path, so two repos sharing a base name do not collide. It mirrors the key
+// scheme pkg/status uses for usage files; duplicated rather than shared so
+// internal/engine keeps depending on nothing outside the engine.
+func workspaceKey(absRepoPath string) string {
+	sum := sha256.Sum256([]byte(absRepoPath))
+	short := hex.EncodeToString(sum[:])[:8]
+
+	base := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, filepath.Base(absRepoPath))
+	if base == "" {
+		base = "repo"
+	}
+	return base + "-" + short
+}
+
+// canonicalRepoPath normalizes a repo path so the same workspace always maps to
+// the same key regardless of how it was referenced — absolute, with symlinks
+// resolved (e.g. macOS /var → /private/var).
+func canonicalRepoPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = p
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}
+
+// WorkspaceReceiptPath resolves ~/.enola/graphs/<key>.json for a workspace repo.
+func WorkspaceReceiptPath(repoPath string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(home, globalReceiptDirName, graphsDirName, workspaceKey(canonicalRepoPath(repoPath))+".json"), nil
+}
+
+// LoadWorkspaceReceipt reads the graph receipt for one workspace — the repo a
+// server was launched for. It is the per-workspace counterpart to
+// LoadGlobalReceipt and the file a restart should prefer, since the global one
+// describes whichever process wrote last.
+func LoadWorkspaceReceipt(repoPath string) (*facts.GraphReceipt, error) {
+	path, err := WorkspaceReceiptPath(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return readGraphReceiptFile(path)
+}
+
+// readGraphReceiptFile reads and parses a graph receipt from an explicit path.
+func readGraphReceiptFile(path string) (*facts.GraphReceipt, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading graph receipt: %w", err)
+	}
+	var gr facts.GraphReceipt
+	if err := json.Unmarshal(data, &gr); err != nil {
+		return nil, fmt.Errorf("parsing graph receipt %s: %w", path, err)
+	}
+	return &gr, nil
+}
+
 // LoadGlobalReceipt reads and parses ~/.enola/receipt.json — the graph-wide
 // multi-repo registry describing which repositories currently compose the graph
 // and where they live on disk. It is the counterpart to WriteGlobalReceipt and the
@@ -42,15 +126,7 @@ func LoadGlobalReceipt() (*facts.GraphReceipt, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading global receipt: %w", err)
-	}
-	var gr facts.GraphReceipt
-	if err := json.Unmarshal(data, &gr); err != nil {
-		return nil, fmt.Errorf("parsing global receipt %s: %w", path, err)
-	}
-	return &gr, nil
+	return readGraphReceiptFile(path)
 }
 
 // repoEntries returns one GraphRepoEntry per repository currently in the graph.
@@ -170,7 +246,74 @@ func (e *Engine) WriteGlobalReceipt() error {
 		return fmt.Errorf("writing global receipt: %w", err)
 	}
 	log.Printf("[engine] wrote %s (%d repos)", path, len(gr.Repos))
+
+	// Also write this workspace's own receipt. The global file above is shared by
+	// every enola process on the machine and describes whichever generated last;
+	// this one is keyed by the repo this server was launched for, so a restart
+	// restores THIS graph rather than a sibling terminal's. Non-fatal — the
+	// global receipt is still a usable fallback.
+	if err := e.writeWorkspaceReceipt(b, data); err != nil {
+		log.Printf("[engine] warning: workspace receipt not written: %v", err)
+	}
 	return nil
+}
+
+// writeWorkspaceReceipt persists the same receipt bytes under
+// ~/.enola/graphs/<workspace>.json. The workspace is the engine's configured
+// repo — stable across appends, unlike the snapshot's most-recent repo — so the
+// key does not move when a second repo is appended to the graph.
+func (e *Engine) writeWorkspaceReceipt(b *snapshotBundle, data []byte) error {
+	repo := e.workspaceRepo(b)
+	if repo == "" {
+		return nil
+	}
+	path, err := WorkspaceReceiptPath(repo)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating graphs dir: %w", err)
+	}
+	if err := writeFileAtomic(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing workspace receipt: %w", err)
+	}
+	log.Printf("[engine] wrote %s", path)
+	return nil
+}
+
+// workspaceRepo returns the repo this engine's graph belongs to: the configured
+// repo when set, otherwise the snapshot's primary repo.
+func (e *Engine) workspaceRepo(b *snapshotBundle) string {
+	if e.cfg != nil && e.cfg.Repo != "" {
+		return canonicalRepoPath(e.cfg.Repo)
+	}
+	if b.snapshot != nil && b.snapshot.Meta.RepoPath != "" {
+		return canonicalRepoPath(b.snapshot.Meta.RepoPath)
+	}
+	return ""
+}
+
+// GraphReceipt returns the receipt for the graph this engine holds RIGHT NOW,
+// assembled in memory from the published snapshot bundle. It exists so a viewer
+// (the dashboard) can describe its own process's graph instead of reading the
+// shared ~/.enola/receipt.json, which any other running server may have
+// overwritten with a different repo set.
+//
+// Membership timestamps are merged forward from this workspace's receipt on
+// disk, so "added at" / "in graph for" survive a restart. Returns nil when no
+// snapshot is loaded.
+func (e *Engine) GraphReceipt() *facts.GraphReceipt {
+	b := e.current.Load()
+	if b.snapshot == nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	gr := e.assembleGraphReceipt(b, now)
+
+	if path, err := WorkspaceReceiptPath(e.workspaceRepo(b)); err == nil {
+		gr.Repos = mergeRepoEntries(gr.Repos, readPriorGraphReceipt(path), now)
+	}
+	return &gr
 }
 
 // mergeRepoEntries carries per-repo membership state forward from a prior receipt

--- a/internal/engine/workspace_receipt_test.go
+++ b/internal/engine/workspace_receipt_test.go
@@ -1,0 +1,131 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// newWorkspaceEngine builds an engine pinned to repoPath holding one fact, so
+// each test workspace produces a distinguishable graph.
+func newWorkspaceEngine(t *testing.T, repoPath, label string) *Engine {
+	t.Helper()
+	cfg := config.Default()
+	cfg.Repo = repoPath
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	eng.store.Add(facts.Fact{Kind: facts.KindModule, Name: "m-" + label, Repo: label})
+	eng.SetSnapshot(&facts.Snapshot{Meta: facts.SnapshotMeta{
+		RepoPath: repoPath, SnapshotID: "sha256:" + label, FactCount: 1,
+	}})
+	return eng
+}
+
+// TestWorkspaceReceiptsAreIsolated is the regression test for cross-terminal
+// graph bleed: a user commonly runs one enola server per agent terminal, and
+// ~/.enola/receipt.json can only describe one of them. Each workspace must
+// therefore also get its own receipt, so a restart in repo A restores A's graph
+// rather than whatever a sibling terminal snapshotted last.
+func TestWorkspaceReceiptsAreIsolated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoA := filepath.Join(t.TempDir(), "alpha")
+	repoB := filepath.Join(t.TempDir(), "beta")
+
+	engA := newWorkspaceEngine(t, repoA, "alpha")
+	if err := engA.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt(alpha): %v", err)
+	}
+	// The second workspace writes afterwards, so the machine-wide receipt now
+	// describes beta — exactly the situation that used to poison alpha's restart.
+	engB := newWorkspaceEngine(t, repoB, "beta")
+	if err := engB.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt(beta): %v", err)
+	}
+
+	shared, err := LoadGlobalReceipt()
+	if err != nil {
+		t.Fatalf("LoadGlobalReceipt: %v", err)
+	}
+	if shared.SnapshotID != "sha256:beta" {
+		t.Fatalf("machine-wide receipt = %q, want the last writer (beta)", shared.SnapshotID)
+	}
+
+	// Each workspace's own receipt must still describe that workspace.
+	for _, tc := range []struct{ repo, want string }{{repoA, "sha256:alpha"}, {repoB, "sha256:beta"}} {
+		got, err := LoadWorkspaceReceipt(tc.repo)
+		if err != nil {
+			t.Fatalf("LoadWorkspaceReceipt(%s): %v", tc.repo, err)
+		}
+		if got.SnapshotID != tc.want {
+			t.Errorf("workspace receipt for %s = %q, want %q — a sibling server's graph leaked in",
+				tc.repo, got.SnapshotID, tc.want)
+		}
+	}
+}
+
+// TestWorkspaceKeyDisambiguatesSameBaseName guards the keying: two repos sharing
+// a directory name (a monorepo checked out twice, say) must not share a receipt.
+func TestWorkspaceKeyDisambiguatesSameBaseName(t *testing.T) {
+	a := workspaceKey("/one/api")
+	b := workspaceKey("/two/api")
+	if a == b {
+		t.Fatalf("same key %q for /one/api and /two/api", a)
+	}
+	for _, k := range []string{a, b} {
+		if filepath.Base(k) != k {
+			t.Errorf("key %q is not a plain filename stem", k)
+		}
+	}
+}
+
+// TestGraphReceiptReadsLiveEngine covers what the dashboard renders: the graph
+// receipt assembled in memory, which must reflect this engine even when the
+// shared file on disk says something else.
+func TestGraphReceiptReadsLiveEngine(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repo := filepath.Join(t.TempDir(), "gamma")
+	eng := newWorkspaceEngine(t, repo, "gamma")
+
+	// Plant a conflicting machine-wide receipt, as another running server would.
+	if err := os.MkdirAll(filepath.Join(home, ".enola"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".enola", "receipt.json"),
+		[]byte(`{"snapshot_id":"sha256:someone-else"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gr := eng.GraphReceipt()
+	if gr == nil {
+		t.Fatal("GraphReceipt() = nil, want the live graph")
+	}
+	if gr.SnapshotID != "sha256:gamma" {
+		t.Errorf("SnapshotID = %q, want the live engine's sha256:gamma", gr.SnapshotID)
+	}
+	if len(gr.Repos) != 1 || gr.Repos[0].Label != "gamma" {
+		t.Errorf("Repos = %+v, want just gamma", gr.Repos)
+	}
+}
+
+// TestGraphReceiptWithoutSnapshot returns nil rather than an empty shell, which
+// is what makes the dashboard show its "no graph loaded" note.
+func TestGraphReceiptWithoutSnapshot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	eng, err := New(config.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if gr := eng.GraphReceipt(); gr != nil {
+		t.Errorf("GraphReceipt() = %+v, want nil with no snapshot loaded", gr)
+	}
+}

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain sandboxes the home directory for the entire package test binary. The
+// generate_snapshot handler writes the machine-wide and per-workspace graph
+// receipts under ~/.enola, so without this a test run would overwrite the
+// developer's own receipts with temp-dir paths — and a real enola server started
+// afterwards would read them.
+//
+// Individual tests may still call t.Setenv("HOME", ...) for their own temp dir;
+// this is the backstop for any that do not.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "enola-server-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	for _, key := range []string{
+		"HOME",        // unix/darwin: os.UserHomeDir reads $HOME
+		"USERPROFILE", // windows
+	} {
+		if err := os.Setenv(key, tmp); err != nil {
+			panic(err)
+		}
+	}
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/enola-labs/enola/internal/config"
@@ -37,6 +38,7 @@ import (
 	"github.com/enola-labs/enola/internal/renderers/llmcontext"
 	"github.com/enola-labs/enola/internal/server"
 	"github.com/enola-labs/enola/pkg/plugin"
+	"github.com/enola-labs/enola/pkg/status"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -106,9 +108,18 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	return e.eng.WriteArtifacts(repoPath)
 }
 
-// WriteGlobalReceipt refreshes the graph-wide receipt at ~/.enola/receipt.json.
+// WriteGlobalReceipt refreshes the graph-wide receipt at ~/.enola/receipt.json
+// and this workspace's own copy under ~/.enola/graphs/.
 func (e *Engine) WriteGlobalReceipt() error {
 	return e.eng.WriteGlobalReceipt()
+}
+
+// GraphReceipt returns the receipt for the graph THIS engine currently holds,
+// assembled in memory. A viewer with several servers running must use this
+// rather than reading ~/.enola/receipt.json, which describes whichever process
+// generated a snapshot last. Nil when no snapshot is loaded.
+func (e *Engine) GraphReceipt() *facts.GraphReceipt {
+	return e.eng.GraphReceipt()
 }
 
 // SetBaseline pins the current on-disk snapshot as the diff baseline.
@@ -248,24 +259,83 @@ func NewServer(eng *Engine, cfg *config.Config) (*Server, error) {
 	return &Server{srv: srv}, nil
 }
 
+// GraphStateFunc returns a callback reporting what this engine currently holds,
+// for status.Tracker.SetGraphFunc. It is what lets a user with several servers
+// running tell them apart — each instance record then names the repos, snapshot
+// and fact counts of its own process rather than of whichever one wrote last.
+//
+// The callback is invoked on every status write, so it only reads the published
+// (immutable) snapshot bundle and never blocks on IO.
+func GraphStateFunc(eng *Engine) status.GraphFunc {
+	return func() status.GraphState {
+		g := status.GraphState{PrimaryRepo: eng.ActiveRepo()}
+
+		snap := eng.Snapshot()
+		if snap != nil {
+			g.SnapshotID = snap.Meta.SnapshotID
+			if t, err := time.Parse(time.RFC3339, snap.Meta.GeneratedAt); err == nil {
+				g.SnapshotAt = t
+			}
+			g.FactCount = snap.Meta.FactCount
+			g.InsightCount = snap.Meta.InsightCount
+		}
+
+		store := eng.Store()
+		repos := eng.RepoPaths()
+		if len(repos) == 0 && snap != nil && snap.Meta.RepoPath != "" {
+			// Single-repo graph: RepoPaths stays empty until a repo is appended.
+			repos = map[string]string{filepath.Base(snap.Meta.RepoPath): snap.Meta.RepoPath}
+		}
+		for label, path := range repos {
+			r := status.InstanceRepo{Label: label, Path: path}
+			if store != nil {
+				r.FactCount = store.CountByRepo(label)
+			}
+			g.Repos = append(g.Repos, r)
+		}
+		sort.Slice(g.Repos, func(i, j int) bool { return g.Repos[i].Label < g.Repos[j].Label })
+		return g
+	}
+}
+
 // AutoLoadSnapshot restores an existing snapshot from disk if available, so queries
 // (and the enterprise tools) work immediately after a restart WITHOUT a
 // generate_snapshot call.
 //
-// It prefers the graph-wide registry at ~/.enola/receipt.json: that lists every
-// repo currently in the graph and their paths, so a restart restores the WHOLE
-// multi-repo graph — not just cfg.Repo — with no extractor runs. If that is
-// unavailable it falls back to a single-repo restore of cfg.Repo. Either way it
-// restores facts + insights + the snapshot meta (incl. generated_at, which the
-// freshness check needs), unlike the old facts-only load.
+// It prefers a graph registry listing every repo in the graph and their paths, so
+// a restart restores the WHOLE multi-repo graph — not just cfg.Repo — with no
+// extractor runs. Two registries exist and are tried in order:
+//
+//  1. ~/.enola/graphs/<workspace>.json — the receipt for THIS workspace (cfg.Repo).
+//  2. ~/.enola/receipt.json — the machine-wide receipt, describing whichever
+//     server generated a snapshot last.
+//
+// The workspace file comes first because a user typically runs several servers at
+// once, one per agent terminal: reading the shared file would restore a sibling
+// terminal's repo set into this process. The shared file remains the fallback for
+// graphs snapshotted before the workspace receipt existed. Failing both, it falls
+// back to a single-repo restore of cfg.Repo. Either way it restores facts +
+// insights + the snapshot meta (incl. generated_at, which the freshness check
+// needs), unlike the old facts-only load.
 //
 // It publishes a fresh bundle via engine.RestoreFromDir. This is safe ONLY because
 // it runs single-threaded at startup, before the MCP server begins serving tool
 // calls — no reader can observe a half-built store. Callers must keep it strictly
 // before Server.Run.
 func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
-	// Preferred path: reload the full multi-repo graph from the global registry.
-	if gr, err := engine.LoadGlobalReceipt(); err == nil && len(gr.Repos) > 0 {
+	// Preferred path: this workspace's own graph.
+	if gr, err := engine.LoadWorkspaceReceipt(cfg.Repo); err == nil && len(gr.Repos) > 0 {
+		if restoreFromGlobalReceipt(eng, cfg, gr) {
+			return
+		}
+		log.Printf("[bootstrap] workspace receipt present but multi-repo restore incomplete; trying the machine-wide receipt")
+	}
+
+	// Fallback: the machine-wide registry — but only when it actually describes
+	// this workspace. It is written by every server on the machine, so adopting it
+	// blindly would restore a graph another agent terminal snapshotted, which is
+	// the cross-talk the workspace receipt above exists to prevent.
+	if gr, err := engine.LoadGlobalReceipt(); err == nil && len(gr.Repos) > 0 && receiptCovers(gr, cfg.Repo) {
 		if restoreFromGlobalReceipt(eng, cfg, gr) {
 			return
 		}
@@ -287,6 +357,30 @@ func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
 		return
 	}
 	log.Printf("[bootstrap] restored single-repo snapshot for %s", label)
+}
+
+// receiptCovers reports whether a graph receipt includes the given workspace
+// repo, i.e. whether restoring it would give this server its OWN graph. Paths are
+// compared canonically (absolute, symlinks resolved) because a receipt records
+// the path as the writing server resolved it.
+func receiptCovers(gr *facts.GraphReceipt, repo string) bool {
+	want, err := filepath.Abs(repo)
+	if err != nil {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(want); err == nil {
+		want = resolved
+	}
+	for _, r := range gr.Repos {
+		got := r.Path
+		if resolved, err := filepath.EvalSymlinks(got); err == nil {
+			got = resolved
+		}
+		if got == want {
+			return true
+		}
+	}
+	return false
 }
 
 // restoreFromGlobalReceipt reloads the complete multi-repo graph named by the

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/enola-labs/enola/internal/config"
 	"github.com/enola-labs/enola/internal/facts"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 )
@@ -38,6 +39,42 @@ func writeGoRepo(t *testing.T) string {
 	}
 	write("go.mod", "module example.com/smoke\n\ngo 1.25\n")
 	write("main.go", "package main\n\nfunc Greet() string { return \"hi\" }\n\nfunc main() { _ = Greet() }\n")
+	return dir
+}
+
+// engineFor builds an engine whose configured workspace is repo — the equivalent
+// of one agent terminal launching a server there. The returned config is the same
+// pointer the engine holds, as bootstrap.NewEngine hands out.
+func engineFor(t *testing.T, repo string) (*bootstrap.Engine, *config.Config) {
+	t.Helper()
+	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{
+		ConfigPath: filepath.Join(t.TempDir(), "no-such-config.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	cfg.Repo = repo
+	return eng, cfg
+}
+
+// writeBiggerGoRepo creates a Go module with more symbols than writeGoRepo, so a
+// restore that picked up the wrong workspace is detectable by fact count alone.
+func writeBiggerGoRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/bigger\n\ngo 1.25\n")
+	write("main.go", "package main\n\nfunc main() { _ = Alpha() }\n")
+	write("alpha/alpha.go", "package alpha\n\ntype Alpha struct{}\n\nfunc (a Alpha) One() int { return 1 }\n\nfunc (a Alpha) Two() int { return 2 }\n")
+	write("beta/beta.go", "package beta\n\ntype Beta struct{}\n\nfunc (b Beta) Three() int { return 3 }\n\nfunc Helper() {}\n")
 	return dir
 }
 
@@ -137,49 +174,138 @@ func TestAutoLoadSnapshot(t *testing.T) {
 }
 
 // TestAutoLoadSnapshot_FromGlobalReceipt verifies the multi-repo restore path: a
-// prior session's ~/.enola/receipt.json is used to reload the graph on a fresh
-// engine, even when cfg.Repo points somewhere with no snapshot. HOME is isolated so
-// the receipt written by WriteGlobalReceipt is the only one seen.
+// prior session's graph receipt reloads the WHOLE graph — every repo appended to
+// it — and not merely cfg.Repo's own snapshot dir.
+//
+// The proof is that cfg.Repo's own .enola is deleted before the restart, so the
+// single-repo fallback cannot be the source; only the receipt, which points at the
+// appended repo's dir holding the complete store, can supply the facts. HOME is
+// isolated so the receipt written here is the only one seen.
 func TestAutoLoadSnapshot_FromGlobalReceipt(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	// Session 1: generate a snapshot and record it in the global receipt.
+	// Session 1: snapshot the workspace, then append a second repo to the graph.
 	repo := writeGoRepo(t)
-	eng1, cfg, err := bootstrap.NewEngine(bootstrap.Options{
-		ConfigPath: filepath.Join(t.TempDir(), "no-such-config.yaml"),
-	})
-	if err != nil {
-		t.Fatalf("NewEngine: %v", err)
-	}
-	snap, err := eng1.GenerateSnapshot(context.Background(), repo, false)
-	if err != nil {
+	appended := writeBiggerGoRepo(t)
+	eng1, cfg1 := engineFor(t, repo)
+	if _, err := eng1.GenerateSnapshot(context.Background(), repo, false); err != nil {
 		t.Fatalf("GenerateSnapshot: %v", err)
 	}
-	if err := eng1.WriteArtifacts(repo); err != nil {
+	snap, err := eng1.GenerateSnapshot(context.Background(), appended, true)
+	if err != nil {
+		t.Fatalf("GenerateSnapshot (append): %v", err)
+	}
+	// In append mode WriteArtifacts writes the entire store, so the appended
+	// repo's dir holds every repo's facts.
+	if err := eng1.WriteArtifacts(appended); err != nil {
 		t.Fatalf("WriteArtifacts: %v", err)
 	}
 	if err := eng1.WriteGlobalReceipt(); err != nil {
 		t.Fatalf("WriteGlobalReceipt: %v", err)
 	}
 
-	// Session 2 (restart): a brand-new engine whose cfg.Repo has NO snapshot, so a
-	// successful restore can only have come from the global receipt.
-	eng2, cfg2, err := bootstrap.NewEngine(bootstrap.Options{
-		ConfigPath: filepath.Join(t.TempDir(), "no-such-config.yaml"),
-	})
-	if err != nil {
-		t.Fatalf("NewEngine 2: %v", err)
+	// Remove the workspace's own artifacts so a single-repo restore is impossible.
+	if err := os.RemoveAll(filepath.Join(repo, cfg1.Output.Dir)); err != nil {
+		t.Fatal(err)
 	}
-	_ = cfg
-	cfg2.Repo = t.TempDir() // empty dir, no .enola
+
+	// Session 2 (restart) in the same workspace.
+	eng2, cfg2 := engineFor(t, repo)
 	bootstrap.AutoLoadSnapshot(eng2, cfg2)
 
 	if got := eng2.Store().Count(); got != snap.Meta.FactCount {
-		t.Errorf("restored %d facts, want %d", got, snap.Meta.FactCount)
+		t.Errorf("restored %d facts, want %d (the whole multi-repo graph)", got, snap.Meta.FactCount)
+	}
+	if len(eng2.RepoPaths()) != 2 {
+		t.Errorf("restored %d repo paths, want 2", len(eng2.RepoPaths()))
 	}
 	restored := eng2.Snapshot()
 	if restored == nil || restored.Meta.GeneratedAt == "" {
 		t.Fatalf("expected a restored snapshot with generated_at, got %+v", restored)
+	}
+}
+
+// TestAutoLoadSnapshot_PrefersOwnWorkspace is the cross-terminal regression test.
+// A user typically runs one server per agent terminal; the machine-wide receipt
+// describes only whichever generated last. A restart in workspace A must come back
+// holding A's graph, not the graph the other terminal happened to snapshot.
+func TestAutoLoadSnapshot_PrefersOwnWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Terminal 1 snapshots workspace A.
+	repoA := writeGoRepo(t)
+	engA, cfgA := engineFor(t, repoA)
+	snapA, err := engA.GenerateSnapshot(context.Background(), repoA, false)
+	if err != nil {
+		t.Fatalf("GenerateSnapshot(A): %v", err)
+	}
+	if err := engA.WriteArtifacts(repoA); err != nil {
+		t.Fatalf("WriteArtifacts(A): %v", err)
+	}
+	if err := engA.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt(A): %v", err)
+	}
+
+	// Terminal 2 then snapshots a much larger workspace B, becoming the last
+	// writer of ~/.enola/receipt.json.
+	repoB := writeBiggerGoRepo(t)
+	engB, _ := engineFor(t, repoB)
+	snapB, err := engB.GenerateSnapshot(context.Background(), repoB, false)
+	if err != nil {
+		t.Fatalf("GenerateSnapshot(B): %v", err)
+	}
+	if err := engB.WriteArtifacts(repoB); err != nil {
+		t.Fatalf("WriteArtifacts(B): %v", err)
+	}
+	if err := engB.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt(B): %v", err)
+	}
+	if snapA.Meta.FactCount == snapB.Meta.FactCount {
+		t.Fatalf("test setup: both workspaces have %d facts, so the restore cannot be told apart", snapA.Meta.FactCount)
+	}
+
+	// Terminal 1 restarts. It must come back with A's graph.
+	restarted, cfgRestart := engineFor(t, cfgA.Repo)
+	bootstrap.AutoLoadSnapshot(restarted, cfgRestart)
+
+	if got := restarted.Store().Count(); got != snapA.Meta.FactCount {
+		t.Errorf("restored %d facts, want %d (workspace A); %d would be workspace B's graph",
+			got, snapA.Meta.FactCount, snapB.Meta.FactCount)
+	}
+	if snap := restarted.Snapshot(); snap == nil || snap.Meta.RepoPath != snapA.Meta.RepoPath {
+		t.Errorf("restored repo path = %+v, want %s", snap, snapA.Meta.RepoPath)
+	}
+}
+
+// TestAutoLoadSnapshot_IgnoresForeignGlobalReceipt covers the second half of the
+// same cross-talk: a workspace with no receipt of its own must NOT adopt the
+// machine-wide one when that receipt describes someone else's repo. Restoring it
+// would silently hand this server another agent terminal's graph — answering
+// every query about the wrong codebase.
+func TestAutoLoadSnapshot_IgnoresForeignGlobalReceipt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Another terminal snapshots its workspace and writes the machine-wide receipt.
+	foreign := writeBiggerGoRepo(t)
+	engForeign, _ := engineFor(t, foreign)
+	if _, err := engForeign.GenerateSnapshot(context.Background(), foreign, false); err != nil {
+		t.Fatalf("GenerateSnapshot(foreign): %v", err)
+	}
+	if err := engForeign.WriteArtifacts(foreign); err != nil {
+		t.Fatalf("WriteArtifacts(foreign): %v", err)
+	}
+	if err := engForeign.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt(foreign): %v", err)
+	}
+
+	// A server starts in a never-snapshotted workspace. It must come up empty
+	// rather than inheriting the foreign graph.
+	mine, cfg := engineFor(t, t.TempDir())
+	bootstrap.AutoLoadSnapshot(mine, cfg)
+
+	if got := mine.Store().Count(); got != 0 {
+		t.Errorf("restored %d facts into a workspace that has no snapshot; "+
+			"the machine-wide receipt of another server was adopted", got)
 	}
 }
 

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -25,6 +25,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/enola-labs/enola/pkg/bootstrap"
@@ -77,6 +80,20 @@ type Options struct {
 	// Title names the product in the page title, heading and footer. Defaults to
 	// defaultTitle.
 	Title string
+
+	// Tracker is this process's usage tracker, and the ONLY source the page uses
+	// to describe the server it is served by — PID, uptime, dashboard port, the
+	// graph loaded, and this process's own tool counts. Without it the page can
+	// only render the cross-process aggregate, which with several servers running
+	// would attribute a sibling's identity to this one.
+	Tracker *status.Tracker
+
+	// StablePort is an optional fixed loopback port this dashboard also listens
+	// on, in addition to its own ephemeral one, so there is a URL worth
+	// bookmarking. The first server to claim it becomes the "front door"; the
+	// others retry in the background and take it over when that server exits.
+	// Zero disables it.
+	StablePort int
 }
 
 // defaultTitle is the product name shown when Options.Title is empty.
@@ -99,6 +116,12 @@ type engineView interface {
 	// service and cross-repo-edge lists behind the graph-receipt counters (the
 	// receipt itself stores only the counts). Reads are concurrency-safe.
 	Store() *facts.Store
+	// GraphReceipt describes the graph THIS engine holds, assembled in memory.
+	// It is what the graph panel renders, so that panel and the store-derived
+	// panels below it can never describe different repo sets — which reading the
+	// machine-wide ~/.enola/receipt.json would allow whenever a second server is
+	// running. Nil when no snapshot is loaded.
+	GraphReceipt() *facts.GraphReceipt
 }
 
 // Server is a running dashboard HTTP server bound to a loopback port.
@@ -109,6 +132,11 @@ type Server struct {
 	tmpl   *template.Template
 	labels map[string]string // insight-source allowlist + display labels
 	title  string            // product name in the page title/heading/footer
+	mux    *http.ServeMux
+
+	// frontDoor is set once this server claims the stable port. Read from every
+	// request handler and written by the claim goroutine, hence atomic.
+	frontDoor atomic.Bool
 }
 
 // Start binds a free ephemeral port on 127.0.0.1, serves the dashboard from a
@@ -137,16 +165,96 @@ func Start(eng *bootstrap.Engine, opts Options) (*Server, error) {
 		title:  titleOr(opts.Title),
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", s.handleIndex)
+	s.mux = http.NewServeMux()
+	s.mux.HandleFunc("/", s.handleIndex)
 
 	go func() {
-		if err := http.Serve(ln, mux); err != nil {
+		if err := http.Serve(ln, s.mux); err != nil {
 			log.Printf("dashboard: serve stopped: %v", err)
 		}
 	}()
 
+	if opts.StablePort > 0 {
+		go s.claimStablePort(opts.StablePort)
+	}
+
 	return s, nil
+}
+
+// DefaultStablePort is the shared, bookmarkable dashboard port used when neither
+// the config nor the environment names one.
+const DefaultStablePort = 7171
+
+// StablePortEnv overrides the configured shared-URL port. Set it to "0" or "off"
+// to disable the shared URL and keep only this server's ephemeral port.
+const StablePortEnv = "ENOLA_DASHBOARD_PORT"
+
+// ResolveStablePort decides which fixed port the dashboard should also listen on:
+// ENOLA_DASHBOARD_PORT if set, else the configured port, else DefaultStablePort.
+// Zero (from either source, or "off" in the environment) disables it; a negative
+// configured value does the same. An unparseable environment value is reported and
+// ignored rather than silently dropping the feature.
+func ResolveStablePort(configured int) int {
+	if v, ok := os.LookupEnv(StablePortEnv); ok {
+		v = strings.TrimSpace(v)
+		if v == "off" || v == "none" {
+			return 0
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			log.Printf("dashboard: ignoring %s=%q: not a port number", StablePortEnv, v)
+		} else {
+			return max(n, 0)
+		}
+	}
+	switch {
+	case configured < 0:
+		return 0
+	case configured == 0:
+		return DefaultStablePort
+	default:
+		return configured
+	}
+}
+
+// stableRetryInterval is how often a server that lost the race for the stable
+// port re-tries it, so the bookmarkable URL is picked up again within seconds of
+// the owning server exiting.
+const stableRetryInterval = 5 * time.Second
+
+// claimStablePort keeps trying to bind the stable loopback port and serves the
+// same page from it once it succeeds. Exactly one server can hold the port at a
+// time — the OS decides the race — and every server keeps retrying until it wins,
+// so the URL survives the front-door terminal closing.
+//
+// It runs for the life of the process: if the listener ever fails, the loop
+// resumes trying. Failures are logged at most once per state change; a port held
+// by another server is the normal case, not an error.
+func (s *Server) claimStablePort(port int) {
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	for {
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			time.Sleep(stableRetryInterval)
+			continue
+		}
+
+		s.frontDoor.Store(true)
+		if s.opts.Tracker != nil {
+			s.opts.Tracker.SetFrontDoor(true)
+		}
+		log.Printf("dashboard: serving the shared URL http://%s", addr)
+
+		// Serve blocks until the listener breaks; then this server is no longer
+		// the front door and the loop goes back to competing for the port.
+		err = http.Serve(ln, s.mux)
+		s.frontDoor.Store(false)
+		if s.opts.Tracker != nil {
+			s.opts.Tracker.SetFrontDoor(false)
+		}
+		log.Printf("dashboard: shared URL listener stopped: %v", err)
+		time.Sleep(stableRetryInterval)
+	}
 }
 
 // Port returns the loopback port the dashboard is listening on.
@@ -202,11 +310,44 @@ func buildTemplate(overlay string) (*template.Template, error) {
 	return t, nil
 }
 
-// toolRow is one row of the tool-usage table (session vs lifetime total).
+// toolRow is one row of the tool-usage table (this server vs lifetime total).
 type toolRow struct {
 	Name    string
 	Session int
 	Total   int
+}
+
+// instanceRow is one row of the instances table: another enola server running
+// right now, with the URL of its dashboard. Self marks the one serving this page.
+type instanceRow struct {
+	PID       int
+	Binary    string
+	Repos     string
+	Uptime    string
+	Calls     int
+	URL       string
+	Self      bool
+	FrontDoor bool
+}
+
+// instanceRows projects the live-instance registry into table rows. selfPID is
+// the process serving this page, which is highlighted rather than hidden — a
+// user comparing two dashboards needs to see which row is the page they are on.
+func instanceRows(instances []status.Instance, selfPID int, now time.Time) []instanceRow {
+	rows := make([]instanceRow, 0, len(instances))
+	for _, inst := range instances {
+		rows = append(rows, instanceRow{
+			PID:       inst.PID,
+			Binary:    inst.Binary,
+			Repos:     inst.RepoLabels(),
+			Uptime:    formatDuration(now.Sub(inst.StartTime)),
+			Calls:     inst.SessionCalls(),
+			URL:       inst.URL(),
+			Self:      inst.PID == selfPID,
+			FrontDoor: inst.FrontDoor,
+		})
+	}
+	return rows
 }
 
 // valueRow is one row of the value-estimate table (pre-formatted for display).
@@ -222,6 +363,8 @@ type pageData struct {
 	RefreshSeconds int
 	Title          string
 
+	// This server's own identity. Never sourced from the cross-process aggregate:
+	// with several agent terminals open, that would name a sibling process.
 	Running       bool
 	PID           int
 	Port          int
@@ -229,6 +372,20 @@ type pageData struct {
 	StartedAt     string
 	TrackingSince string
 	ReposTracked  int
+	Binary        string
+	ConfigPath    string
+	WorkDir       string
+	ReposLoaded   string
+	SessionCalls  int
+
+	// FrontDoor is true when this server currently owns the stable URL, and
+	// StableURL names it (empty when the feature is off).
+	FrontDoor bool
+	StableURL string
+
+	// Instances is every enola server running right now, this one included, so a
+	// user with several terminals open can see them all and switch between them.
+	Instances []instanceRow
 
 	Tools      []toolRow
 	Values     []valueRow
@@ -281,22 +438,50 @@ func (s *Server) buildPage() pageData {
 		Port:           s.port,
 	}
 
+	now := time.Now()
+
+	// Identity comes from THIS process's tracker. A user running one server per
+	// agent terminal must be able to tell, from the page alone, which one they are
+	// looking at — so nothing here may come from the cross-process aggregate.
+	var self status.Instance
+	if s.opts.Tracker != nil {
+		self = s.opts.Tracker.Self()
+		data.Running = true
+		data.PID = self.PID
+		data.Binary = self.Binary
+		if self.Version != "" {
+			data.Binary += " " + self.Version
+		}
+		data.ConfigPath = self.ConfigPath
+		data.WorkDir = self.WorkDir
+		data.ReposLoaded = self.RepoLabels()
+		data.SessionCalls = self.SessionCalls()
+		if !self.StartTime.IsZero() {
+			data.StartedAt = self.StartTime.Format("2006-01-02 15:04:05")
+			data.Uptime = formatDuration(now.Sub(self.StartTime))
+		}
+		data.Tools = toolRows(nil, self.SessionCounts) // totals filled in below
+	}
+
+	data.FrontDoor = s.frontDoor.Load()
+	if s.opts.StablePort > 0 {
+		data.StableURL = fmt.Sprintf("http://127.0.0.1:%d", s.opts.StablePort)
+	}
+
+	// Lifetime totals and the per-repo tracking window are genuinely cross-process
+	// figures, and are labelled as such on the page.
 	ss := status.ServerSnapshot()
 	if ss.Found {
-		data.Running = ss.Alive
-		data.PID = ss.PID
 		data.ReposTracked = ss.Repos
-		if !ss.StartTime.IsZero() {
-			data.StartedAt = ss.StartTime.Format("2006-01-02 15:04:05")
-			if ss.Alive {
-				data.Uptime = formatDuration(time.Since(ss.StartTime))
-			}
-		}
 		if !ss.TrackingSince.IsZero() {
 			data.TrackingSince = ss.TrackingSince.Format("2006-01-02 15:04:05")
 		}
-		data.Tools = toolRows(ss.GrandTotal, ss.Session)
+		data.Tools = toolRows(ss.GrandTotal, self.SessionCounts)
 		data.Values, data.ValueTotal = valueRows(ss.GrandTotal)
+		data.Instances = instanceRows(ss.Instances, self.PID, now)
+	}
+	if len(data.Instances) == 0 {
+		data.Instances = instanceRows(status.LiveInstances(), self.PID, now)
 	}
 
 	// Current-snapshot receipt: prefer the live in-memory receipt, falling back
@@ -311,12 +496,15 @@ func (s *Server) buildPage() pageData {
 		data.ReceiptNote = "No snapshot loaded yet — run generate_snapshot to populate this."
 	}
 
-	// Graph-wide receipt: ~/.enola/receipt.json on disk.
-	if gv, err := readGraphReceipt(); err != nil {
-		data.GraphNote = "No graph receipt yet — it is written to ~/.enola/receipt.json when a snapshot is generated."
-	} else {
+	// Graph receipt: assembled from THIS engine's live graph, so the repo list
+	// always describes the same store as the services/insights/coverage panels
+	// below it. Reading the shared ~/.enola/receipt.json here would show whichever
+	// repos another running server snapshotted last.
+	if gv := s.eng.GraphReceipt(); gv != nil {
 		data.HasGraph = true
 		data.Graph = gv
+	} else {
+		data.GraphNote = "No graph loaded in this server yet — run generate_snapshot to populate this."
 	}
 
 	// Service and cross-repo-edge lists from the live store, backing the clickable
@@ -398,24 +586,7 @@ func (s *Server) currentInsights() []facts.Insight {
 	return ins
 }
 
-// readGraphReceipt reads and parses the graph-wide receipt at ~/.enola/receipt.json.
-func readGraphReceipt() (*facts.GraphReceipt, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	b, err := os.ReadFile(filepath.Join(home, ".enola", "receipt.json"))
-	if err != nil {
-		return nil, err
-	}
-	var gv facts.GraphReceipt
-	if err := json.Unmarshal(b, &gv); err != nil {
-		return nil, err
-	}
-	return &gv, nil
-}
-
-// toolRows builds the sorted union of tool-usage rows (session and lifetime).
+// toolRows builds the sorted union of tool-usage rows (this server and lifetime).
 func toolRows(total, session map[string]int) []toolRow {
 	set := make(map[string]struct{}, len(total)+len(session))
 	for k := range total {

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -25,6 +25,7 @@ type fakeArtifacts struct {
 	activeRepo string
 	outputDir  string
 	store      *facts.Store
+	graph      *facts.GraphReceipt
 }
 
 func (f fakeArtifacts) GetArtifact(name string) ([]byte, error) {
@@ -42,6 +43,8 @@ func (f fakeArtifacts) ActiveRepo() string { return f.activeRepo }
 func (f fakeArtifacts) OutputDir(repoPath string) string { return f.outputDir }
 
 func (f fakeArtifacts) Store() *facts.Store { return f.store }
+
+func (f fakeArtifacts) GraphReceipt() *facts.GraphReceipt { return f.graph }
 
 // newTestServer builds a Server exactly as Start does — parsed template and
 // merged insight labels included — but without binding a port. Constructing the
@@ -88,7 +91,7 @@ func TestHandlerDegradesGracefully(t *testing.T) {
 		"refreshes automatically every 30", // stated on the page
 		"127.0.0.1:54321",                  // the dashboard port/URL
 		"No snapshot loaded yet",           // degraded current receipt
-		"No graph receipt yet",             // degraded graph receipt
+		"No graph loaded in this server",   // degraded graph receipt
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(body, want) {
@@ -111,13 +114,19 @@ func TestHandlerRendersReceipts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write a graph receipt into the isolated ~/.enola/receipt.json.
-	graph := facts.GraphReceipt{
+	// The graph panel must come from THIS engine. To prove it does, plant a
+	// different graph in the machine-wide ~/.enola/receipt.json — the file another
+	// running server would have overwritten — and assert none of it reaches the page.
+	graph := &facts.GraphReceipt{
 		SnapshotID:   "graph-xyz",
 		ServiceCount: 7,
 		Repos:        []facts.GraphRepoEntry{{Label: "backend", Path: "/x/backend", FactCount: 100}},
 	}
-	gb, err := json.Marshal(graph)
+	foreign := facts.GraphReceipt{
+		SnapshotID: "graph-from-another-server",
+		Repos:      []facts.GraphRepoEntry{{Label: "someone-elses-repo", Path: "/x/elsewhere"}},
+	}
+	fb, err := json.Marshal(foreign)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,11 +134,11 @@ func TestHandlerRendersReceipts(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), gb, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), fb, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	s := newTestServer(8080, fakeArtifacts{receipt: rb})
+	s := newTestServer(8080, fakeArtifacts{receipt: rb, graph: graph})
 	rec := httptest.NewRecorder()
 	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
@@ -140,6 +149,12 @@ func TestHandlerRendersReceipts(t *testing.T) {
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"graph-from-another-server", "someone-elses-repo"} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("body contains %q — the graph panel must render THIS engine's graph, "+
+				"not the machine-wide receipt another server may have written", unwanted)
 		}
 	}
 }
@@ -245,22 +260,11 @@ func TestGraphDetails(t *testing.T) {
 
 // TestHandlerRendersModals verifies the clickable counters and modal contents are
 // rendered when the store holds service facts. The clickable count buttons live in
-// the graph-receipt cards, so a graph receipt must exist on disk for them to render.
+// the graph-receipt cards, so the engine must report a graph for them to render.
 func TestHandlerRendersModals(t *testing.T) {
-	home := isolateHome(t)
+	isolateHome(t)
 
-	graph := facts.GraphReceipt{SnapshotID: "graph-xyz", ServiceCount: 2, CrossRepoEdgeCount: 1}
-	gb, err := json.Marshal(graph)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dir := filepath.Join(home, ".enola")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), gb, 0o644); err != nil {
-		t.Fatal(err)
-	}
+	graph := &facts.GraphReceipt{SnapshotID: "graph-xyz", ServiceCount: 2, CrossRepoEdgeCount: 1}
 
 	st := facts.NewStore()
 	st.Add(facts.Fact{Kind: facts.KindService, Name: "frontend", Relations: []facts.Relation{
@@ -268,7 +272,7 @@ func TestHandlerRendersModals(t *testing.T) {
 	}})
 	st.Add(facts.Fact{Kind: facts.KindService, Name: "backend"})
 
-	s := newTestServer(8080, fakeArtifacts{err: errors.New("no receipt"), store: st})
+	s := newTestServer(8080, fakeArtifacts{err: errors.New("no receipt"), store: st, graph: graph})
 	rec := httptest.NewRecorder()
 	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
@@ -428,24 +432,13 @@ func TestMergedLabelsDoesNotMutatePackageMap(t *testing.T) {
 }
 
 // TestHandlerRendersInsightsModal verifies the clickable Insights counter and the
-// modal's grouped bars render when insights.json is available via GetArtifact. A
-// graph receipt is written to disk so the graph card (which hosts one clickable
-// counter) renders.
+// modal's grouped bars render when insights.json is available via GetArtifact. The
+// engine reports a graph so the graph card (which hosts one clickable counter)
+// renders.
 func TestHandlerRendersInsightsModal(t *testing.T) {
-	home := isolateHome(t)
+	isolateHome(t)
 
-	graph := facts.GraphReceipt{SnapshotID: "graph-xyz", InsightCount: 2}
-	gb, err := json.Marshal(graph)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dir := filepath.Join(home, ".enola")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "receipt.json"), gb, 0o644); err != nil {
-		t.Fatal(err)
-	}
+	graph := &facts.GraphReceipt{SnapshotID: "graph-xyz", InsightCount: 2}
 
 	insights := []facts.Insight{
 		{Source: "god-class", Title: "UserService is a god class", Confidence: 0.9},
@@ -456,7 +449,7 @@ func TestHandlerRendersInsightsModal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := newTestServer(8080, fakeArtifacts{insights: ib})
+	s := newTestServer(8080, fakeArtifacts{insights: ib, graph: graph})
 	rec := httptest.NewRecorder()
 	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 

--- a/pkg/dashboard/identity_test.go
+++ b/pkg/dashboard/identity_test.go
@@ -1,0 +1,182 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/enola-labs/enola/pkg/facts"
+	"github.com/enola-labs/enola/pkg/status"
+)
+
+// TestPageDescribesItsOwnServer is the regression test for the complaint that
+// started this work: with one enola server per agent terminal, the dashboard used
+// to fill its Server/PID/uptime cards from the cross-process aggregate, which
+// picks whichever process started last. A page served by this process would then
+// announce a sibling's PID.
+//
+// Here a foreign instance is registered with a NEWER start time — exactly the
+// case that used to win — and the page must still describe this process.
+func TestPageDescribesItsOwnServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const foreignPID = 999999 // never a live PID, so it must not be picked
+	registerForeign(t, status.Instance{
+		PID:           foreignPID,
+		StartTime:     time.Now().Add(time.Hour),
+		Heartbeat:     time.Now().Add(time.Hour),
+		Binary:        "enola",
+		DashboardPort: 59999,
+	})
+
+	tr := status.NewTracker("/tmp/my-repo")
+	tr.SetStartTime(time.Now().Add(-5 * time.Minute))
+	tr.SetIdentity(status.Identity{Binary: "enola-enterprise", Version: "4.2.0", WorkDir: "/tmp/my-workspace"})
+	tr.SetGraphFunc(func() status.GraphState {
+		return status.GraphState{Repos: []status.InstanceRepo{{Label: "my-repo", Path: "/tmp/my-repo"}}}
+	})
+	tr.PersistStartup()
+	defer tr.Close()
+
+	s := newTestServer(8080, fakeArtifacts{}, Options{Tracker: tr})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"PID " + strconv.Itoa(os.Getpid()), // this process, not the newer sibling
+		"enola-enterprise 4.2.0",           // which binary is serving the page
+		"/tmp/my-workspace",                // which terminal launched it
+		"my-repo",                          // what THIS server has loaded
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q — the page must describe the process serving it", want)
+		}
+	}
+	if strings.Contains(body, "PID "+strconv.Itoa(foreignPID)) {
+		t.Error("body names another server's PID as its own")
+	}
+}
+
+// TestPageListsLiveInstances covers the switcher: a user with several agent
+// terminals open must be able to reach every other server's dashboard from any
+// one of them, and see at a glance which page they are on.
+func TestPageListsLiveInstances(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// A sibling that is genuinely alive (this test's own process, under a start
+	// time far enough back to be a distinct record) would collide with the
+	// tracker's record, so use the parent process: alive, and not us.
+	sibling := os.Getppid()
+	registerForeign(t, status.Instance{
+		PID:           sibling,
+		StartTime:     time.Now().Add(-time.Minute),
+		Heartbeat:     time.Now(),
+		Binary:        "enola",
+		DashboardPort: 54545,
+		FrontDoor:     true,
+		Repos:         []status.InstanceRepo{{Label: "other-repo", Path: "/tmp/other"}},
+	})
+
+	tr := status.NewTracker("/tmp/my-repo")
+	tr.SetStartTime(time.Now())
+	tr.SetDashboardPort(8080)
+	tr.SetIdentity(status.Identity{Binary: "enola"})
+	tr.PersistStartup()
+	defer tr.Close()
+
+	s := newTestServer(8080, fakeArtifacts{}, Options{Tracker: tr})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"Servers running",
+		"http://127.0.0.1:54545", // a clickable link to the sibling's dashboard
+		"other-repo",             // what the sibling has loaded
+		"this page",              // the row marking the current dashboard
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+// TestPageWithoutTrackerStillRenders guards the zero-Options path: a caller that
+// supplies no tracker (as the tests and any minimal embedder do) must still get a
+// page rather than a nil dereference.
+func TestPageWithoutTrackerStillRenders(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	s := newTestServer(8080, fakeArtifacts{graph: &facts.GraphReceipt{SnapshotID: "g1"}})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "g1") {
+		t.Error("body missing the graph receipt")
+	}
+}
+
+func TestResolveStablePort(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		setEnv     bool
+		configured int
+		want       int
+	}{
+		{name: "default when unset", want: DefaultStablePort},
+		{name: "configured port wins over default", configured: 9000, want: 9000},
+		{name: "negative config disables", configured: -1, want: 0},
+		{name: "env overrides config", env: "9100", setEnv: true, configured: 9000, want: 9100},
+		{name: "env off disables", env: "off", setEnv: true, configured: 9000, want: 0},
+		{name: "env zero disables", env: "0", setEnv: true, want: 0},
+		{name: "unparseable env falls back to config", env: "banana", setEnv: true, configured: 9000, want: 9000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(StablePortEnv, tt.env)
+			} else if err := os.Unsetenv(StablePortEnv); err != nil {
+				t.Fatal(err)
+			}
+			if got := ResolveStablePort(tt.configured); got != tt.want {
+				t.Errorf("ResolveStablePort(%d) = %d, want %d", tt.configured, got, tt.want)
+			}
+		})
+	}
+}
+
+// registerForeign plants another server's record in the isolated registry,
+// standing in for a second agent terminal's enola process. It writes the file
+// directly — the on-disk layout is the registry's cross-process contract, and
+// pkg/status offers no way for one process to register another.
+func registerForeign(t *testing.T, inst status.Instance) {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".enola", "instances")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := fmt.Sprintf("%d-%d.json", inst.PID, inst.StartTime.UnixNano())
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -40,6 +40,8 @@
     th { background: var(--th); font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; color: var(--muted); }
     td.num, th.num { text-align: right; }
     tr.total td { font-weight: 700; border-top: 2px solid var(--border); }
+    tr.self-row td { background: color-mix(in srgb, var(--accent) 10%, transparent); }
+    a { color: var(--accent); }
     .note { color: var(--muted); font-style: italic; }
     .chips { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .2rem; }
     .chip { background: var(--th); border: 1px solid var(--border); border-radius: 6px; padding: .05rem .45rem; font-size: .8rem; }
@@ -117,25 +119,50 @@
     <h1>{{.Title}}</h1>
     {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
   </header>
-  <div class="refresh">This page refreshes automatically every {{.RefreshSeconds}} seconds. Served on <code>http://127.0.0.1:{{.Port}}</code>.</div>
+  <div class="refresh">This page refreshes automatically every {{.RefreshSeconds}} seconds. Served on <code>http://127.0.0.1:{{.Port}}</code>{{if .FrontDoor}} and on the shared URL <code>{{.StableURL}}</code>{{end}}.</div>
 
+  <h2>This server</h2>
+  <p class="note">Everything on this page describes this one process and the graph it holds. Other servers are listed below.</p>
   <div class="grid">
-    <div class="card"><div class="k">Server</div><div class="v">{{if .Running}}PID {{.PID}}{{else}}stopped{{end}}</div></div>
+    <div class="card"><div class="k">Process</div><div class="v">PID {{.PID}}</div></div>
+    {{if .Binary}}<div class="card"><div class="k">Binary</div><div class="v">{{.Binary}}</div></div>{{end}}
     {{if .Uptime}}<div class="card"><div class="k">Uptime</div><div class="v">{{.Uptime}}</div></div>{{end}}
     {{if .StartedAt}}<div class="card"><div class="k">Started</div><div class="v">{{.StartedAt}}</div></div>{{end}}
-    {{if .TrackingSince}}<div class="card"><div class="k">Tracking since</div><div class="v">{{.TrackingSince}}</div></div>{{end}}
-    <div class="card"><div class="k">Repos tracked</div><div class="v">{{.ReposTracked}}</div></div>
-    <div class="card"><div class="k">Dashboard port</div><div class="v">{{.Port}}</div></div>
+    {{if .ReposLoaded}}<div class="card"><div class="k">Repos loaded</div><div class="v">{{.ReposLoaded}}</div></div>{{end}}
+    <div class="card"><div class="k">Calls served</div><div class="v">{{.SessionCalls}}</div></div>
+    <div class="card"><div class="k">Dashboard port</div><div class="v">{{.Port}}{{if .FrontDoor}} <span class="badge on">shared URL</span>{{end}}</div></div>
   </div>
+  {{if .WorkDir}}<div class="card" style="margin-top:.75rem"><div class="k">Launched from</div><div class="v">{{.WorkDir}}{{if .ConfigPath}} <span class="note" style="font-size:.85rem;font-weight:400">(config: {{.ConfigPath}})</span>{{end}}</div></div>{{end}}
+
+  {{if .Instances}}
+  <h2>Servers running <span class="note">({{len .Instances}})</span></h2>
+  <p class="note">One enola server runs per agent session, each with its own graph. Follow a link to inspect another one.</p>
+  <div class="table-scroll"><table>
+    <thead><tr><th>PID</th><th>Binary</th><th>Repos</th><th class="num">Uptime</th><th class="num">Calls</th><th>Dashboard</th></tr></thead>
+    <tbody>
+      {{range .Instances}}<tr{{if .Self}} class="self-row"{{end}}>
+        <td>{{.PID}}{{if .Self}} <span class="badge on">this page</span>{{end}}</td>
+        <td>{{.Binary}}</td>
+        <td>{{.Repos}}</td>
+        <td class="num">{{.Uptime}}</td>
+        <td class="num">{{.Calls}}</td>
+        <td>{{if .URL}}<a href="{{.URL}}">{{.URL}}</a>{{if .FrontDoor}} <span class="chip">shared</span>{{end}}{{else}}<span class="note">none</span>{{end}}</td>
+      </tr>{{end}}
+    </tbody>
+  </table></div>
+  {{end}}
 
   <h2>Tool usage</h2>
   {{if .Tools}}
   <div class="table-scroll"><table>
-    <thead><tr><th>Tool</th><th class="num">Session</th><th class="num">Total</th></tr></thead>
+    <thead><tr><th>Tool</th><th class="num">This server</th><th class="num">All servers, lifetime</th></tr></thead>
     <tbody>
       {{range .Tools}}<tr><td>{{.Name}}</td><td class="num">{{.Session}}</td><td class="num">{{.Total}}</td></tr>{{end}}
     </tbody>
   </table></div>
+  <p class="note">
+    "This server" counts only the calls this process has served{{if .TrackingSince}}; the lifetime column sums every repo on this machine since {{.TrackingSince}}{{end}}{{if .ReposTracked}} ({{.ReposTracked}} repo(s) tracked){{end}}.
+  </p>
   {{else}}<p class="note">No tool calls recorded yet.</p>{{end}}
 
   <h2>Value estimate <span class="note">(approximate)</span></h2>
@@ -181,7 +208,7 @@
   </div>
   {{end}}{{else}}<p class="note">{{.ReceiptNote}}</p>{{end}}
 
-  <h2>Graph receipt <span class="note">(~/.enola/receipt.json)</span></h2>
+  <h2>Graph receipt <span class="note">(this server's graph)</span></h2>
   {{if .HasGraph}}{{with .Graph}}
   <div class="grid">
     <div class="card"><div class="k">Snapshot ID</div><div class="v">{{.SnapshotID}}</div></div>

--- a/pkg/status/aggregate.go
+++ b/pkg/status/aggregate.go
@@ -72,26 +72,41 @@ func AggregateUsage(dir string) (Aggregate, error) {
 	return agg, nil
 }
 
-// ServerStatus is the aggregated view of a single MCP server's activity across
-// every repo it has served: the historical grand total plus the current
-// session. This is what plain --status renders — it is not tied to any cwd.
+// ServerStatus is the aggregated view of enola activity across every repo that
+// has been served: the historical grand total plus what the currently-running
+// servers have done. This is what plain --status renders — it is not tied to any
+// cwd.
+//
+// Several servers commonly run at once (one per agent terminal), so Instances
+// is the authoritative list and the scalar PID/StartTime/DashboardPort/Alive
+// fields describe only the *primary* instance — this process when the caller is
+// itself a server, otherwise the most recently started live one. Anything that
+// must describe a specific process (a dashboard naming itself) should read
+// Tracker.Self or Instances rather than these.
 type ServerStatus struct {
 	GrandTotal    map[string]int // sum of ToolCounts across all repos (lifetime)
-	Session       map[string]int // sum of SessionCounts for the current server run
-	StartTime     time.Time      // newest StartTime seen (the current/most-recent run)
-	PID           int            // PID of that run
-	DashboardPort int            // localhost HTTP dashboard port of that run (0 if none)
-	Alive         bool           // whether that PID is still running
+	Session       map[string]int // sum of SessionCounts across live instances
+	Instances     []Instance     // every server running right now, oldest first
+	StartTime     time.Time      // primary instance's start time
+	PID           int            // primary instance's PID
+	DashboardPort int            // primary instance's dashboard port (0 if none)
+	Alive         bool           // whether any server is running
 	TrackingSince time.Time      // earliest TrackingSince across all repos
 	Repos         int            // number of repos with recorded usage
 	Found         bool           // false if no usage files exist
 }
 
 // AggregateServer collapses all per-repo usage files in dir into one server
-// view. The grand total sums every file; the session sums only files written by
-// the current server run — identified as those sharing the newest StartTime, so
-// stale session counts from a previous run (files not re-touched yet) are
-// excluded. Best-effort: unreadable/malformed files are skipped.
+// view, and overlays the live-instance registry.
+//
+// The grand total sums every usage file. Live process state — which servers are
+// running, their PIDs, dashboard ports and session counts — comes from the
+// registry (see instance.go), because the usage files are shared by every
+// process and their per-process fields are whatever the last writer happened to
+// stamp. When the registry is empty (no server running, or records written by an
+// older build) it falls back to the previous heuristic: treat the file with the
+// newest StartTime as the server, and count sessions only from files sharing it.
+// Best-effort: unreadable/malformed files are skipped.
 func AggregateServer(dir string) ServerStatus {
 	ss := ServerStatus{
 		GrandTotal: make(map[string]int),
@@ -124,22 +139,39 @@ func AggregateServer(dir string) ServerStatus {
 	ss.Found = true
 	ss.Repos = len(infos)
 
-	// First pass: grand total, newest StartTime, earliest TrackingSince.
+	// Lifetime totals and the tracking window come from the shared usage files.
 	for _, info := range infos {
 		for k, v := range info.ToolCounts {
 			ss.GrandTotal[k] += v
-		}
-		if info.StartTime.After(ss.StartTime) {
-			ss.StartTime = info.StartTime
-			ss.PID = info.PID
-			ss.DashboardPort = info.DashboardPort
 		}
 		if !info.TrackingSince.IsZero() && (ss.TrackingSince.IsZero() || info.TrackingSince.Before(ss.TrackingSince)) {
 			ss.TrackingSince = info.TrackingSince
 		}
 	}
 
-	// Second pass: session counts only from files belonging to the current run.
+	// Live process state comes from the registry when it has anything to say.
+	if ss.Instances = LiveInstances(); len(ss.Instances) > 0 {
+		for _, inst := range ss.Instances {
+			for k, v := range inst.SessionCounts {
+				ss.Session[k] += v
+			}
+		}
+		primary := primaryInstance(ss.Instances)
+		ss.PID = primary.PID
+		ss.StartTime = primary.StartTime
+		ss.DashboardPort = primary.DashboardPort
+		ss.Alive = true
+		return ss
+	}
+
+	// No registry: fall back to the newest-StartTime heuristic over usage files.
+	for _, info := range infos {
+		if info.StartTime.After(ss.StartTime) {
+			ss.StartTime = info.StartTime
+			ss.PID = info.PID
+			ss.DashboardPort = info.DashboardPort
+		}
+	}
 	for _, info := range infos {
 		if info.StartTime.Equal(ss.StartTime) {
 			for k, v := range info.SessionCounts {
@@ -150,6 +182,20 @@ func AggregateServer(dir string) ServerStatus {
 
 	ss.Alive = isProcessAlive(ss.PID)
 	return ss
+}
+
+// primaryInstance picks the instance the scalar ServerStatus fields describe:
+// this process when the caller is itself a running server (so a server never
+// reports a sibling as itself), otherwise the most recently started one.
+// instances must be non-empty and sorted oldest-first, as LiveInstances returns.
+func primaryInstance(instances []Instance) Instance {
+	self := os.Getpid()
+	for _, inst := range instances {
+		if inst.PID == self {
+			return inst
+		}
+	}
+	return instances[len(instances)-1]
 }
 
 // PrintStatusAll renders the cross-repo aggregate to stderr. Because the stats

--- a/pkg/status/atomic.go
+++ b/pkg/status/atomic.go
@@ -1,0 +1,35 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to a temp file in the destination directory and
+// renames it over path, so a concurrent reader never observes a torn or partial
+// file. Several enola processes read each other's status files while they are
+// being rewritten, which makes the rename the only safe publication step.
+//
+// It mirrors the engine's writer of the same name (internal/engine/global_receipt.go);
+// duplicated rather than exported so pkg/status keeps depending on nothing but
+// the standard library.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/pkg/status/filelock_unix.go
+++ b/pkg/status/filelock_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package status
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockFile is an exclusive advisory lock held across processes for the duration
+// of a read-modify-write of a shared counter file.
+type lockFile struct {
+	f *os.File
+}
+
+// acquireLock blocks until it holds an exclusive lock on path+".lock". The lock
+// file itself is never read — only its descriptor matters — so a leftover file
+// from a crashed process is harmless: flock is released by the kernel when the
+// owning process dies.
+//
+// A failure to lock is returned rather than fatal; callers degrade to an
+// unsynchronized write, which is no worse than the pre-lock behaviour.
+func acquireLock(path string) (*lockFile, error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return &lockFile{f: f}, nil
+}
+
+// release unlocks and closes the lock file. Safe on a nil receiver so callers
+// can defer it unconditionally.
+func (l *lockFile) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+}

--- a/pkg/status/filelock_windows.go
+++ b/pkg/status/filelock_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package status
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockFile is an exclusive lock held across processes for the duration of a
+// read-modify-write of a shared counter file.
+type lockFile struct {
+	f  *os.File
+	ov windows.Overlapped
+}
+
+// acquireLock blocks until it holds an exclusive lock on path+".lock", using
+// LockFileEx — the Windows counterpart to flock. Like flock, the lock is
+// released by the OS if the owning process dies, so a leftover lock file from a
+// crash does not wedge later runs.
+func acquireLock(path string) (*lockFile, error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	l := &lockFile{f: f}
+	if err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0, 1, 0, &l.ov,
+	); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return l, nil
+}
+
+// release unlocks and closes the lock file. Safe on a nil receiver so callers
+// can defer it unconditionally.
+func (l *lockFile) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = windows.UnlockFileEx(windows.Handle(l.f.Fd()), 0, 1, 0, &l.ov)
+	_ = l.f.Close()
+}

--- a/pkg/status/instance.go
+++ b/pkg/status/instance.go
@@ -1,0 +1,236 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// An enola MCP server is launched once per agent/terminal session, so a user
+// commonly has several running at the same time — different repos, different
+// binaries (enola / enola-enterprise), each with its own in-memory graph and its
+// own dashboard on its own ephemeral port.
+//
+// The instance registry is what makes that fleet observable. Every server writes
+// one record describing itself to
+//
+//	~/.enola/instances/<pid>-<startUnixNano>.json
+//
+// and removes it on exit. Each file has exactly one writer (its own process), so
+// unlike the per-repo usage files there is no write contention and no need for a
+// lock. Readers (LiveInstances) reap records whose process is gone, so a hard
+// kill self-heals.
+//
+// The start-time suffix defeats PID reuse: a recycled PID cannot resurrect a
+// dead instance's record.
+
+// instancesDirName is the registry directory under ~/.enola.
+const instancesDirName = "instances"
+
+// heartbeatInterval is how often a running server refreshes its record so an
+// idle instance (no tool calls) still looks alive to readers.
+const heartbeatInterval = 30 * time.Second
+
+// staleAfter bounds how long a record with a live PID may go un-refreshed before
+// readers treat it as dead. It is a backstop for a PID that was reused by an
+// unrelated process between the write and the read; generously above
+// heartbeatInterval so a busy or paused server is never reaped by mistake.
+const staleAfter = 10 * time.Minute
+
+// InstanceRepo is one repository loaded into an instance's graph.
+type InstanceRepo struct {
+	Label     string `json:"label"`
+	Path      string `json:"path"`
+	FactCount int    `json:"fact_count,omitempty"`
+}
+
+// Instance is one running enola MCP server, as it describes itself on disk. It
+// answers the question a user with several agent terminals open cannot otherwise
+// answer: which process is this, what has it loaded, and where is its dashboard.
+type Instance struct {
+	PID       int       `json:"pid"`
+	StartTime time.Time `json:"start_time"`
+	Heartbeat time.Time `json:"heartbeat"`
+
+	// Identity of the binary and the launch context — what distinguishes two
+	// instances at a glance.
+	Binary     string `json:"binary"`               // "enola" / "enola-enterprise"
+	Version    string `json:"version,omitempty"`    // build version
+	Licensed   bool   `json:"licensed,omitempty"`   // enterprise features active
+	ConfigPath string `json:"config_path,omitempty"`// resolved mcp-arch.yaml
+	WorkDir    string `json:"work_dir,omitempty"`   // cwd, i.e. which workspace launched it
+
+	// Graph state, refreshed after each generate_snapshot.
+	PrimaryRepo  string         `json:"primary_repo,omitempty"` // abs cfg.Repo
+	Repos        []InstanceRepo `json:"repos,omitempty"`
+	SnapshotID   string         `json:"snapshot_id,omitempty"`
+	SnapshotAt   time.Time      `json:"snapshot_at,omitempty"`
+	FactCount    int            `json:"fact_count,omitempty"`
+	InsightCount int            `json:"insight_count,omitempty"`
+
+	// Dashboard reachability. FrontDoor marks the instance that currently owns
+	// the stable, bookmarkable port (see pkg/dashboard).
+	DashboardPort int  `json:"dashboard_port,omitempty"`
+	FrontDoor     bool `json:"front_door,omitempty"`
+
+	// This process's own activity — never aggregated from other instances.
+	LastTool      string         `json:"last_tool,omitempty"`
+	LastCallAt    time.Time      `json:"last_call_at,omitempty"`
+	SessionCounts map[string]int `json:"session_counts,omitempty"`
+}
+
+// URL is the instance's dashboard URL, or "" when it serves no dashboard.
+func (i Instance) URL() string {
+	if i.DashboardPort <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d", i.DashboardPort)
+}
+
+// SessionCalls is the total number of tool calls this instance has served.
+func (i Instance) SessionCalls() int {
+	n := 0
+	for _, v := range i.SessionCounts {
+		n += v
+	}
+	return n
+}
+
+// RepoLabels renders the instance's loaded repos as a compact "a, b, c" label,
+// falling back to the primary repo's base name when no graph is loaded yet.
+func (i Instance) RepoLabels() string {
+	if len(i.Repos) == 0 {
+		if i.PrimaryRepo == "" {
+			return ""
+		}
+		return filepath.Base(i.PrimaryRepo)
+	}
+	labels := make([]string, 0, len(i.Repos))
+	for _, r := range i.Repos {
+		labels = append(labels, r.Label)
+	}
+	return strings.Join(labels, ", ")
+}
+
+// instancesDir returns the directory holding per-instance records.
+func instancesDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".enola", instancesDirName), nil
+}
+
+// instanceFileName is the record's filename: PID plus start time, so a reused
+// PID cannot collide with a dead instance's record.
+func instanceFileName(pid int, start time.Time) string {
+	return fmt.Sprintf("%d-%d.json", pid, start.UnixNano())
+}
+
+// writeInstance persists one instance record, best-effort. The file has a single
+// writer (the process it describes), so a plain write is safe; it is still
+// written atomically so a concurrent reader never sees a truncated record.
+func writeInstance(inst Instance) error {
+	dir, err := instancesDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(inst, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(filepath.Join(dir, instanceFileName(inst.PID, inst.StartTime)), data, 0o644)
+}
+
+// removeInstance deletes one instance's record. Best-effort: a failure just
+// leaves a stale record for LiveInstances to reap.
+func removeInstance(pid int, start time.Time) {
+	dir, err := instancesDir()
+	if err != nil {
+		return
+	}
+	_ = os.Remove(filepath.Join(dir, instanceFileName(pid, start)))
+}
+
+// LiveInstances returns every enola MCP server currently running on this
+// machine for this user, newest last, and reaps the records of those that are
+// not. A record is considered dead when its PID is gone, or when its PID is
+// alive but the record has not been refreshed for staleAfter (a PID-reuse
+// guard). Best-effort throughout: unreadable or malformed records are skipped.
+func LiveInstances() []Instance {
+	dir, err := instancesDir()
+	if err != nil {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	now := time.Now()
+	var live []Instance
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var inst Instance
+		if err := json.Unmarshal(data, &inst); err != nil {
+			// A malformed record can never become valid; drop it.
+			_ = os.Remove(path)
+			continue
+		}
+		if !instanceAlive(inst, now) {
+			_ = os.Remove(path)
+			continue
+		}
+		live = append(live, inst)
+	}
+
+	sort.Slice(live, func(i, j int) bool {
+		if live[i].StartTime.Equal(live[j].StartTime) {
+			return live[i].PID < live[j].PID
+		}
+		return live[i].StartTime.Before(live[j].StartTime)
+	})
+	return live
+}
+
+// instanceAlive reports whether a record describes a still-running server. The
+// current process is always alive regardless of heartbeat age, so a server that
+// reads the registry before its first heartbeat never reaps itself.
+func instanceAlive(inst Instance, now time.Time) bool {
+	if inst.PID == os.Getpid() {
+		return true
+	}
+	if !isProcessAlive(inst.PID) {
+		return false
+	}
+	hb := inst.Heartbeat
+	if hb.IsZero() {
+		hb = inst.StartTime
+	}
+	return now.Sub(hb) <= staleAfter
+}
+
+// FrontDoorInstance returns the live instance currently serving the stable
+// dashboard port, if any.
+func FrontDoorInstance() (Instance, bool) {
+	for _, inst := range LiveInstances() {
+		if inst.FrontDoor {
+			return inst, true
+		}
+	}
+	return Instance{}, false
+}

--- a/pkg/status/instance_test.go
+++ b/pkg/status/instance_test.go
@@ -1,0 +1,257 @@
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestInstanceRoundTrip covers the basic registry contract: a written record is
+// readable, and Close removes it.
+func TestInstanceRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	start := time.Now()
+	tr := NewTracker("/tmp/example-repo")
+	tr.SetStartTime(start)
+	tr.SetDashboardPort(45678)
+	tr.SetIdentity(Identity{Binary: "enola", Version: "1.2.3", ConfigPath: "mcp-arch.yaml", WorkDir: "/tmp/wd"})
+	tr.SetGraphFunc(func() GraphState {
+		return GraphState{
+			PrimaryRepo: "/tmp/example-repo",
+			Repos:       []InstanceRepo{{Label: "api", Path: "/tmp/example-repo", FactCount: 42}},
+			FactCount:   42,
+		}
+	})
+	tr.PersistStartup()
+	defer tr.Close()
+
+	live := LiveInstances()
+	if len(live) != 1 {
+		t.Fatalf("LiveInstances() = %d records, want 1", len(live))
+	}
+	got := live[0]
+	if got.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", got.PID, os.Getpid())
+	}
+	if got.Binary != "enola" || got.Version != "1.2.3" {
+		t.Errorf("binary/version = %q/%q, want enola/1.2.3", got.Binary, got.Version)
+	}
+	if got.DashboardPort != 45678 || got.URL() != "http://127.0.0.1:45678" {
+		t.Errorf("dashboard = %d / %q", got.DashboardPort, got.URL())
+	}
+	if got.RepoLabels() != "api" {
+		t.Errorf("RepoLabels() = %q, want %q", got.RepoLabels(), "api")
+	}
+
+	tr.Close()
+	if live := LiveInstances(); len(live) != 0 {
+		t.Errorf("after Close: %d records remain, want 0", len(live))
+	}
+}
+
+// TestLiveInstancesReapsDeadAndKeepsLive is the guarantee the dashboard's
+// instance list rests on: records left behind by servers that died (a hard-killed
+// agent terminal) must disappear, while the live ones stay. PID 0 is never a
+// running user process, so it stands in for a dead server.
+func TestLiveInstancesReapsDeadAndKeepsLive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	now := time.Now()
+	dead := Instance{PID: 0, StartTime: now.Add(-time.Hour), Heartbeat: now.Add(-time.Hour), Binary: "enola"}
+	// A live PID whose record has not been refreshed for far longer than the
+	// heartbeat interval: treated as stale, guarding against PID reuse.
+	stalePID := Instance{PID: os.Getppid(), StartTime: now.Add(-24 * time.Hour), Heartbeat: now.Add(-24 * time.Hour)}
+	alive := Instance{PID: os.Getpid(), StartTime: now, Heartbeat: now, Binary: "enola-enterprise"}
+
+	for _, inst := range []Instance{dead, stalePID, alive} {
+		if err := writeInstance(inst); err != nil {
+			t.Fatalf("writeInstance(%d): %v", inst.PID, err)
+		}
+	}
+
+	live := LiveInstances()
+	if len(live) != 1 {
+		t.Fatalf("LiveInstances() = %d, want 1 (only the running process)", len(live))
+	}
+	if live[0].PID != os.Getpid() {
+		t.Errorf("survivor PID = %d, want %d", live[0].PID, os.Getpid())
+	}
+
+	// Reaping must also unlink the files, not merely filter them out.
+	dir, err := instancesDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("registry holds %d files after reaping, want 1", len(entries))
+	}
+}
+
+// TestInstanceFileNameSurvivesPIDReuse asserts the record key includes the start
+// time, so a recycled PID cannot resurrect a dead instance's record.
+func TestInstanceFileNameSurvivesPIDReuse(t *testing.T) {
+	a := instanceFileName(4242, time.Unix(1, 0))
+	b := instanceFileName(4242, time.Unix(2, 0))
+	if a == b {
+		t.Fatalf("same filename %q for two different start times", a)
+	}
+	if !strings.HasPrefix(a, "4242-") {
+		t.Errorf("filename %q does not lead with the PID", a)
+	}
+}
+
+// TestConcurrentTrackersDoNotLoseCounts is the regression test for the bug this
+// registry work was built on: several servers share one per-repo usage file, and
+// the old write path stamped baseline+ownSession over it. Two processes on one
+// repo therefore overwrote each other and increments vanished.
+//
+// Two trackers here stand in for two servers on the same repo. Every recorded
+// call must survive in the shared file.
+func TestConcurrentTrackersDoNotLoseCounts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const repo = "/tmp/shared-repo"
+	const callsEach = 50
+
+	a := NewTracker(repo)
+	a.SetStartTime(time.Now())
+	b := NewTracker(repo)
+	b.SetStartTime(time.Now())
+
+	var wg sync.WaitGroup
+	for _, tr := range []*Tracker{a, b} {
+		wg.Add(1)
+		go func(tr *Tracker) {
+			defer wg.Done()
+			for range callsEach {
+				tr.OnToolCall("explore", repo)
+			}
+		}(tr)
+	}
+	wg.Wait()
+
+	path, err := usagePath(canonicalRepoPath(repo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, _, err := ReadStatus(path)
+	if err != nil {
+		t.Fatalf("ReadStatus: %v", err)
+	}
+	if want := 2 * callsEach; info.ToolCounts["explore"] != want {
+		t.Errorf("explore total = %d, want %d — concurrent servers lost counts",
+			info.ToolCounts["explore"], want)
+	}
+
+	a.Close()
+	b.Close()
+}
+
+// TestFlushMergesForeignIncrements checks the delta merge directly: counts a
+// sibling process wrote between two of our flushes must be preserved, not
+// overwritten by our own idea of the total.
+func TestFlushMergesForeignIncrements(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const repo = "/tmp/merge-repo"
+	tr := NewTracker(repo)
+	tr.SetStartTime(time.Now())
+	defer tr.Close()
+
+	tr.OnToolCall("explore", repo) // ours: 1
+
+	path, err := usagePath(canonicalRepoPath(repo))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate another server bumping the shared file behind our back.
+	info, _, err := ReadStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info.ToolCounts["explore"] += 10
+	info.ToolCounts["query_facts"] = 3
+	writeStatusFile(t, path, info)
+
+	tr.OnToolCall("explore", repo) // ours: 2
+
+	after, _, err := ReadStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := after.ToolCounts["explore"]; got != 12 {
+		t.Errorf("explore = %d, want 12 (1 ours + 10 sibling + 1 ours)", got)
+	}
+	if got := after.ToolCounts["query_facts"]; got != 3 {
+		t.Errorf("query_facts = %d, want 3 — a sibling's tool counts were dropped", got)
+	}
+}
+
+// TestAggregateServerPrefersRegistryForLiveState verifies --status and the
+// dashboard read live process state from the registry rather than from whichever
+// usage file happens to carry the newest StartTime.
+func TestAggregateServerPrefersRegistryForLiveState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir, err := usageDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A usage file claiming a dead server started later than the live one. Under
+	// the old newest-StartTime rule this would have been reported as "the server".
+	writeUsage(t, dir, StatusInfo{
+		RepoPath: "/repo/stale", PID: 0, StartTime: time.Now().Add(time.Hour),
+		DashboardPort: 9999, ToolCounts: map[string]int{"explore": 4},
+	})
+
+	tr := NewTracker("/repo/live")
+	tr.SetStartTime(time.Now())
+	tr.SetDashboardPort(4321)
+	tr.PersistStartup()
+	defer tr.Close()
+
+	ss := AggregateServer(dir)
+	if ss.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d (the live registered server)", ss.PID, os.Getpid())
+	}
+	if ss.DashboardPort != 4321 {
+		t.Errorf("DashboardPort = %d, want 4321 (not the dead server's 9999)", ss.DashboardPort)
+	}
+	if !ss.Alive {
+		t.Error("Alive = false, want true")
+	}
+	if len(ss.Instances) != 1 {
+		t.Errorf("Instances = %d, want 1", len(ss.Instances))
+	}
+}
+
+// writeStatusFile writes a StatusInfo to an explicit path, standing in for
+// another enola process updating the shared per-repo counter file.
+func writeStatusFile(t *testing.T, path string, info StatusInfo) {
+	t.Helper()
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -3,22 +3,29 @@ package status
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // StatusFile is the name of the status file written to .enola/.
 const StatusFile = ".enola-status.json"
 
-// StatusInfo holds the serializable status data.
+// StatusInfo is the serializable content of a per-repo usage file.
 //
-// ToolCounts is the lifetime grand total (accumulated across server restarts);
-// SessionCounts is the usage of the current process only (since the last
-// reload). Both are persisted so a separate --status invocation, which only
-// reads this file, can render both tiers.
+// ToolCounts is the lifetime grand total for that repo, accumulated across
+// restarts AND across every enola process on the machine — the file is shared,
+// so writers merge their own delta into it rather than overwriting it (see
+// Tracker.flush).
+//
+// The remaining fields describe a single process and are therefore only as good
+// as the last writer. They are still persisted for compatibility with older
+// binaries, but nothing reads them any more: live process state comes from the
+// instance registry (see instance.go), which has one writer per file.
 type StatusInfo struct {
 	PID           int            `json:"pid"`
 	StartTime     time.Time      `json:"start_time"`               // current process start (drives Uptime)
@@ -27,15 +34,10 @@ type StatusInfo struct {
 	ToolCounts    map[string]int `json:"tool_counts"`              // lifetime grand total
 	SessionCounts map[string]int `json:"session_counts,omitempty"` // since last reload
 
-	// DashboardPort is the localhost port of an HTTP dashboard served by this
-	// process (0 if none). It is persisted so a separate --status invocation,
-	// which never talks to the running server, can print the dashboard URL.
-	//
-	// The OSS server serves no dashboard and always leaves this zero; a wrapper
-	// binary that does sets it via Tracker.SetDashboardPort. Because both share
-	// ~/.enola/usage/, an OSS --status may read a file written by such a wrapper
-	// — printing that URL is correct, since it points at the server that is
-	// actually running.
+	// DashboardPort is the localhost port of the dashboard served by whichever
+	// process wrote this file last (0 if none). Kept for compatibility with
+	// binaries predating the instance registry; current readers take the port
+	// from the registry, which can name every running server rather than one.
 	DashboardPort int `json:"dashboard_port,omitempty"`
 }
 
@@ -44,23 +46,68 @@ type StatusInfo struct {
 // usage is attributed to the repo each call actually operated on (passed to
 // OnToolCall) rather than to a single fixed repo.
 //
-// Each repo gets its own repoState and its own file under ~/.enola/usage/.
+// Each repo gets its own repoState and its own file under ~/.enola/usage/. Those
+// files are SHARED with every other enola process on the machine, so the tracker
+// only ever adds its own unflushed delta to whatever is on disk, under a
+// cross-process lock (see flush). Everything that belongs to this process alone
+// — PID, start time, dashboard port, session counts, loaded graph — lives in its
+// instance record instead (see instance.go), which has a single writer.
 type Tracker struct {
 	mu            sync.Mutex
 	start         time.Time
-	dashboardPort int    // localhost HTTP dashboard port (0 if none), persisted per write
+	dashboardPort int    // localhost HTTP dashboard port (0 if none)
+	frontDoor     bool   // owns the stable dashboard port
+	ident         Identity
 	fallbackRepo  string // used when a call reports an empty repo path
 	repos         map[string]*repoState
+	lastTool      string
+	lastCallAt    time.Time
+
+	// graphFn reports the caller's current graph state for the instance record.
+	// Held as an atomic so Self can call it without the tracker lock — the
+	// callback reads the engine, which must never re-enter the tracker.
+	graphFn atomic.Pointer[GraphFunc]
+
+	stopHeartbeat chan struct{}
+	stopOnce      sync.Once
 }
 
+// Identity is the launch context that distinguishes one running server from
+// another in the registry: which binary, from which workspace, with which config.
+type Identity struct {
+	Binary     string // "enola" / "enola-enterprise"
+	Version    string
+	Licensed   bool // enterprise features active
+	ConfigPath string
+	WorkDir    string
+}
+
+// GraphState is the snapshot of the engine's graph published in the instance
+// record, so a reader can tell what this server has actually loaded.
+type GraphState struct {
+	PrimaryRepo  string
+	Repos        []InstanceRepo
+	SnapshotID   string
+	SnapshotAt   time.Time
+	FactCount    int
+	InsightCount int
+}
+
+// GraphFunc reports the current graph state. It is called without the tracker
+// lock held and must not call back into the Tracker.
+type GraphFunc func() GraphState
+
 // repoState holds one repo's counters. baseline is the lifetime total loaded
-// from disk (immutable for the process); session is this process's increments.
-// The persisted grand total is baseline + session.
+// from disk at first touch; session is this process's increments; flushed is
+// how much of session has already been merged into the shared file, so a write
+// contributes exactly the unflushed delta and never clobbers another process's
+// concurrent increments.
 type repoState struct {
 	repoPath      string
 	filePath      string
 	baseline      map[string]int
 	session       map[string]int
+	flushed       map[string]int
 	trackingSince time.Time
 }
 
@@ -71,6 +118,30 @@ func NewTracker(fallbackRepo string) *Tracker {
 		fallbackRepo: canonicalRepoPath(fallbackRepo),
 		repos:        make(map[string]*repoState),
 	}
+}
+
+// SetIdentity records the launch context published in this process's instance
+// record. Call it once at startup, before PersistStartup.
+func (t *Tracker) SetIdentity(id Identity) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ident = id
+}
+
+// SetGraphFunc registers the callback that reports the engine's current graph
+// state. Pulling it on demand (rather than pushing after each snapshot) keeps
+// the instance record fresh with no extra wiring at the generate_snapshot site.
+func (t *Tracker) SetGraphFunc(fn GraphFunc) {
+	t.graphFn.Store(&fn)
+}
+
+// SetFrontDoor records whether this instance currently owns the stable dashboard
+// port, and republishes the record so other dashboards see the change promptly.
+func (t *Tracker) SetFrontDoor(v bool) {
+	t.mu.Lock()
+	t.frontDoor = v
+	t.mu.Unlock()
+	t.persistInstance()
 }
 
 // SetStartTime records the current process start time (drives Uptime).
@@ -88,13 +159,18 @@ func (t *Tracker) SetDashboardPort(p int) {
 	t.dashboardPort = p
 }
 
-// PersistStartup writes the fallback repo's status file once at startup, so a
-// usage file carrying this process's PID, start time and dashboard port exists
-// even before the first tool call is recorded. Best-effort.
+// PersistStartup publishes this process's instance record and writes the
+// fallback repo's usage file, so both exist before the first tool call is
+// recorded, and starts the heartbeat that keeps the record fresh while the
+// server sits idle. Best-effort.
 func (t *Tracker) PersistStartup() {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.writeLocked(t.stateLocked(t.fallbackRepo))
+	rs := t.stateLocked(t.fallbackRepo)
+	t.mu.Unlock()
+
+	t.flush(rs)
+	t.persistInstance()
+	t.startHeartbeat()
 }
 
 // OnToolCall is the callback registered with the server. repo is the absolute
@@ -107,10 +183,124 @@ func (t *Tracker) OnToolCall(toolName, repo string) {
 	repo = canonicalRepoPath(repo)
 
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	rs := t.stateLocked(repo)
 	rs.session[toolName]++
-	t.writeLocked(rs)
+	t.lastTool = toolName
+	t.lastCallAt = time.Now()
+	t.mu.Unlock()
+
+	// Both writes happen outside the tracker lock: flush takes a cross-process
+	// file lock, and persistInstance calls the graph callback (which reads the
+	// engine). Holding t.mu across either would serialize tool calls behind IO.
+	t.flush(rs)
+	t.persistInstance()
+}
+
+// startHeartbeat refreshes the instance record on a fixed interval so an idle
+// server still looks alive to readers (LiveInstances treats a long-unrefreshed
+// record as stale). Idempotent; stopped by Close.
+func (t *Tracker) startHeartbeat() {
+	t.mu.Lock()
+	if t.stopHeartbeat != nil {
+		t.mu.Unlock()
+		return
+	}
+	stop := make(chan struct{})
+	t.stopHeartbeat = stop
+	t.mu.Unlock()
+
+	go func() {
+		tick := time.NewTicker(heartbeatInterval)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				t.persistInstance()
+			}
+		}
+	}()
+}
+
+// Close stops the heartbeat, flushes any unwritten counters and removes this
+// process's instance record, so the registry reflects the shutdown immediately
+// rather than waiting for a reader to reap it. Safe to call more than once, and
+// safe to defer even if PersistStartup was never called.
+func (t *Tracker) Close() {
+	t.stopOnce.Do(func() {
+		t.mu.Lock()
+		stop := t.stopHeartbeat
+		t.stopHeartbeat = nil
+		states := make([]*repoState, 0, len(t.repos))
+		for _, rs := range t.repos {
+			states = append(states, rs)
+		}
+		start := t.start
+		t.mu.Unlock()
+
+		if stop != nil {
+			close(stop)
+		}
+		for _, rs := range states {
+			t.flush(rs)
+		}
+		removeInstance(os.Getpid(), start)
+	})
+}
+
+// Self returns this process's instance record: its identity, its dashboard, its
+// own session counts, and the graph it currently holds. This — never the
+// cross-process aggregate — is what a dashboard must use to describe itself.
+func (t *Tracker) Self() Instance {
+	// Pull graph state before taking the lock: the callback reads the engine.
+	var g GraphState
+	if fn := t.graphFn.Load(); fn != nil {
+		g = (*fn)()
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	session := make(map[string]int)
+	for _, rs := range t.repos {
+		for k, v := range rs.session {
+			session[k] += v
+		}
+	}
+
+	primary := g.PrimaryRepo
+	if primary == "" {
+		primary = t.fallbackRepo
+	}
+
+	return Instance{
+		PID:           os.Getpid(),
+		StartTime:     t.start,
+		Heartbeat:     time.Now(),
+		Binary:        t.ident.Binary,
+		Version:       t.ident.Version,
+		Licensed:      t.ident.Licensed,
+		ConfigPath:    t.ident.ConfigPath,
+		WorkDir:       t.ident.WorkDir,
+		PrimaryRepo:   primary,
+		Repos:         g.Repos,
+		SnapshotID:    g.SnapshotID,
+		SnapshotAt:    g.SnapshotAt,
+		FactCount:     g.FactCount,
+		InsightCount:  g.InsightCount,
+		DashboardPort: t.dashboardPort,
+		FrontDoor:     t.frontDoor,
+		LastTool:      t.lastTool,
+		LastCallAt:    t.lastCallAt,
+		SessionCounts: session,
+	}
+}
+
+// persistInstance republishes this process's registry record. Best-effort: a
+// failed write only makes this instance briefly invisible to other dashboards.
+func (t *Tracker) persistInstance() {
+	_ = writeInstance(t.Self())
 }
 
 // GetStatus returns the current status snapshot for a single repo. Caller need
@@ -132,6 +322,7 @@ func (t *Tracker) stateLocked(repo string) *repoState {
 		repoPath: repo,
 		baseline: make(map[string]int),
 		session:  make(map[string]int),
+		flushed:  make(map[string]int),
 	}
 	fp, err := usagePath(repo)
 	if err != nil {
@@ -174,10 +365,26 @@ func (t *Tracker) loadLocked(rs *repoState) {
 		// actually succeeded. If the write fails (disk full, permission
 		// denied, unwritable dir), leave the legacy file intact so the data
 		// survives and migration is retried on the next call.
-		if err := t.writeLockedErr(rs); err == nil {
+		if err := t.migrateLocked(rs); err == nil {
 			_ = os.Remove(legacyPath(rs.repoPath))
 		}
 	}
+}
+
+// migrateLocked writes an adopted legacy total through to the repo's home file.
+// It runs on first touch, while t.mu is held, so it cannot go through flush (which
+// takes that lock itself). Skipping the cross-process lock is safe here: this path
+// only runs when the home file does not exist yet, and a sibling migrating the same
+// legacy file would write the very same totals. Caller holds t.mu.
+func (t *Tracker) migrateLocked(rs *repoState) error {
+	data, err := json.MarshalIndent(t.infoLocked(rs), "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(rs.filePath), 0o755); err != nil {
+		return err
+	}
+	return writeFileAtomic(rs.filePath, data, 0o644)
 }
 
 // infoLocked builds a StatusInfo (grand total + session) for a repo. Caller holds t.mu.
@@ -204,24 +411,77 @@ func (t *Tracker) infoLocked(rs *repoState) StatusInfo {
 	}
 }
 
-// writeLocked persists a repo's counters to its file, best-effort. Caller holds t.mu.
-func (t *Tracker) writeLocked(rs *repoState) {
-	_ = t.writeLockedErr(rs)
-}
-
-// writeLockedErr persists a repo's counters to its file and returns any error,
-// so callers that must not act on a failed write (e.g. legacy-file migration)
-// can check it. Caller holds t.mu.
-func (t *Tracker) writeLockedErr(rs *repoState) error {
-	data, err := json.MarshalIndent(t.infoLocked(rs), "", "  ")
-	if err != nil {
-		return err
-	}
-	// Ensure the containing directory exists (~/.enola/usage or legacy .enola).
+// flush merges this process's unflushed increments into a repo's shared counter
+// file. The file is shared with every other enola process on the machine, so the
+// whole read-modify-write runs under a cross-process lock and contributes only
+// the delta — never this process's own idea of the total, which would silently
+// discard a sibling's concurrent increments.
+//
+// Best-effort: on any failure the delta stays unflushed and is retried on the
+// next call, so counts are deferred rather than lost.
+func (t *Tracker) flush(rs *repoState) {
 	if err := os.MkdirAll(filepath.Dir(rs.filePath), 0o755); err != nil {
-		return err
+		return
 	}
-	return os.WriteFile(rs.filePath, data, 0o644)
+
+	// Take the cross-process lock first, then the tracker lock — always in that
+	// order, and never the reverse, so two enola goroutines cannot deadlock.
+	// A lock failure is not fatal: we degrade to an unsynchronized merge.
+	lk, err := acquireLock(rs.filePath)
+	if err != nil {
+		log.Printf("[status] warning: could not lock %s: %v (writing unsynchronized)", rs.filePath, err)
+	}
+	defer lk.release()
+
+	t.mu.Lock()
+	delta := make(map[string]int, len(rs.session))
+	pending := make(map[string]int, len(rs.session))
+	for k, v := range rs.session {
+		pending[k] = v
+		if d := v - rs.flushed[k]; d > 0 {
+			delta[k] = d
+		}
+	}
+	info := t.infoLocked(rs)
+	baseline := make(map[string]int, len(rs.baseline))
+	for k, v := range rs.baseline {
+		baseline[k] = v
+	}
+	t.mu.Unlock()
+
+	// Re-read the on-disk totals inside the lock so the merge starts from what
+	// siblings have already written. A missing file falls back to the baseline
+	// this process loaded (covers the first write and legacy migration).
+	total := baseline
+	if onDisk, _, err := ReadStatus(rs.filePath); err == nil {
+		total = onDisk.ToolCounts
+		if total == nil {
+			total = make(map[string]int)
+		}
+		// Keep the earliest tracking-since across processes.
+		if !onDisk.TrackingSince.IsZero() && (info.TrackingSince.IsZero() || onDisk.TrackingSince.Before(info.TrackingSince)) {
+			info.TrackingSince = onDisk.TrackingSince
+		}
+	}
+	for k, v := range delta {
+		total[k] += v
+	}
+	info.ToolCounts = total
+
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := writeFileAtomic(rs.filePath, data, 0o644); err != nil {
+		return
+	}
+
+	// The delta is now durable; record it so the next flush does not re-add it.
+	t.mu.Lock()
+	for k, v := range pending {
+		rs.flushed[k] = v
+	}
+	t.mu.Unlock()
 }
 
 // ReadStatus reads and validates a status file at the given path.
@@ -270,13 +530,16 @@ func PrintStatus() {
 
 	fmt.Fprintf(os.Stderr, "\n=== enola MCP Status ===\n")
 
-	if ss.Alive {
+	switch {
+	case len(ss.Instances) > 0:
+		printInstances(ss.Instances)
+	case ss.Alive:
 		fmt.Fprintf(os.Stderr, "Server:    running (PID %d)\n", ss.PID)
 		fmt.Fprintf(os.Stderr, "Uptime:    %s\n", formatDuration(time.Since(ss.StartTime)))
 		if ss.DashboardPort > 0 {
 			fmt.Fprintf(os.Stderr, "Dashboard: http://127.0.0.1:%d (auto-refreshes every 30s)\n", ss.DashboardPort)
 		}
-	} else {
+	default:
 		fmt.Fprintf(os.Stderr, "Server:    not running (was PID %d)\n", ss.PID)
 		if !ss.StartTime.IsZero() {
 			fmt.Fprintf(os.Stderr, "Started at: %s\n", ss.StartTime.Format("2006-01-02 15:04:05"))
@@ -291,6 +554,41 @@ func PrintStatus() {
 	printToolUsage(ss.GrandTotal, ss.Session)
 	printValue(ss.GrandTotal, ss.Session)
 	fmt.Fprintf(os.Stderr, "\n")
+}
+
+// printInstances renders every enola MCP server running right now — one row per
+// process, with its own dashboard URL. Several agent terminals mean several
+// servers, and each has its own graph, so naming them individually is the only
+// honest report; the row marked "(this)" is the process printing the table, and
+// "(shared)" marks the one currently serving the stable dashboard URL.
+func printInstances(instances []Instance) {
+	fmt.Fprintf(os.Stderr, "Servers running: %d\n\n", len(instances))
+
+	maxRepo := len("repos")
+	for _, inst := range instances {
+		if l := len(inst.RepoLabels()); l > maxRepo {
+			maxRepo = l
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "  %7s  %-*s  %8s  %6s  %s\n", "pid", maxRepo, "repos", "uptime", "calls", "dashboard")
+	self := os.Getpid()
+	for _, inst := range instances {
+		url := inst.URL()
+		if url == "" {
+			url = "(none)"
+		}
+		if inst.FrontDoor {
+			url += " (shared)"
+		}
+		tag := ""
+		if inst.PID == self {
+			tag = " (this)"
+		}
+		fmt.Fprintf(os.Stderr, "  %7d  %-*s  %8s  %6d  %s%s\n",
+			inst.PID, maxRepo, inst.RepoLabels(),
+			formatDuration(time.Since(inst.StartTime)), inst.SessionCalls(), url, tag)
+	}
 }
 
 // printToolUsage renders per-tool call counts in two tiers: session (current
@@ -311,7 +609,9 @@ func printToolUsage(total, session map[string]int) {
 			maxLen = len(name)
 		}
 	}
-	fmt.Fprintf(os.Stderr, "  %-*s  %8s  %8s\n", maxLen, "tool", "session", "total")
+	// "running" is the sum over the servers alive right now (all of them, not
+	// one arbitrary process); "total" is the lifetime figure on disk.
+	fmt.Fprintf(os.Stderr, "  %-*s  %8s  %8s\n", maxLen, "tool", "running", "total")
 	for _, name := range names {
 		fmt.Fprintf(os.Stderr, "  %-*s  %8d  %8d\n", maxLen, name, session[name], total[name])
 	}
@@ -346,7 +646,7 @@ func printValue(total, session map[string]int) {
 	fmt.Fprintf(os.Stderr, "\nValue Estimate (approximate):\n")
 
 	// Align the tool column to the longest name.
-	maxLen := len("this session")
+	maxLen := len("running now")
 	for _, tv := range rep.Tools {
 		if len(tv.Tool) > maxLen {
 			maxLen = len(tv.Tool)
@@ -362,7 +662,7 @@ func printValue(total, session map[string]int) {
 
 	sess := ComputeValue(session)
 	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
-		maxLen, "this session", sess.TotalCalls, formatDuration(sess.TotalTimeSaved), humanCount(sess.TotalTokensSaved))
+		maxLen, "running now", sess.TotalCalls, formatDuration(sess.TotalTimeSaved), humanCount(sess.TotalTokensSaved))
 }
 
 // humanCount renders a large count with thousands/millions suffixes (e.g. 1.2M).


### PR DESCRIPTION
One MCP server is started per agent session, so several run at once — different repos, sometimes the same repo, sharing ~/.enola. Nothing modelled a running instance, so per-process and shared state were conflated:

- The dashboard filled its PID/uptime/session cards from the cross-process aggregate, which picks the usage file with the newest start time. A page served by one process routinely announced another process's PID.
- The graph panel read the machine-wide receipt while the services, insights and coverage panels read the live store, so the two halves of one page could describe different codebases.
- Per-repo counter files were rewritten as baseline+ownSession, so two servers on one repo silently discarded each other's increments: 80 recorded calls came back as 50.
- A restart preferred the machine-wide receipt and could come back holding whatever repos another session had snapshotted last.
- Dashboards bound only an ephemeral port announced on stderr, so there was no address worth returning to.

Add an instance registry under ~/.enola/instances/, written by the process it describes and reaped once that PID is gone. Counter writes now merge only the unflushed delta, under a cross-process lock. Graph receipts are additionally written per workspace and preferred on restart; the machine-wide file is used only when it covers this workspace, and otherwise nothing is restored — starting empty is recoverable and visible, starting with another session's graph is neither. The dashboard takes its identity from the tracker and its graph from the engine, lists every live server with a link to it, and competes for a fixed port so one URL stays valid as servers come and go.

Also sandbox HOME for the server test package: the generate_snapshot handler writes receipts under ~/.enola, so a test run overwrote the developer's own.