### PR TITLE
chore: use install -m 755 for safe atomic binary placement

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ fi
 INSTALL_DIR="${ENOLA_INSTALL_DIR:-$HOME/.local/bin}"
 mkdir -p "$INSTALL_DIR"
 
-cp "$TMPDIR/$BIN_NAME" "$INSTALL_DIR/enola"
+install -m 755 "$TMPDIR/$BIN_NAME" "$INSTALL_DIR/enola"
 
 echo "==> enola v${VERSION} installed to $INSTALL_DIR/enola"
 echo ""


### PR DESCRIPTION
## Summary
Updates install.sh to use `install -m 755` instead of `cp` when copying the extracted binary to the destination directory.

## Rationale
- **Executable Permissions**: Ensures the installed binary is always granted `rwxr-xr-x` (`0755`) permissions, avoiding permission denied errors if system `umask` or archive attributes strip execution bits.
- **Atomic Replacement**: `install` unlinks (removes) an existing binary before replacing it, preventing `Text file busy` (`ETXTBSY`) errors when updating `enola` while it is running.