### PR TITLE
Price the value model from measured corpus, not call counts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -240,7 +240,7 @@ Agent tooling starts one MCP server per session, so several run concurrently —
 
 That registry is what lets `--status` list every running server with its own URL, and what lets a dashboard name the process serving it instead of guessing from the newest usage file — a guess that, with several terminals open, was usually a different process.
 
-The value estimate is a deliberately simple model in [`pkg/status/value.go`](pkg/status/value.go): one weight per tool (the number of manual lookups a call replaces) times two conversion constants (seconds and tokens per lookup). `RegisterToolWeights` lets a wrapper price the tools it adds instead of letting them fall through to the default weight; it is guarded by a mutex because registration happens at startup while reads come from the tool callback.
+The value estimate `--status` and the dashboard render lives in [`pkg/status/value.go`](pkg/status/value.go) and has its own section below — see [The value model](#the-value-model).
 
 **[`pkg/dashboard`](pkg/dashboard)** serves the read-only page described in the README, on a loopback port bound at startup (`--no-dashboard` skips it). It is **strictly a viewer**: `buildPage` runs per request and every source is read through an accessor the MCP tools already use — `Options.Tracker`, the engine's published store, and the receipt/insight artifacts (preferring the in-memory copy, falling back to the last-written file on disk, since `AutoLoadSnapshot` restores facts without full receipt metadata). Nothing it does mutates server state, and every source degrades to an explanatory note rather than an error page.
 
@@ -258,6 +258,141 @@ The page reads receipts into the engine's own `facts.Receipt` / `facts.GraphRece
 **The insight allowlist.** `insightLabels` in [`pkg/dashboard/insights.go`](pkg/dashboard/insights.go) maps explainer id → display label, one entry per explainer `bootstrap.NewEngine` registers, and it doubles as an admission list: `insightDetails` drops any insight whose `Source` is absent from it, and excludes it from the structural/candidate counts. This matters because both binaries share a repo's `.enola/insights.json` — without the filter, a file written by a build with extra explainers would surface findings this engine cannot produce. For the same reason the clickable insight counters render the *filtered* total rather than the receipt's raw `insight_count`, so the number you click always matches the list you get.
 
 **The overlay.** A wrapper adds panels through `Options` rather than by forking the page. `Overlay` is a template fragment redefining any of the blocks `OverlayBlocks()` publishes — `extra-styles`, `extra-cards`, `extra-modals`, `extra-scripts` — each of which is passed the page root, so the fragment reaches its own data as `{{.Extra}}`, computed per request by `Options.Extra(store)`. `InsightLabels` widens the allowlist above (a wrapper that registers explainers *must* use it, or its own findings are filtered out of its own dashboard) and `Title` names the product. Two tests hold the contract from both ends: `TestOverlayBlocksExistInPage` here, and a matching check in the wrapper that its fragment defines only published names. Note that every server gets its own `Clone` of the base template even without an overlay — `html/template` refuses to clone a template that has already executed, so rendering straight from the package-level base would break the *next* dashboard's construction.
+
+---
+
+## The value model
+
+`--status`, `--status --all` and the dashboard all report an estimate of what enola saved you, in two currencies: **tokens** and **time**. The model lives in [`pkg/status/value.go`](pkg/status/value.go) and is computed from real per-tool call counts recorded under `~/.enola/usage/`. This section says exactly what those numbers mean, because a savings figure that nobody can explain is worth less than no figure at all.
+
+### What is being counted
+
+The estimate answers one question:
+
+> **What would an agent have had to ingest to arrive at the same answer using ordinary tools — grep, glob, open a file, read it, infer?**
+
+That counterfactual, not the size of enola's own response, is the baseline. The distinction matters. A `query_facts` call that returns 12 KB of JSON has not "cost" you 3,000 tokens — it has *replaced* an exploration loop that would have grepped, opened a dozen files, and re-derived the same edges imperfectly. Pricing the response instead of what it displaced would measure the wrong thing entirely, and would perversely reward tools that answer less.
+
+The counterfactual is also why the model is anchored to **corpus size**, not to call count. Reconstructing a graph of a large monorepo (33.0M tokens of parsed source, 477,383 facts, 47,711 files) and reconstructing one of a small service (72K tokens) are not the same act of work. Any flat per-call price is wrong at both ends by more than two orders of magnitude, so there isn't one.
+
+### The corpus anchor
+
+Every figure derives from one measurement: **the token size of the source enola actually parsed**, computed by `ScanFootprint` in [`pkg/status/footprint.go`](pkg/status/footprint.go) and cached per repo in the usage file.
+
+Two properties of that measurement are load-bearing:
+
+- It counts **parsed source only**, not `files_seen`. A snapshot's `file_hashes` list covers everything the walker touched, including whatever else lives in the tree. On one real repository the two differ by 39× — 3.1M tokens of source against 121M once JPEGs, an MP4 or two and a 63 MB GeoIP database are folded in. An agent was never going to read those, so they are not corpus.
+- It is a **measurement, not a guess**. Nothing else in this model is allowed to invent a corpus size.
+
+Measured across the workloads enola is actually pointed at, the spread the model has to cover is roughly **460×**:
+
+| Workload | Parsed source | Facts | Wall clock |
+|---|---:|---:|---:|
+| Single small service (Go) | 72K tokens | 3,475 | 0.4s |
+| Mid-size project (Python + TS) | 1.78M | 16,909 | 1.1s |
+| Large project (Python + TS) | 5.90M | 51,645 | 3.5s |
+| **8-repo product ecosystem** (5 languages, backend + web + iOS + Android) | **10.62M** | 155,796 | 9.1s |
+| **Large monorepo** (Ruby + TS + Python + Java) | **33.00M** | 477,383 | 30.9s |
+
+The rendered digest (`llm_context.md`) is capped at ~16K tokens regardless. For the monorepo at the bottom of that table, that is a **2,065:1** compression of the corpus into the artifact an agent actually reads.
+
+### Tokens
+
+```
+first snapshot     = corpus_tokens × rediscoveryFactor
+additional repo    = above + priorCorpusTokens × crossRepoPremiumFactor
+refresh (unchanged)= refreshConfirmCredit
+refresh (changed)  = changed_fraction × corpus_tokens × rediscoveryFactor + refreshConfirmCredit
+query tools        = weight × tokensPerManualOp − response_tokens
+```
+
+Credit is never negative, and a failed call earns nothing at all.
+
+**A repo is never credited more than its own corpus.** Reading every line of it is the most an agent could possibly have ingested on its account, so that is the ceiling — the cross-repo premium tops a snapshot up toward it but never past it. Without that bound, a 4K-token service joining a 50M-token graph would earn hundreds of times its own source. The bound buys a property worth stating plainly: **cumulative snapshot credit never exceeds the size of the code itself.** If a total ever reads higher than the corpus it was computed over, the model is wrong, not the codebase.
+
+The premium is also scoped to the graph actually loaded. A non-append snapshot resets the store, and the corpus pool resets with it — a repo joining a small cluster is credited for edges against that cluster, not against everything indexed earlier in the session.
+
+`rediscoveryFactor` (< 1) encodes that an agent doing this by hand does **not** read every file. It reads a lot of them, greps the rest, and stops when it thinks it understands enough — usually before it actually does. Crediting the full corpus would assume an exhaustiveness no agent exhibits.
+
+**The cross-repo premium** is not a bonus for doing more work; it prices a different *kind* of result. A cross-repo edge — an iOS client calling a route served by its backend — can only be derived with both corpora resident at once. That is why `append` is priced above a second independent snapshot, and it leads directly to the threshold below.
+
+**The infeasibility threshold.** When the corpus that must be simultaneously resident exceeds `agentContextWindow`, the counterfactual is not *expensive* — it is **impossible**. The 8-repo ecosystem above resolves its cross-repo edges across 10.62M tokens held at once; the monorepo is 33M. No amount of patience or budget gets an agent there by re-reading files, because it cannot hold the sides of the comparison in the same context.
+
+Such entries keep their numeric credit (so totals stay arithmetic) but are **flagged in the output** rather than quietly rendered as a large number. A footnote saying *"exceeds a single context window — not reproducible by re-reading"* is a stronger and more honest claim than any figure, and it is the case both large workloads in the table above fall into.
+
+**Refreshes are not waste.** Re-running `generate_snapshot` on an unchanged repo looks redundant and isn't: it answers *"is my understanding of this system still valid?"*, which is the question [`internal/engine/freshness.go`](internal/engine/freshness.go) exists to answer and which is genuinely expensive to settle by hand — you must re-derive the graph to know whether it moved. So an unchanged refresh earns a small fixed credit (real, but far below a first build), and a changed one is scaled by the fraction of files whose hashes actually moved. The `snapshot_id`, `git.commit` and `config_hash` recorded in `snapshot.meta.json` are what make that distinction exact rather than heuristic.
+
+**The ledger has the final say on "first".** Whether a repo has been built before is answered by the usage history, not by the repo's `.enola` directory. Those are different questions with different lifetimes: repo-local metadata says *"is this graph on disk current?"* and travels with the working copy — it survives clearing `~/.enola`, and it arrives with a fresh clone. The value model asks *"has this installation ever been credited for building this graph?"*, which only the ledger can answer. So a snapshot the server reports as unchanged is still priced as a first build when no snapshot credit exists for that repo yet. Without that rule a leftover meta file suppresses the credit permanently, and resetting your statistics silently makes every subsequent build look free.
+
+Note that "unchanged" is decided on **file hashes**, not on the snapshot id alone. An id can move without any source moving — a version bump, a config change — and that earns confirmation credit rather than a full rebuild's worth. Two distinct cases are therefore carried explicitly: a changed-fraction of exactly zero means *the files are identical*, while a **negative** fraction means *no previous snapshot to compare against*, which is a genuine first build. They must not share a default — one of them is worth a whole corpus and the other is worth a few thousand tokens.
+
+For the **query tools**, `weight` remains an ordinal judgement — how much exploration one call displaces, relative to the others — while `tokensPerManualOp` converts it into tokens. That constant is calibrated to the **median** parsed source file across the corpora above (~800 tokens), not the mean, which outliers inflate by roughly 2.5×. Response tokens are subtracted, which is what finally makes the `output_mode` ladder visible in the estimate: `summary` mode genuinely saves more than `full` mode, and the model should say so.
+
+### Time
+
+Time saved is **your** time — a human waiting on an agent — not CPU time and not model throughput:
+
+```
+time_saved = (tokens_avoided / agentTokensPerSecond) × reworkFactor
+```
+
+`agentTokensPerSecond` is end-to-end discovery throughput: tool round trips and reasoning included, not raw generation speed.
+
+`reworkFactor` is the **non-determinism premium**, and it is the honest core of enola's pitch. An agent re-deriving your architecture from grep does not merely take longer — it gets things subtly wrong often enough that some fraction of the work is done twice: the migration attempted a second time, the caller missed until code review, the refactor undone. enola returns the same graph every time. Pricing that as a named, tunable multiplier is better than burying it inside a per-tool weight where nobody can find or argue with it.
+
+### The constants
+
+All seven live at the top of [`pkg/status/value.go`](pkg/status/value.go) so tuning is a one-line change. Where a range was defensible, the lower end was chosen:
+
+| Constant | Meaning |
+|---|---|
+| `rediscoveryFactor` | Fraction of a corpus an agent actually ingests before it stops. |
+| `crossRepoPremiumFactor` | Share of the already-loaded corpus credited for resolving a new repo's edges against it. |
+| `refreshConfirmCredit` | Per-repo credit for establishing that nothing changed. |
+| `tokensPerManualOp` | Median parsed source file, in tokens. |
+| `agentTokensPerSecond` | End-to-end agent discovery throughput. |
+| `reworkFactor` | Non-determinism premium — work done twice. |
+| `agentContextWindow` | Threshold past which the counterfactual is infeasible. |
+
+### A worked example
+
+Mapping the 8-repo ecosystem from the table above — one `generate_snapshot` per repo, the first `fresh` and the rest `append`, then one refresh and a handful of reads:
+
+```
+Value Estimate (approximate):
+  tool                calls   ~time saved   ~tokens saved
+  explore                 1            7s           11.7K
+  generate_snapshot       9     1h 6m 54s            6.7M
+  query_facts             2            6s           10.6K
+  query_insights          1           14s           23.9K
+  show_symbol             1            0s               0
+  TOTAL                  14     1h 7m 22s           6.7M†
+  running now            14     1h 7m 22s            6.7M
+
+  † corpus exceeds a single context window — not reproducible by re-reading files.
+```
+
+Four things in that output are worth reading closely:
+
+- **6.7M tokens for the snapshots** is `10.62M × 0.6` plus the cross-repo premiums — derived from the corpus, so the same nine calls against a smaller or larger estate would score differently.
+- **1h 7m for 6.7M tokens** is the agent-throughput conversion, not a per-lookup charge. It is time you spend waiting on an agent, so it is bounded by how fast an agent ingests, not by how long a person would take to read the same code.
+- **`show_symbol` earned 0.** It was called with a name that does not exist. The call is counted — it happened — but a "not found" displaces no work.
+- **The dagger.** 10.62M tokens cannot be held at once, so the eight cross-repo edges in this graph are not derivable by re-reading files at any budget.
+
+Re-running the identical session immediately afterwards yields **15.4K** for the same nine snapshots: every repo's `snapshot_id` matched, so each earned confirmation credit instead of a rebuild. That gap — 6.7M versus 15.4K for byte-identical commands — is the model distinguishing building an understanding from confirming one still holds.
+
+### What it deliberately does not model
+
+- **Reasoning tokens.** Only ingestion is priced. The thinking an agent does *about* what it read is not counted, on either side of the comparison.
+- **Cache warmth.** A repeat read inside one session is cheaper than a cold one; the model ignores this in enola's disfavour.
+- **Downstream consequence.** The missed caller found in code review, the afternoon spent reconstructing how two services talk, the design decision made on a wrong mental model. `reworkFactor` prices a slice of this; the rest is not attempted.
+- **Value not yet consumed.** A graph built and never queried is credited for the build. It is a durable, reusable artifact and the credit is for producing it — not a forecast that it will be used.
+
+### Extending it
+
+`RegisterToolWeights` lets a wrapper binary price the tools it adds instead of letting them fall through to `defaultWeight` — a licensed wrapper registers its own at startup, before the server begins serving. The map is mutex-guarded because registration happens once at startup while reads come from the tool callback and, in wrapper binaries, from concurrent HTTP handlers.
+
+One rule matters here: **the credit is persisted alongside the count**, not repriced at render time. Every binary shares `~/.enola/usage/`, and a build that has never heard of a tool would price it at `defaultWeight` — so the same usage file would report a materially different figure depending on which binary you ran `--status` from. Recording the token figure when the call happens is what makes the number a property of the data rather than of the reader.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ enola removes the guessing from the part that should never be guessed: the struc
 
 The result is the difference between *vibe coding* - prompt, hope, fix - and **AI-augmented engineering**: fewer wrong turns, fewer tokens burned, and work you can reproduce. enola adds determinism where AI lacks it, so your agent spends its intelligence on the actual problem instead of re-learning your repo.
 
-**The savings show up in two currencies.** Tokens are the obvious one: a graph query costs a fraction of the file-reading it replaces. Time is the bigger one - work that doesn't have to be redone because the agent knew the blast radius before it started, and knew it had gone wrong before you did. `enola --status` (and `--status --all`, per repository) reports both, from real per-tool call counts recorded under `~/.enola/usage/`. It's a static estimate, clearly labelled as one - but it's counted from what your agents actually did, not from a brochure.
+**The savings show up in two currencies.** Tokens are the obvious one: a graph query costs a fraction of the file-reading it replaces. Time is the bigger one - work that doesn't have to be redone because the agent knew the blast radius before it started, and knew it had gone wrong before you did. And past a certain size the comparison stops being about cost at all: linking an 8-repo ecosystem means holding 10M+ tokens of source at once, so those cross-repo edges aren't expensive to find by grepping, they're *unreachable* by grepping. `enola --status` (and `--status --all`, per repository) reports both currencies, priced against what an agent would have had to ingest instead - measured corpus sizes and real call counts recorded under `~/.enola/usage/`. It's an estimate, clearly labelled as one, and [documented in full](ARCHITECTURE.md#the-value-model) - but it's counted from what your agents actually did, not from a brochure.
 
 > 📖 **Want the *why* before the *what*?** [**The most boring file in enola**](https://enola.tech/blog/the-most-boring-file-in-enola) is the story of why enola exists at all, and the design decision the whole thing rests on. It's the best place to start.
 
@@ -150,7 +150,7 @@ Everyone above the keyboard needs the same thing enola produces: a structural ma
 - **Anyone about to refactor** - know the **blast radius before** touching code with `impact_analysis`, and know **what your refactor actually did** after, with `diff_snapshot`. A large refactor usually fails in one of two ways: you missed a caller, or you moved the mess rather than removing it. The first is a traversal; the second is a delta. Both are answers, not opinions.
 - **Anyone reviewing AI-written code** - the hardest question in an agent-heavy workflow isn't "does it work?", it's "did it change the architecture in a way nobody asked for?" `diff_snapshot` answers exactly that, and only that: it reports what *moved*, never pre-existing state, so a clean diff is genuinely a clean bill of structural health rather than a wall of noise you learn to ignore.
 - **Architects** - the structural view you usually maintain by hand, computed from the code instead of a diagram that drifts out of date: dependency cycles, layer violations, call-graph hotspots, cross-repo coupling, and dependency depth - plus a module/dependency diagram an agent regenerates from the current commit, so the picture stays honest. Pin a baseline at the start of a migration and every diff afterwards tells you whether the codebase is moving toward the target architecture or away from it.
-- **Engineering leaders - CTOs, VPs, and managers** - a trustworthy picture of a codebase's shape for planning, onboarding, and risk. Deterministic signals (cycles, hotspots, coupling) instead of gut feel, a new-hire tour or a deck diagram that matches reality, a map that's reproducible run to run - so two people looking at it see the same thing - and, via `--status` and the dashboard, a running tally of what the tooling has actually saved across every repo your team points it at.
+- **Engineering leaders - CTOs, VPs, and managers** - a trustworthy picture of a codebase's shape for planning, onboarding, and risk. Deterministic signals (cycles, hotspots, coupling) instead of gut feel, a new-hire tour or a deck diagram that matches reality, a map that's reproducible run to run - so two people looking at it see the same thing - and, via `--status` and the dashboard, a running tally of what the tooling has actually saved across every repo your team points it at - priced against the reconstruction it replaced, by a model that is [written down and arguable](ARCHITECTURE.md#the-value-model) rather than asserted.
 
 ---
 
@@ -364,7 +364,7 @@ Some questions don't need an agent at all. The MCP server also serves a **read-o
 - *What did the analysis find?* - every insight grouped by explainer and filterable by confidence, so you can see the cycles and hotspots without asking a model to list them.
 - *Is this snapshot trustworthy?* - the receipt: snapshot ID, enola version, git ref and dirty flag, extractors used.
 - *Why does this snapshot look thin?* - extraction quality: files seen vs. parsed vs. skipped, parse errors with samples, unresolved cross-repo edges, coverage gaps.
-- *What has this actually saved me?* - the same value estimate `--status` prints, per tool and lifetime.
+- *What has this actually saved me?* - the same value estimate `--status` prints, per tool and lifetime ([how it's calculated](ARCHITECTURE.md#the-value-model)).
 
 Reading it costs nothing and burns no context. It's also the fastest way to sanity-check a snapshot before you trust an answer built on it.
 
@@ -590,7 +590,7 @@ Run `enola --help` for the full text. With no flags, enola starts the MCP server
 | `--generate [config_path]` | Generate a snapshot and exit - no MCP server. Artifacts go to `output.dir` (default `.enola/`). |
 | `--explain [repo_path]` | Print the statistics report above and exit. Read-only: nothing is written to `.enola/`. |
 | `--list` | List the MCP tools this build serves, with one-line summaries. |
-| `--status` | List every enola server running right now - PID, repos, uptime, calls, dashboard URL - plus per-tool call counts and an estimate of the time and context those calls saved. |
+| `--status` | List every enola server running right now - PID, repos, uptime, calls, dashboard URL - plus per-tool call counts and an estimate of the reconstruction those calls saved, in time and tokens. |
 | `--status --all` | The same usage, broken down per repository. |
 | `--no-dashboard` | Start the MCP server without the localhost dashboard. |
 | `--version` | Print the build version. |
@@ -613,25 +613,36 @@ Repos tracked: 21
 
 Tool Usage:
   tool                running     total
-  generate_snapshot        18       145
-  query_facts               9        32
-  query_insights            4        15
-  ...
+  explore                   1         1
+  generate_snapshot         9         9
+  query_facts               2         2
+  query_insights            1         1
+  show_symbol               1         1
 
 Value Estimate (approximate):
   tool                calls   ~time saved   ~tokens saved
-  generate_snapshot     145   120h 50m 0s           29.0M
-  query_insights         15     3h 45m 0s          900.0K
-  impact_analysis        10      2h 5m 0s          500.0K
-  ...
-  TOTAL                 237   132h 5m 30s           31.7M
+  explore                 1            7s           11.7K
+  generate_snapshot       9     1h 6m 54s            6.7M
+  query_facts             2            6s           10.6K
+  query_insights          1           14s           23.9K
+  show_symbol             1            0s               0
+  TOTAL                  14     1h 7m 22s           6.7M†
+  running now            14     1h 7m 22s            6.7M
+
+  † corpus exceeds a single context window — not reproducible by re-reading files.
 ```
+
+That's one session mapping an 8-repo, 5-language product ecosystem - 10.6M tokens of source, reduced to a queryable graph in about nine seconds. Two details worth noticing: `show_symbol` earned **0** because it was called with a name that doesn't exist (the call is counted; a "not found" displaces no work), and re-running the identical session immediately afterwards scores **15.4K** instead of 6.7M, because every repo's snapshot id matched and each call earned confirmation credit rather than a rebuild. Building an understanding and confirming one still holds are different things, and the estimate says so.
 
 `--status --all` gives the same figures broken down **per repository**, sorted by tokens saved - useful for seeing which part of your estate the tooling is actually earning its keep on.
 
-Be clear about what these numbers are: a **static per-tool model** of how many manual lookups (open a file, grep, read) one call replaces, converted at 30 seconds and ~2,000 tokens per lookup. They're an estimate, labelled as one - but the *call counts* are real, recorded per repository under `~/.enola/usage/`, so they survive server restarts and deleting a repo's `.enola/` directory, and `--status` works from any directory, not just a snapshotted one.
+Be clear about what these numbers are. They answer one question: **what would an agent have had to ingest to reach the same answer with ordinary tools - grep, glob, open a file, read it, infer?** So a snapshot is priced from the *corpus it indexed*, measured, not from the fact that a call happened; a repo of 72K tokens and a monorepo of 33M are not the same act of work. Reading time converts to your time waiting on the agent, including the rework a non-deterministic reconstruction implies. Failed calls are counted but earn nothing, and the tokens you spend reading enola's own response are subtracted - so `output_mode='summary'` genuinely scores better than `'full'`.
 
-And the estimate is deliberately conservative in one important way: it prices only the lookups your agent *didn't have to do*. It doesn't try to price the refactor it didn't have to redo - the second attempt at a migration, the missed caller found in code review, the afternoon spent reconstructing how two services talk. That's the saving `impact_analysis` and `diff_snapshot` are really for, and it's the one you'll feel first.
+They're an estimate, labelled as one - but the inputs are real: corpus sizes measured at snapshot time, call counts recorded per repository under `~/.enola/usage/`. They survive server restarts and deleting a repo's `.enola/` directory, and `--status` works from any directory, not just a snapshotted one. The full model, its constants and what it deliberately leaves out are in [ARCHITECTURE.md](ARCHITECTURE.md#the-value-model).
+
+**The dagger matters more than the number.** When the corpus exceeds what an agent can hold at once - as an 8-repo ecosystem or a large monorepo does - the counterfactual isn't expensive, it's *impossible*: cross-repo edges can't be derived by re-reading files when both sides can't be in context together. Those rows are flagged, because "not reproducible by re-reading" is a stronger claim than any figure.
+
+And the estimate stays conservative where it can't measure. It prices the ingestion an agent avoided and a slice of the rework; it doesn't try to price the missed caller found in code review, or the afternoon spent reconstructing how two services talk. That's the saving `impact_analysis` and `diff_snapshot` are really for, and it's the one you'll feel first.
 
 ### The dashboard
 

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -160,7 +160,7 @@ func main() {
 	// Deregister on the way out so the registry reflects the shutdown at once
 	// rather than waiting for a reader to reap a dead PID.
 	defer tracker.Close()
-	srv.SetToolCallback(tracker.OnToolCall)
+	srv.SetToolCallback(tracker.Record)
 
 	// Start the localhost HTTP dashboard alongside the MCP server. It binds a
 	// free loopback port — plus the shared, bookmarkable one if it can claim it —

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -432,6 +432,7 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 
 			FilesSeen:         len(files),
 			FilesParsed:       e.store.CountFilesWithFacts(files, parsedPrefix),
+			SourceBytes:       e.store.SourceBytesWithFacts(files, parsedPrefix, absRepo),
 			FilesSkipped:      skips.count,
 			DirsSkipped:       skips.dirCount,
 			SkippedSample:     skips.sample,

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -234,6 +234,7 @@ type SnapshotMeta struct {
 	// Extraction-quality fields (the loop signal).
 	FilesSeen         int               `json:"files_seen,omitempty"`         // source files the walker enumerated (excludes ignored)
 	FilesParsed       int               `json:"files_parsed,omitempty"`       // distinct files that produced at least one fact
+	SourceBytes       int64             `json:"source_bytes,omitempty"`       // on-disk bytes of the FilesParsed set — the corpus this graph replaces reading (see pkg/status value model)
 	FilesSkipped      int               `json:"files_skipped,omitempty"`      // ignored FILES the walker visited; a pruned directory counts once in DirsSkipped, not once per file
 	DirsSkipped       int               `json:"dirs_skipped,omitempty"`       // ignored DIRECTORIES pruned whole; their contents are never visited, so they are counted nowhere else
 	SkippedSample     []string          `json:"skipped_sample,omitempty"`     // a capped sample of both, each naming the glob that matched it

--- a/internal/facts/store.go
+++ b/internal/facts/store.go
@@ -120,6 +120,35 @@ func (s *Store) CountFilesWithFacts(files []string, prefix string) int {
 	return n
 }
 
+// SourceBytesWithFacts returns the total on-disk size of the walked files that
+// produced at least one fact — the same set CountFilesWithFacts counts, measured
+// rather than counted. root is the repo root that files are relative to.
+//
+// This is the corpus figure the value model in pkg/status is anchored to, and it
+// deliberately measures only *parsed* files. Summing every walked file instead
+// folds in whatever else lives in the tree — images, media, vendored databases,
+// stale artifacts — which on a real repo is a 39x difference, and none of it is
+// source an agent would have read. Unreadable files are skipped, not estimated.
+func (s *Store) SourceBytesWithFacts(files []string, prefix, root string) int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var total int64
+	for _, f := range files {
+		key := prefix + filepath.ToSlash(f)
+		if idxs, ok := s.byFile[key]; !ok || len(idxs) == 0 {
+			continue
+		}
+		p := f
+		if !filepath.IsAbs(p) && root != "" {
+			p = filepath.Join(root, f)
+		}
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			total += info.Size()
+		}
+	}
+	return total
+}
+
 // ByKind returns all facts of the given kind.
 func (s *Store) ByKind(kind string) []Fact {
 	s.mu.RLock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,13 +19,44 @@ import (
 	"github.com/enola-labs/enola/internal/facts"
 	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/mcputil"
+	"github.com/enola-labs/enola/pkg/status"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// toolCallbackFunc is invoked once per tool call with the tool name and the repo
-// the call operated on. Stored behind an atomic.Pointer so SetToolCallback and the
-// per-call fireToolCallback are race-free regardless of call ordering.
-type toolCallbackFunc func(tool, repo string)
+// toolCallbackFunc is invoked once per completed tool call, with everything the
+// value model needs that cannot be recovered afterwards: the outcome, the size of
+// the response the agent had to read, and — for generate_snapshot — the corpus it
+// indexed. Stored behind an atomic.Pointer so SetToolCallback and the per-call
+// fire are race-free regardless of call ordering.
+type toolCallbackFunc func(status.ToolCall)
+
+// callRecord is the per-call scratchpad a handler uses to tell the value
+// middleware what it did. The middleware puts one in the context before invoking
+// the handler and reads it afterwards, so the common case — a read tool that only
+// needs its name, repo and response size — costs the handler nothing.
+//
+// Only generate_snapshot enriches it, because only a snapshot's value depends on
+// facts the middleware cannot see from the outside.
+type callRecord struct {
+	mu       sync.Mutex
+	repo     string
+	snapshot *status.SnapshotValue
+}
+
+type callRecordKey struct{}
+
+// recordSnapshot attaches snapshot-value detail to the in-flight call, if the
+// call is being observed. Safe to call when it is not.
+func recordSnapshot(ctx context.Context, repo string, sv status.SnapshotValue) {
+	rec, ok := ctx.Value(callRecordKey{}).(*callRecord)
+	if !ok || rec == nil {
+		return
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	rec.repo = repo
+	rec.snapshot = &sv
+}
 
 // Server wraps the MCP server and connects it to the snapshot engine.
 type Server struct {
@@ -51,6 +82,11 @@ type Server struct {
 	// auto-append heuristic never fires on top of auto-loaded-only state. Guarded
 	// by genMu (only read/written inside the locked generate_snapshot handler).
 	snapshotsGenerated bool
+
+	// corpusByRepo remembers each repo's measured corpus for this session, so a
+	// later append can price cross-repo edge resolution against what is already
+	// loaded. Guarded by genMu, like snapshotsGenerated.
+	corpusByRepo map[string]int
 
 	// Freshness-banner cache. freshnessBanner() shells out to git per repo, so the
 	// result is memoized for freshTTL to keep that cost off the hot path of
@@ -84,6 +120,12 @@ func New(eng *engine.Engine, cfg *config.Config) (*Server, error) {
 	// Prepend a freshness warning to tool results when the loaded graph looks
 	// stale. Registered once here so it also covers the license-gated enterprise
 	// tools, which register on this same MCP server after New returns.
+	// Order matters: valueMiddleware is registered first so it runs OUTSIDE the
+	// freshness one, and therefore measures the response the agent actually
+	// receives — banner included. Both are registered once here, so they also
+	// cover the license-gated enterprise tools, which register on this same MCP
+	// server after New returns.
+	s.mcp.AddReceivingMiddleware(s.valueMiddleware)
 	s.mcp.AddReceivingMiddleware(s.freshnessMiddleware)
 
 	return s, nil
@@ -96,21 +138,158 @@ func (s *Server) Run(ctx context.Context) error {
 	return s.mcp.Run(ctx, &mcp.StdioTransport{})
 }
 
-// SetToolCallback sets a callback invoked each time a tool is called. The
-// callback receives the tool name and the absolute path of the repo the call
+// SetToolCallback sets a callback invoked once per completed tool call. The
+// callback receives the tool name, the absolute path of the repo the call
 // operated on (the active snapshot's repo, or the target repo for
-// generate_snapshot). It is safe to call before Run().
-func (s *Server) SetToolCallback(cb func(tool, repo string)) {
+// generate_snapshot), whether the call succeeded, how large its response was,
+// and any snapshot detail. It is safe to call before Run().
+func (s *Server) SetToolCallback(cb func(status.ToolCall)) {
 	fn := toolCallbackFunc(cb)
 	s.toolCallback.Store(&fn)
 }
 
 // fireToolCallback invokes the tool callback if set. Safe to call concurrently
 // from multiple tool-call goroutines.
-func (s *Server) fireToolCallback(tool, repo string) {
+func (s *Server) fireToolCallback(call status.ToolCall) {
 	if cbp := s.toolCallback.Load(); cbp != nil {
-		(*cbp)(tool, repo)
+		(*cbp)(call)
 	}
+}
+
+// valueMiddleware records every tool call AFTER its handler has run.
+//
+// Recording centrally, and after the handler, is what makes three things
+// possible. The outcome is known, so a validation failure or a "run
+// generate_snapshot first" is counted as a call but credited nothing. The
+// response is in hand, so its size can be subtracted — which is what makes
+// output_mode visible in the estimate. And because it is registered once on the
+// shared MCP server, it covers the license-gated enterprise tools too, so a
+// wrapper never has to report its own calls and cannot drift by forgetting.
+func (s *Server) valueMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		if method != "tools/call" {
+			return next(ctx, method, req)
+		}
+		params, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+		if !ok {
+			return next(ctx, method, req)
+		}
+
+		rec := &callRecord{}
+		result, err := next(context.WithValue(ctx, callRecordKey{}, rec), method, req)
+
+		call := status.ToolCall{Tool: params.Name, Repo: s.activeRepo(), OK: err == nil}
+		if ctr, ok := result.(*mcp.CallToolResult); ok && ctr != nil {
+			call.OK = call.OK && !ctr.IsError
+			call.ResponseBytes = resultBytes(ctr)
+		}
+		rec.mu.Lock()
+		if rec.repo != "" {
+			call.Repo = rec.repo
+		}
+		call.Snapshot = rec.snapshot
+		rec.mu.Unlock()
+
+		s.fireToolCallback(call)
+		return result, err
+	}
+}
+
+// charsPerToken is the rough characters-per-token ratio used to convert source
+// bytes into tokens, matching the engine's own heuristic elsewhere.
+const charsPerToken = 4
+
+// rememberCorpus records a repo's measured corpus so that snapshotting a sibling
+// repo afterwards can price the cross-repo edge resolution against everything
+// already loaded. Caller holds genMu.
+func (s *Server) rememberCorpus(repo string, tokens int) {
+	if s.corpusByRepo == nil {
+		s.corpusByRepo = make(map[string]int)
+	}
+	s.corpusByRepo[repo] = tokens
+}
+
+// priorCorpusTokens is the combined corpus loaded before this call, excluding the
+// repo about to be indexed. It is deliberately session-scoped: after a restart it
+// starts empty, so the first snapshot of a session claims no cross-repo premium.
+// Under-crediting a restart is the right way to be wrong here. Caller holds genMu.
+func (s *Server) priorCorpusTokens(exclude string) int {
+	total := 0
+	for repo, tokens := range s.corpusByRepo {
+		if repo != exclude {
+			total += tokens
+		}
+	}
+	return total
+}
+
+// previousSnapshot reads a repo's last snapshot id and file hashes from its own
+// .enola directory. Returns zero values when there is no readable previous
+// snapshot, which the caller treats as a first build.
+func previousSnapshot(absRepo string) (string, map[string]string) {
+	data, err := os.ReadFile(filepath.Join(absRepo, ".enola", "snapshot.meta.json"))
+	if err != nil {
+		return "", nil
+	}
+	var meta facts.SnapshotMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", nil
+	}
+	hashes := make(map[string]string, len(meta.FileHashes))
+	for _, fh := range meta.FileHashes {
+		hashes[fh.Path] = fh.Hash
+	}
+	return meta.SnapshotID, hashes
+}
+
+// changedFraction is the share of the current files whose content differs from
+// the previous snapshot (added, removed or modified), in [0,1]. It returns -1
+// when there is no previous snapshot to compare against — a first build, which
+// the value model prices as re-deriving everything.
+//
+// Returning -1 rather than 1 for that case matters: a genuine zero (the files
+// are identical even though the snapshot id moved, e.g. after a version bump)
+// must earn confirmation credit, not a full rebuild's worth.
+func changedFraction(prev map[string]string, current []facts.FileHash) float64 {
+	if len(prev) == 0 || len(current) == 0 {
+		return -1
+	}
+	changed := 0
+	for _, fh := range current {
+		if prev[fh.Path] != fh.Hash {
+			changed++
+		}
+	}
+	// Files that disappeared are work too: their edges have to be retired.
+	for path := range prev {
+		found := false
+		for _, fh := range current {
+			if fh.Path == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			changed++
+		}
+	}
+	f := float64(changed) / float64(len(current))
+	if f > 1 {
+		return 1
+	}
+	return f
+}
+
+// resultBytes measures the text an agent has to read from a tool result. Non-text
+// content is ignored rather than guessed at.
+func resultBytes(ctr *mcp.CallToolResult) int {
+	n := 0
+	for _, c := range ctr.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			n += len(tc.Text)
+		}
+	}
+	return n
 }
 
 // freshTTL bounds how often the freshness banner recomputes. The banner shells out
@@ -592,10 +771,6 @@ func (s *Server) registerTools() {
 			return errorResult(fmt.Sprintf("invalid repo path: %v", err)), nil, nil
 		}
 
-		// Attribute this call to the repo actually being indexed (resolved
-		// above), not the previously loaded one.
-		s.fireToolCallback("generate_snapshot", absRepo)
-
 		if args.Fresh && args.Append {
 			return errorResult("fresh and append are mutually exclusive: fresh forces a single-repo reset; append adds to the existing store. Pick one."), nil, nil
 		}
@@ -639,11 +814,38 @@ func (s *Server) registerTools() {
 			}
 		}
 
+		// A non-append snapshot resets the store, so the cross-repo corpus pool must
+		// reset with it. Without this, the premium for joining a graph is charged
+		// against repos that were discarded when the store was cleared — a repo
+		// appended to a small cluster would be credited for edges against every
+		// unrelated repo snapshotted earlier in the session.
+		if !appendMode {
+			s.corpusByRepo = nil
+		}
+
+		// Read this repo's previous snapshot from disk before overwriting it, so the
+		// value model can tell a first build from a refresh, and an unchanged
+		// refresh from one that has real work to re-derive. Disk rather than the
+		// in-memory snapshot because in append mode the loaded snapshot describes
+		// whichever repo was indexed last, not this one.
+		prevID, prevHashes := previousSnapshot(absRepo)
+		priorCorpus := s.priorCorpusTokens(absRepo)
+
 		snapshot, err := s.eng.GenerateSnapshot(ctx, absRepo, appendMode)
 		if err != nil {
 			return errorResult(fmt.Sprintf("snapshot generation failed: %v", err)), nil, nil
 		}
 		s.snapshotsGenerated = true
+
+		corpusTokens := int(snapshot.Meta.SourceBytes / charsPerToken)
+		s.rememberCorpus(absRepo, corpusTokens)
+		recordSnapshot(ctx, absRepo, status.SnapshotValue{
+			CorpusTokens:      corpusTokens,
+			PriorCorpusTokens: priorCorpus,
+			Append:            appendMode,
+			Unchanged:         prevID != "" && prevID == snapshot.Meta.SnapshotID,
+			ChangedFraction:   changedFraction(prevHashes, snapshot.Meta.FileHashes),
+		})
 
 		// Write artifacts to disk
 		if err := s.eng.WriteArtifacts(absRepo); err != nil {
@@ -752,7 +954,6 @@ func (s *Server) registerTools() {
 			"For dependencies, set prop='source' prop_value='internal'|'external'|'stdlib' to filter noise. " +
 			"Supports pagination via offset/limit (default 100, max 500).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args queryFactsArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("query_facts", s.activeRepo())
 		store := s.eng.Store()
 		if store.Count() == 0 {
 			return errorResult("No facts available. Run generate_snapshot first."), nil, nil
@@ -890,7 +1091,6 @@ func (s *Server) registerTools() {
 			"Use context_lines to widen or narrow the window. " +
 			"Works in both single-repo and multi-repo (append) mode.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args showSymbolArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("show_symbol", s.activeRepo())
 		snapshot := s.eng.Snapshot()
 		if snapshot == nil {
 			return errorResult("No snapshot available. Run generate_snapshot first."), nil, nil
@@ -986,7 +1186,6 @@ func (s *Server) registerTools() {
 			"Accepts absolute filesystem paths — they are normalised automatically. Pass max_tokens to hard-cap large directory/module output. " +
 			"Use query_facts for precise filtering, traverse for multi-hop graph walks.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args exploreArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("explore", s.activeRepo())
 		store := s.eng.Store()
 		if store.Count() == 0 {
 			return errorResult("No facts available. Run generate_snapshot first."), nil, nil
@@ -1047,7 +1246,6 @@ func (s *Server) registerTools() {
 			"Start with summary; escalate to compact/full only when you need specific nodes. Always keep max_depth/max_nodes bounded, and pass max_tokens to hard-cap the response. " +
 			"Defaults: max_depth=5, max_nodes=100. Use instead of repeated explore calls for transitive relationships.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args traverseArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("traverse", s.activeRepo())
 		store := s.eng.Store()
 		if store.Count() == 0 {
 			return errorResult("No facts available. Run generate_snapshot first."), nil, nil
@@ -1129,7 +1327,6 @@ func (s *Server) registerTools() {
 			"If no path connects any candidate pair, found=false and a 'note' explains whether the endpoints were " +
 			"ambiguous (with the candidates tried) or resolved uniquely but unreachable within max_depth hops.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args findPathArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("find_path", s.activeRepo())
 		store := s.eng.Store()
 		if store.Count() == 0 {
 			return errorResult("No facts available. Run generate_snapshot first."), nil, nil
@@ -1205,7 +1402,6 @@ func (s *Server) registerTools() {
 			"Start with summary; escalate only when you need the specific nodes. Keep max_depth/max_nodes bounded and pass max_tokens to hard-cap the response. " +
 			"Defaults: max_depth=3, max_nodes=200.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args impactAnalysisArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("impact_analysis", s.activeRepo())
 		store := s.eng.Store()
 		if store.Count() == 0 {
 			return errorResult("No facts available. Run generate_snapshot first."), nil, nil
@@ -1265,7 +1461,6 @@ func (s *Server) registerTools() {
 			"Use this before concluding a service is isolated. Only meaningful for multi-repo (append-mode) snapshots; single-repo snapshots have no service nodes. " +
 			"output_mode='summary' (DEFAULT) returns a markdown table; 'full' returns JSON. Optional repo= filters to one service.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args coverageReportArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("coverage_report", s.activeRepo())
 		store := s.eng.Store()
 		if store.Count() == 0 {
 			return errorResult("No facts available. Run generate_snapshot first."), nil, nil
@@ -1295,7 +1490,6 @@ func (s *Server) registerTools() {
 			"All explainers populate insights, but route/cross-repo findings (unused-routes, crossrepo, coverage) only appear for multi-repo (append-mode) snapshots of a backend plus its clients. " +
 			"Prefer this over hand-diffing query_facts results: e.g. query_insights(explainer=\"unused-routes\") returns the per-repo dead-route candidates directly.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args queryInsightsArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("query_insights", s.activeRepo())
 		snap := s.eng.Snapshot()
 		if snap == nil {
 			return errorResult("No snapshot available. Run generate_snapshot first."), nil, nil
@@ -1329,7 +1523,6 @@ func (s *Server) registerTools() {
 			"The pinned baseline survives repeated generate_snapshot runs, so it stays valid across several edit rounds — " +
 			"unlike the auto-rotated 'previous' snapshot, which only ever holds the immediately-preceding run.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args setBaselineArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("set_baseline", s.activeRepo())
 		repoPath := s.currentRepoPath()
 		if repoPath == "" {
 			return errorResult("No snapshot available. Run generate_snapshot first, then set_baseline."), nil, nil
@@ -1358,7 +1551,6 @@ func (s *Server) registerTools() {
 			"output_mode ladder: 'summary' (DEFAULT — headline regressions/improvements + structural tally) → 'compact' (adds finding descriptions, evidence, and the changed edges/facts) → 'full' (complete JSON). " +
 			"New findings carry their original confidence and caveats; confidence < 1.0 is a candidate to verify, not a verdict.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args diffSnapshotArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("diff_snapshot", s.activeRepo())
 		snap := s.eng.Snapshot()
 		if snap == nil || s.eng.Store().Count() == 0 {
 			return errorResult("No snapshot available. Run generate_snapshot first."), nil, nil
@@ -1422,7 +1614,6 @@ func (s *Server) registerTools() {
 			"Read it before trusting an impact_analysis or a diff, and to spot thin extraction (a missing detection, a bad ignore glob, a failing extractor). " +
 			"output_mode: 'summary' (DEFAULT — the headline provenance + quality metrics) → 'full' (complete JSON receipt).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args snapshotReceiptArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("snapshot_receipt", s.activeRepo())
 		snap := s.eng.Snapshot()
 		if snap == nil || s.eng.Store().Count() == 0 {
 			return errorResult("No snapshot available. Run generate_snapshot first."), nil, nil
@@ -1444,7 +1635,6 @@ func (s *Server) registerTools() {
 			"baseline= selects what to compare against: 'pinned' (DEFAULT — set_baseline snapshot), 'previous' (the immediately-preceding run), or an explicit path to a directory holding receipt.json/snapshot.meta.json. " +
 			"output_mode: 'summary' (DEFAULT — markdown) → 'full' (complete JSON).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args compareReceiptsArgs) (*mcp.CallToolResult, any, error) {
-		s.fireToolCallback("compare_receipts", s.activeRepo())
 		snap := s.eng.Snapshot()
 		if snap == nil || s.eng.Store().Count() == 0 {
 			return errorResult("No snapshot available. Run generate_snapshot first."), nil, nil

--- a/internal/server/usage_e2e_test.go
+++ b/internal/server/usage_e2e_test.go
@@ -32,7 +32,7 @@ func TestE2E_ToolUsageIsRecordedForStatus(t *testing.T) {
 	repo := copyTree(t, filepath.Join("..", "engine", "testdata", "repos", "go_sample"), t.TempDir())
 	tracker := status.NewTracker(repo)
 	tracker.SetStartTime(time.Now())
-	srv.SetToolCallback(tracker.OnToolCall)
+	srv.SetToolCallback(tracker.Record)
 	tracker.PersistStartup()
 
 	serverT, clientT := mcp.NewInMemoryTransports()
@@ -75,7 +75,62 @@ func TestE2E_ToolUsageIsRecordedForStatus(t *testing.T) {
 	}
 
 	// The value estimate is what makes --status more than a counter dump.
-	if rep := status.ComputeValue(ss.GrandTotal); rep.TotalCalls != 3 || rep.TotalTokensSaved == 0 {
+	rep := status.ComputeValue(ss.GrandTotal, ss.GrandSaved)
+	if rep.TotalCalls != 3 || rep.TotalTokensSaved == 0 {
 		t.Errorf("value report over recorded usage: %d calls, %d tokens saved", rep.TotalCalls, rep.TotalTokensSaved)
+	}
+
+	// Credit must be recorded per call, not re-derived from counts at render
+	// time — that is what keeps the figure identical across binaries.
+	if ss.GrandSaved["generate_snapshot"] == 0 {
+		t.Error("generate_snapshot recorded no corpus-derived credit")
+	}
+	if ss.GrandSaved["query_facts"] == 0 {
+		t.Error("query_facts recorded no credit")
+	}
+}
+
+// A tool that fails is still a call that happened, but it displaced no work.
+// This holds end-to-end only because recording runs after the handler: a read
+// tool called with no snapshot loaded must earn nothing for its error message.
+func TestE2E_FailedCallCountedButNotCredited(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("HOME", t.TempDir())
+
+	eng, cfg := newTestEngine(t)
+	srv, err := bootstrap.NewServer(eng, cfg)
+	if err != nil {
+		t.Fatalf("bootstrap.NewServer: %v", err)
+	}
+
+	tracker := status.NewTracker(t.TempDir())
+	tracker.SetStartTime(time.Now())
+	srv.SetToolCallback(tracker.Record)
+	tracker.PersistStartup()
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	if _, err := srv.MCP().Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "enola-test", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	// No snapshot has been generated, so this returns "No facts available".
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "query_insights", Arguments: map[string]any{},
+	}); err != nil {
+		t.Fatalf("query_insights: %v", err)
+	}
+
+	ss := status.ServerSnapshot()
+	if got := ss.GrandTotal["query_insights"]; got != 1 {
+		t.Errorf("failed call should still be counted: got %d, want 1", got)
+	}
+	if got := ss.GrandSaved["query_insights"]; got != 0 {
+		t.Errorf("failed call must earn no credit: got %d, want 0", got)
 	}
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -168,10 +168,14 @@ func (s *Server) Run(ctx context.Context) error {
 	return s.srv.Run(ctx)
 }
 
-// SetToolCallback sets a callback invoked each time a tool is called. The
-// callback receives the tool name and the absolute repo path the call operated
-// on.
-func (s *Server) SetToolCallback(cb func(tool, repo string)) {
+// SetToolCallback sets a callback invoked once per completed tool call, with the
+// tool name, the absolute repo path the call operated on, whether it succeeded,
+// its response size and any snapshot detail — everything the value model needs
+// that cannot be recovered from a call count afterwards.
+//
+// It fires for every tool on the server, including those a wrapper binary
+// registers, so a wrapper does not report its own calls.
+func (s *Server) SetToolCallback(cb func(status.ToolCall)) {
 	s.srv.SetToolCallback(cb)
 }
 

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -390,6 +390,9 @@ type pageData struct {
 	Tools      []toolRow
 	Values     []valueRow
 	ValueTotal valueRow
+	// BeyondContext marks that some indexed corpus exceeded what an agent can
+	// hold at once, where the token figure understates what enola did.
+	BeyondContext bool
 
 	HasReceipt  bool
 	Receipt     *facts.Receipt
@@ -477,7 +480,8 @@ func (s *Server) buildPage() pageData {
 			data.TrackingSince = ss.TrackingSince.Format("2006-01-02 15:04:05")
 		}
 		data.Tools = toolRows(ss.GrandTotal, self.SessionCounts)
-		data.Values, data.ValueTotal = valueRows(ss.GrandTotal)
+		data.Values, data.ValueTotal = valueRows(ss.GrandTotal, ss.GrandSaved)
+		data.BeyondContext = ss.BeyondContext
 		data.Instances = instanceRows(ss.Instances, self.PID, now)
 	}
 	if len(data.Instances) == 0 {
@@ -610,8 +614,8 @@ func toolRows(total, session map[string]int) []toolRow {
 
 // valueRows builds the per-tool value-estimate rows plus the total row, reusing
 // the shared status value model so the numbers match --status exactly.
-func valueRows(total map[string]int) ([]valueRow, valueRow) {
-	rep := status.ComputeValue(total)
+func valueRows(total, saved map[string]int) ([]valueRow, valueRow) {
+	rep := status.ComputeValue(total, saved)
 	rows := make([]valueRow, 0, len(rep.Tools))
 	for _, tv := range rep.Tools {
 		rows = append(rows, valueRow{

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -569,7 +569,7 @@ func TestHandlerRendersQualityModals(t *testing.T) {
 }
 
 func TestValueRowsHasTotal(t *testing.T) {
-	rows, total := valueRows(map[string]int{"explore": 3})
+	rows, total := valueRows(map[string]int{"explore": 3}, map[string]int{"explore": 24_000})
 	if len(rows) != 1 {
 		t.Fatalf("rows = %d, want 1", len(rows))
 	}
@@ -578,6 +578,11 @@ func TestValueRowsHasTotal(t *testing.T) {
 	}
 	if total.Label != "TOTAL" || total.Calls != 3 {
 		t.Errorf("total = %+v", total)
+	}
+	// The page must render the credit that was recorded, so the dashboard and
+	// --status can never disagree about the same usage file.
+	if rows[0].TokensSaved != "24.0K" {
+		t.Errorf("TokensSaved = %q, want 24.0K", rows[0].TokensSaved)
 	}
 }
 

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -171,9 +171,10 @@
     <thead><tr><th>Tool</th><th class="num">Calls</th><th class="num">~Time saved</th><th class="num">~Tokens saved</th></tr></thead>
     <tbody>
       {{range .Values}}<tr><td>{{.Label}}</td><td class="num">{{.Calls}}</td><td class="num">{{.TimeSaved}}</td><td class="num">{{.TokensSaved}}</td></tr>{{end}}
-      <tr class="total"><td>{{.ValueTotal.Label}}</td><td class="num">{{.ValueTotal.Calls}}</td><td class="num">{{.ValueTotal.TimeSaved}}</td><td class="num">{{.ValueTotal.TokensSaved}}</td></tr>
+      <tr class="total"><td>{{.ValueTotal.Label}}</td><td class="num">{{.ValueTotal.Calls}}</td><td class="num">{{.ValueTotal.TimeSaved}}</td><td class="num">{{.ValueTotal.TokensSaved}}{{if .BeyondContext}}&#8224;{{end}}</td></tr>
     </tbody>
   </table></div>
+  {{if .BeyondContext}}<p class="note">&#8224; Some indexed corpus exceeds a single context window &mdash; that part is not reproducible by re-reading files at any budget, so the token figure understates it.</p>{{end}}
   {{else}}<p class="note">No value recorded yet.</p>{{end}}
 
   <h2>Current snapshot receipt</h2>

--- a/pkg/status/aggregate.go
+++ b/pkg/status/aggregate.go
@@ -13,6 +13,9 @@ import (
 type RepoUsage struct {
 	RepoPath      string
 	Counts        map[string]int // lifetime grand total
+	Saved         map[string]int // lifetime token credit, per tool
+	BeyondContext bool           // some call spanned more than one context window
+	CorpusTokens  int            // last measured parsed-source size
 	TrackingSince time.Time
 }
 
@@ -20,6 +23,8 @@ type RepoUsage struct {
 type Aggregate struct {
 	Repos         []RepoUsage    // sorted by tokens saved, descending
 	Combined      map[string]int // summed grand totals across all repos
+	CombinedSaved map[string]int // summed token credit across all repos
+	BeyondContext bool           // any repo exceeded a context window
 	TrackingSince time.Time      // earliest across all repos
 }
 
@@ -29,6 +34,7 @@ type Aggregate struct {
 func AggregateUsage(dir string) (Aggregate, error) {
 	var agg Aggregate
 	agg.Combined = make(map[string]int)
+	agg.CombinedSaved = make(map[string]int)
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -53,11 +59,18 @@ func AggregateUsage(dir string) (Aggregate, error) {
 		agg.Repos = append(agg.Repos, RepoUsage{
 			RepoPath:      info.RepoPath,
 			Counts:        info.ToolCounts,
+			Saved:         info.TokensSaved,
+			BeyondContext: info.BeyondContext,
+			CorpusTokens:  info.CorpusTokens,
 			TrackingSince: info.TrackingSince,
 		})
 		for k, v := range info.ToolCounts {
 			agg.Combined[k] += v
 		}
+		for k, v := range info.TokensSaved {
+			agg.CombinedSaved[k] += v
+		}
+		agg.BeyondContext = agg.BeyondContext || info.BeyondContext
 		if !info.TrackingSince.IsZero() && (agg.TrackingSince.IsZero() || info.TrackingSince.Before(agg.TrackingSince)) {
 			agg.TrackingSince = info.TrackingSince
 		}
@@ -65,8 +78,8 @@ func AggregateUsage(dir string) (Aggregate, error) {
 
 	// Sort repos by estimated tokens saved, descending (biggest value first).
 	sort.Slice(agg.Repos, func(i, j int) bool {
-		return ComputeValue(agg.Repos[i].Counts).TotalTokensSaved >
-			ComputeValue(agg.Repos[j].Counts).TotalTokensSaved
+		return ComputeValue(agg.Repos[i].Counts, agg.Repos[i].Saved).TotalTokensSaved >
+			ComputeValue(agg.Repos[j].Counts, agg.Repos[j].Saved).TotalTokensSaved
 	})
 
 	return agg, nil
@@ -86,6 +99,9 @@ func AggregateUsage(dir string) (Aggregate, error) {
 type ServerStatus struct {
 	GrandTotal    map[string]int // sum of ToolCounts across all repos (lifetime)
 	Session       map[string]int // sum of SessionCounts across live instances
+	GrandSaved    map[string]int // sum of TokensSaved across all repos (lifetime)
+	SessionSaved  map[string]int // sum of SessionTokens across live instances
+	BeyondContext bool           // any repo's corpus exceeded a context window
 	Instances     []Instance     // every server running right now, oldest first
 	StartTime     time.Time      // primary instance's start time
 	PID           int            // primary instance's PID
@@ -109,8 +125,10 @@ type ServerStatus struct {
 // Best-effort: unreadable/malformed files are skipped.
 func AggregateServer(dir string) ServerStatus {
 	ss := ServerStatus{
-		GrandTotal: make(map[string]int),
-		Session:    make(map[string]int),
+		GrandTotal:   make(map[string]int),
+		Session:      make(map[string]int),
+		GrandSaved:   make(map[string]int),
+		SessionSaved: make(map[string]int),
 	}
 
 	entries, err := os.ReadDir(dir)
@@ -144,6 +162,10 @@ func AggregateServer(dir string) ServerStatus {
 		for k, v := range info.ToolCounts {
 			ss.GrandTotal[k] += v
 		}
+		for k, v := range info.TokensSaved {
+			ss.GrandSaved[k] += v
+		}
+		ss.BeyondContext = ss.BeyondContext || info.BeyondContext
 		if !info.TrackingSince.IsZero() && (ss.TrackingSince.IsZero() || info.TrackingSince.Before(ss.TrackingSince)) {
 			ss.TrackingSince = info.TrackingSince
 		}
@@ -154,6 +176,9 @@ func AggregateServer(dir string) ServerStatus {
 		for _, inst := range ss.Instances {
 			for k, v := range inst.SessionCounts {
 				ss.Session[k] += v
+			}
+			for k, v := range inst.SessionTokens {
+				ss.SessionSaved[k] += v
 			}
 		}
 		primary := primaryInstance(ss.Instances)
@@ -176,6 +201,12 @@ func AggregateServer(dir string) ServerStatus {
 		if info.StartTime.Equal(ss.StartTime) {
 			for k, v := range info.SessionCounts {
 				ss.Session[k] += v
+			}
+			// Credit must travel with the counts here too. Summing one without
+			// the other leaves the session row to be repriced by the legacy
+			// fallback, which made it disagree with the lifetime TOTAL above it.
+			for k, v := range info.SessionTokens {
+				ss.SessionSaved[k] += v
 			}
 		}
 	}
@@ -235,14 +266,33 @@ func PrintStatusAll() {
 	fmt.Fprintf(os.Stderr, "\nValue Estimate (approximate):\n")
 	fmt.Fprintf(os.Stderr, "  %-*s  %6s  %12s  %14s\n", maxLen, "repo", "calls", "~time saved", "~tokens saved")
 	for _, r := range agg.Repos {
-		v := ComputeValue(r.Counts)
-		fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
-			maxLen, displayRepo(r.RepoPath), v.TotalCalls, formatDuration(v.TotalTimeSaved), humanCount(v.TotalTokensSaved))
+		v := ComputeValue(r.Counts, r.Saved)
+		fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %13s%s\n",
+			maxLen, displayRepo(r.RepoPath), v.TotalCalls, formatDuration(v.TotalTimeSaved),
+			humanCount(v.TotalTokensSaved), beyondMark(r.BeyondContext))
 	}
-	total := ComputeValue(agg.Combined)
-	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
-		maxLen, "TOTAL", total.TotalCalls, formatDuration(total.TotalTimeSaved), humanCount(total.TotalTokensSaved))
+	total := ComputeValue(agg.Combined, agg.CombinedSaved)
+	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %13s%s\n",
+		maxLen, "TOTAL", total.TotalCalls, formatDuration(total.TotalTimeSaved),
+		humanCount(total.TotalTokensSaved), beyondMark(agg.BeyondContext))
+	if agg.BeyondContext {
+		fmt.Fprintf(os.Stderr, "\n  %s\n", beyondNote)
+	}
 	fmt.Fprintf(os.Stderr, "\n")
+}
+
+// beyondNote explains the marker on rows whose corpus exceeds what an agent can
+// hold at once. For those, the token figure understates the case: the work was
+// not merely cheaper through enola, it was not available any other way.
+const beyondNote = "† corpus exceeds a single context window — not reproducible by re-reading files."
+
+// beyondMark returns the flag appended to a value row, or a blank of equal width
+// so unflagged rows stay aligned with flagged ones.
+func beyondMark(beyond bool) string {
+	if beyond {
+		return "†"
+	}
+	return " "
 }
 
 // displayRepo renders a repo path for the aggregate table. The full path is

--- a/pkg/status/footprint.go
+++ b/pkg/status/footprint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // charsPerToken is the rough characters-per-token ratio used to convert source
@@ -47,9 +48,22 @@ type snapshotMeta struct {
 	InsightCount int    `json:"insight_count"`
 	FilesSeen    int    `json:"files_seen"`
 	FilesParsed  int    `json:"files_parsed"`
+	SourceBytes  int64  `json:"source_bytes"`
 	FileHashes   []struct {
 		Path string `json:"path"`
 	} `json:"file_hashes"`
+}
+
+// sourceExts is the fallback filter for snapshots written before the engine
+// recorded SourceBytes. It approximates "a file an extractor could have parsed";
+// the engine's own figure, which knows exactly which files produced facts, is
+// always preferred.
+var sourceExts = map[string]bool{
+	".go": true, ".ts": true, ".tsx": true, ".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
+	".rb": true, ".py": true, ".kt": true, ".kts": true, ".swift": true, ".java": true,
+	".rs": true, ".php": true, ".c": true, ".cc": true, ".cpp": true, ".cxx": true,
+	".h": true, ".hpp": true, ".hxx": true, ".m": true, ".mm": true,
+	".proto": true, ".vue": true, ".erb": true, ".haml": true,
 }
 
 // ScanFootprint walks the given .enola directory and reads the snapshot metadata
@@ -109,16 +123,29 @@ func (fp *Footprint) applySnapshotMeta(enolaDir string) {
 		fp.FilesIndexed = meta.FilesSeen
 	}
 
-	for _, fh := range meta.FileHashes {
-		p := fh.Path
-		if !filepath.IsAbs(p) && meta.RepoPath != "" {
-			p = filepath.Join(meta.RepoPath, p)
+	// Prefer the engine's own measurement: it is the size of exactly the files
+	// that produced facts. Only fall back to walking file_hashes for snapshots
+	// written before that field existed — and even then, filter to plausible
+	// source extensions. file_hashes is the files_SEEN set, so summing it whole
+	// counts images, media and vendored databases as though an agent would have
+	// read them: on one real repo, 121M tokens against 3.1M of actual source.
+	if meta.SourceBytes > 0 {
+		fp.SourceBytes = meta.SourceBytes
+	} else {
+		for _, fh := range meta.FileHashes {
+			if !sourceExts[strings.ToLower(filepath.Ext(fh.Path))] {
+				continue
+			}
+			p := fh.Path
+			if !filepath.IsAbs(p) && meta.RepoPath != "" {
+				p = filepath.Join(meta.RepoPath, p)
+			}
+			info, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			fp.SourceBytes += info.Size()
 		}
-		info, err := os.Stat(p)
-		if err != nil {
-			continue
-		}
-		fp.SourceBytes += info.Size()
 	}
 	fp.SourceTokens = int(fp.SourceBytes / charsPerToken)
 }

--- a/pkg/status/footprint_test.go
+++ b/pkg/status/footprint_test.go
@@ -91,6 +91,73 @@ func TestScanFootprint(t *testing.T) {
 	}
 }
 
+// The engine's own measurement covers exactly the files that produced facts, so
+// it must win outright over anything derived from the walked-file list.
+func TestScanFootprintPrefersEngineMeasurement(t *testing.T) {
+	repo := t.TempDir()
+	enolaDir := filepath.Join(repo, ".enola")
+	if err := os.MkdirAll(enolaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "a.go"), make([]byte, 400), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]any{
+		"repo_path":    repo,
+		"source_bytes": 12345,
+		"file_hashes":  []map[string]string{{"path": "a.go"}},
+	}
+	metaBytes, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(enolaDir, "snapshot.meta.json"), metaBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := ScanFootprint(enolaDir)
+	if fp.SourceBytes != 12345 {
+		t.Errorf("SourceBytes: got %d, want the engine's 12345", fp.SourceBytes)
+	}
+}
+
+// file_hashes is the files_SEEN set. Summing it whole counts images, media and
+// vendored databases as though an agent would have read them — on a real repo
+// that turned a 3.1M-token corpus into 121M. The fallback must filter to source.
+func TestScanFootprintFallbackExcludesNonSource(t *testing.T) {
+	repo := t.TempDir()
+	enolaDir := filepath.Join(repo, ".enola")
+	if err := os.MkdirAll(filepath.Join(repo, "uploads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(enolaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "a.go"), make([]byte, 400), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A big binary the walker saw but no extractor ever parsed.
+	if err := os.WriteFile(filepath.Join(repo, "uploads", "photo.jpg"), make([]byte, 4_000_000), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No source_bytes: an old snapshot, so the fallback path runs.
+	meta := map[string]any{
+		"repo_path": repo,
+		"file_hashes": []map[string]string{
+			{"path": "a.go"},
+			{"path": "uploads/photo.jpg"},
+		},
+	}
+	metaBytes, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(enolaDir, "snapshot.meta.json"), metaBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := ScanFootprint(enolaDir)
+	if fp.SourceBytes != 400 {
+		t.Errorf("SourceBytes: got %d, want 400 (the .jpg must not count as corpus)", fp.SourceBytes)
+	}
+}
+
 func TestScanFootprintMissingDir(t *testing.T) {
 	fp := ScanFootprint(filepath.Join(t.TempDir(), "does-not-exist"))
 	if fp.TotalBytes != 0 || fp.Facts != 0 {

--- a/pkg/status/instance.go
+++ b/pkg/status/instance.go
@@ -81,6 +81,7 @@ type Instance struct {
 	LastTool      string         `json:"last_tool,omitempty"`
 	LastCallAt    time.Time      `json:"last_call_at,omitempty"`
 	SessionCounts map[string]int `json:"session_counts,omitempty"`
+	SessionTokens map[string]int `json:"session_tokens,omitempty"` // token credit earned this session, per tool
 }
 
 // URL is the instance's dashboard URL, or "" when it serves no dashboard.

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -34,6 +34,17 @@ type StatusInfo struct {
 	ToolCounts    map[string]int `json:"tool_counts"`              // lifetime grand total
 	SessionCounts map[string]int `json:"session_counts,omitempty"` // since last reload
 
+	// TokensSaved is the lifetime credit per tool, accumulated at call time and
+	// merged the same way ToolCounts is. It is stored rather than recomputed
+	// because its inputs — corpus size, changed-file fraction, response size —
+	// are only knowable when the call happens. Storing the result also makes the
+	// figure binary-independent: a build that has never heard of a tool renders
+	// the credit that build recorded, instead of silently repricing it.
+	TokensSaved    map[string]int `json:"tokens_saved,omitempty"`
+	SessionTokens  map[string]int `json:"session_tokens,omitempty"`
+	BeyondContext  bool           `json:"beyond_context,omitempty"` // some call spanned more than one context window
+	CorpusTokens   int            `json:"corpus_tokens,omitempty"`  // last measured parsed-source size of this repo
+
 	// DashboardPort is the localhost port of the dashboard served by whichever
 	// process wrote this file last (0 if none). Kept for compatibility with
 	// binaries predating the instance registry; current readers take the port
@@ -109,7 +120,30 @@ type repoState struct {
 	session       map[string]int
 	flushed       map[string]int
 	trackingSince time.Time
+
+	// Token credit is accumulated and merged exactly like the counts above:
+	// savedBaseline is what was on disk at first touch, savedSession is this
+	// process's increments, savedFlushed is how much of that is already durable.
+	savedBaseline map[string]int
+	savedSession  map[string]int
+	savedFlushed  map[string]int
+
+	beyondContext bool
+	corpusTokens  int
 }
+
+// hasSnapshotCredit reports whether this repo's usage history has ever credited
+// a snapshot — lifetime or this session. It is the ledger's own answer to "have I
+// seen this repo built before?", which is the question the value model needs;
+// the repo-local .enola metadata answers a different one ("is this graph on disk
+// current?") and is not a substitute. Caller holds t.mu.
+func (rs *repoState) hasSnapshotCredit() bool {
+	return rs.savedBaseline[snapshotTool] > 0 || rs.savedSession[snapshotTool] > 0
+}
+
+// snapshotTool is the one tool whose value is corpus-derived rather than priced
+// from a weight, so it is the tool the ledger check above looks for.
+const snapshotTool = "generate_snapshot"
 
 // NewTracker creates a multi-repo tracker. fallbackRepo (typically the server's
 // launch dir) is used to attribute calls that report an empty repo path.
@@ -173,10 +207,25 @@ func (t *Tracker) PersistStartup() {
 	t.startHeartbeat()
 }
 
-// OnToolCall is the callback registered with the server. repo is the absolute
-// path of the repo the call operated on; an empty repo falls back to the
-// tracker's fallback repo.
+// OnToolCall records a completed call by name only, crediting it as a successful
+// query. It is retained for callers that cannot describe the outcome; the server
+// uses Record, which prices the call properly.
 func (t *Tracker) OnToolCall(toolName, repo string) {
+	t.Record(ToolCall{Tool: toolName, Repo: repo, OK: true})
+}
+
+// Record accounts for one completed tool call: it increments the call count and
+// accumulates the token credit the call earned. repo is the absolute path of the
+// repo the call operated on; an empty repo falls back to the tracker's fallback
+// repo.
+//
+// Credit is computed here, at call time, because its inputs (corpus size,
+// changed-file fraction, response size) are not recoverable afterwards from a
+// call count. A failed call still increments the count — it happened — but earns
+// nothing, since a validation error or a "run generate_snapshot first" displaces
+// no work.
+func (t *Tracker) Record(call ToolCall) {
+	repo := call.Repo
 	if repo == "" {
 		repo = t.fallbackRepo
 	}
@@ -184,8 +233,32 @@ func (t *Tracker) OnToolCall(toolName, repo string) {
 
 	t.mu.Lock()
 	rs := t.stateLocked(repo)
-	rs.session[toolName]++
-	t.lastTool = toolName
+	// A snapshot the LEDGER has never credited is a first build, whatever the
+	// repo's own .enola metadata says. The server decides "unchanged" by
+	// comparing against that metadata, which lives in the repo and outlives this
+	// usage history entirely — it survives clearing ~/.enola, and it arrives with
+	// a fresh clone. Without this check, a repo carrying a stale meta file earns
+	// confirmation credit forever and its first real build is never priced.
+	if call.Snapshot != nil && !rs.hasSnapshotCredit() {
+		firstBuild := *call.Snapshot
+		firstBuild.Unchanged = false
+		firstBuild.ChangedFraction = -1
+		call.Snapshot = &firstBuild
+	}
+	tokens := call.TokensSaved()
+	rs.session[call.Tool]++
+	// Always write the credit key, even when the call earned nothing. Its
+	// presence is what tells a reader "this figure was recorded, trust it"
+	// rather than falling back to repricing from counts — so a tool whose calls
+	// all failed reports the zero it earned instead of a legacy estimate.
+	rs.savedSession[call.Tool] += tokens
+	if call.BeyondContext() {
+		rs.beyondContext = true
+	}
+	if call.Snapshot != nil && call.Snapshot.CorpusTokens > 0 {
+		rs.corpusTokens = call.Snapshot.CorpusTokens
+	}
+	t.lastTool = call.Tool
 	t.lastCallAt = time.Now()
 	t.mu.Unlock()
 
@@ -263,9 +336,13 @@ func (t *Tracker) Self() Instance {
 	defer t.mu.Unlock()
 
 	session := make(map[string]int)
+	sessionTokens := make(map[string]int)
 	for _, rs := range t.repos {
 		for k, v := range rs.session {
 			session[k] += v
+		}
+		for k, v := range rs.savedSession {
+			sessionTokens[k] += v
 		}
 	}
 
@@ -294,6 +371,7 @@ func (t *Tracker) Self() Instance {
 		LastTool:      t.lastTool,
 		LastCallAt:    t.lastCallAt,
 		SessionCounts: session,
+		SessionTokens: sessionTokens,
 	}
 }
 
@@ -319,10 +397,13 @@ func (t *Tracker) stateLocked(repo string) *repoState {
 		return rs
 	}
 	rs := &repoState{
-		repoPath: repo,
-		baseline: make(map[string]int),
-		session:  make(map[string]int),
-		flushed:  make(map[string]int),
+		repoPath:      repo,
+		baseline:      make(map[string]int),
+		session:       make(map[string]int),
+		flushed:       make(map[string]int),
+		savedBaseline: make(map[string]int),
+		savedSession:  make(map[string]int),
+		savedFlushed:  make(map[string]int),
 	}
 	fp, err := usagePath(repo)
 	if err != nil {
@@ -359,6 +440,11 @@ func (t *Tracker) loadLocked(rs *repoState) {
 	for k, v := range info.ToolCounts {
 		rs.baseline[k] = v
 	}
+	for k, v := range info.TokensSaved {
+		rs.savedBaseline[k] = v
+	}
+	rs.beyondContext = info.BeyondContext
+	rs.corpusTokens = info.CorpusTokens
 	rs.trackingSince = info.TrackingSince
 	if migrated {
 		// Only remove the legacy file once the write to its new home has
@@ -400,6 +486,19 @@ func (t *Tracker) infoLocked(rs *repoState) StatusInfo {
 	for k, v := range rs.session {
 		session[k] = v
 	}
+
+	savedTotal := make(map[string]int, len(rs.savedBaseline)+len(rs.savedSession))
+	for k, v := range rs.savedBaseline {
+		savedTotal[k] = v
+	}
+	for k, v := range rs.savedSession {
+		savedTotal[k] += v
+	}
+	savedSession := make(map[string]int, len(rs.savedSession))
+	for k, v := range rs.savedSession {
+		savedSession[k] = v
+	}
+
 	return StatusInfo{
 		PID:           os.Getpid(),
 		StartTime:     t.start,
@@ -407,6 +506,10 @@ func (t *Tracker) infoLocked(rs *repoState) StatusInfo {
 		RepoPath:      rs.repoPath,
 		ToolCounts:    total,
 		SessionCounts: session,
+		TokensSaved:   savedTotal,
+		SessionTokens: savedSession,
+		BeyondContext: rs.beyondContext,
+		CorpusTokens:  rs.corpusTokens,
 		DashboardPort: t.dashboardPort,
 	}
 }
@@ -442,10 +545,22 @@ func (t *Tracker) flush(rs *repoState) {
 			delta[k] = d
 		}
 	}
+	savedDelta := make(map[string]int, len(rs.savedSession))
+	savedPending := make(map[string]int, len(rs.savedSession))
+	for k, v := range rs.savedSession {
+		savedPending[k] = v
+		// A zero delta is still written, so the key exists on disk for a tool
+		// that earned nothing. Credit only ever grows, so this never subtracts.
+		savedDelta[k] = v - rs.savedFlushed[k]
+	}
 	info := t.infoLocked(rs)
 	baseline := make(map[string]int, len(rs.baseline))
 	for k, v := range rs.baseline {
 		baseline[k] = v
+	}
+	savedBase := make(map[string]int, len(rs.savedBaseline))
+	for k, v := range rs.savedBaseline {
+		savedBase[k] = v
 	}
 	t.mu.Unlock()
 
@@ -453,20 +568,36 @@ func (t *Tracker) flush(rs *repoState) {
 	// siblings have already written. A missing file falls back to the baseline
 	// this process loaded (covers the first write and legacy migration).
 	total := baseline
+	savedTotal := savedBase
 	if onDisk, _, err := ReadStatus(rs.filePath); err == nil {
 		total = onDisk.ToolCounts
 		if total == nil {
 			total = make(map[string]int)
 		}
+		savedTotal = onDisk.TokensSaved
+		if savedTotal == nil {
+			savedTotal = make(map[string]int)
+		}
 		// Keep the earliest tracking-since across processes.
 		if !onDisk.TrackingSince.IsZero() && (info.TrackingSince.IsZero() || onDisk.TrackingSince.Before(info.TrackingSince)) {
 			info.TrackingSince = onDisk.TrackingSince
+		}
+		// Beyond-context is sticky: once any process has recorded a corpus too
+		// large to re-read, that stays true of the repo's history.
+		info.BeyondContext = info.BeyondContext || onDisk.BeyondContext
+		// A sibling that just re-measured the corpus wins only if we have not.
+		if info.CorpusTokens == 0 {
+			info.CorpusTokens = onDisk.CorpusTokens
 		}
 	}
 	for k, v := range delta {
 		total[k] += v
 	}
+	for k, v := range savedDelta {
+		savedTotal[k] += v
+	}
 	info.ToolCounts = total
+	info.TokensSaved = savedTotal
 
 	data, err := json.MarshalIndent(info, "", "  ")
 	if err != nil {
@@ -480,6 +611,9 @@ func (t *Tracker) flush(rs *repoState) {
 	t.mu.Lock()
 	for k, v := range pending {
 		rs.flushed[k] = v
+	}
+	for k, v := range savedPending {
+		rs.savedFlushed[k] = v
 	}
 	t.mu.Unlock()
 }
@@ -552,7 +686,7 @@ func PrintStatus() {
 	fmt.Fprintf(os.Stderr, "Repos tracked: %d\n", ss.Repos)
 
 	printToolUsage(ss.GrandTotal, ss.Session)
-	printValue(ss.GrandTotal, ss.Session)
+	printValue(ss.GrandTotal, ss.GrandSaved, ss.Session, ss.SessionSaved, ss.BeyondContext)
 	fmt.Fprintf(os.Stderr, "\n")
 }
 
@@ -635,13 +769,16 @@ func sortedUnion(maps ...map[string]int) []string {
 
 // printValue renders the estimated time and context (tokens) saved by the
 // recorded tool usage. The per-tool table and grand TOTAL are computed on the
-// lifetime totals; a trailing line adds the current-session subtotal. Figures
-// are estimates from a static per-tool model.
-func printValue(total, session map[string]int) {
+// lifetime totals; a trailing line adds the current-session subtotal.
+//
+// Figures are estimates of the reconstruction an agent did not have to perform —
+// see ARCHITECTURE.md, "The value model". beyond marks that some corpus exceeded
+// a single context window, where the token figure understates the case.
+func printValue(total, saved, session, sessionSaved map[string]int, beyond bool) {
 	if len(total) == 0 {
 		return
 	}
-	rep := ComputeValue(total)
+	rep := ComputeValue(total, saved)
 
 	fmt.Fprintf(os.Stderr, "\nValue Estimate (approximate):\n")
 
@@ -657,12 +794,17 @@ func printValue(total, session map[string]int) {
 		fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
 			maxLen, tv.Tool, tv.Calls, formatDuration(tv.TimeSaved), humanCount(tv.TokensSaved))
 	}
-	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
-		maxLen, "TOTAL", rep.TotalCalls, formatDuration(rep.TotalTimeSaved), humanCount(rep.TotalTokensSaved))
+	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %13s%s\n",
+		maxLen, "TOTAL", rep.TotalCalls, formatDuration(rep.TotalTimeSaved),
+		humanCount(rep.TotalTokensSaved), beyondMark(beyond))
 
-	sess := ComputeValue(session)
+	sess := ComputeValue(session, sessionSaved)
 	fmt.Fprintf(os.Stderr, "  %-*s  %6d  %12s  %14s\n",
 		maxLen, "running now", sess.TotalCalls, formatDuration(sess.TotalTimeSaved), humanCount(sess.TotalTokensSaved))
+
+	if beyond {
+		fmt.Fprintf(os.Stderr, "\n  %s\n", beyondNote)
+	}
 }
 
 // humanCount renders a large count with thousands/millions suffixes (e.g. 1.2M).

--- a/pkg/status/value.go
+++ b/pkg/status/value.go
@@ -6,33 +6,86 @@ import (
 	"time"
 )
 
-// The value model converts raw tool-call counts into two human-meaningful
-// factors: time saved and tokens (context) saved. Each tool is assigned a
-// single weight — the number of manual operations (file reads, greps, symbol
-// lookups) a caller would otherwise perform to get the same answer. Two global
-// constants convert that weight into wall-clock time and token estimates.
+// The value model estimates what enola saved you, in two currencies: tokens and
+// time. It answers one question — *what would an agent have had to ingest to
+// reach the same answer using ordinary tools (grep, glob, open a file, read it,
+// infer)?* — and prices that counterfactual, not the size of enola's own
+// response. See ARCHITECTURE.md, "The value model", for the full rationale.
 //
-// These are deliberately estimates: they are derived entirely from call counts
-// and a static table, with no changes to the engine itself. Tune the numbers
-// freely — the model is one weight per tool plus two conversion constants.
+// Two consequences of that framing drive the whole design:
+//
+//  1. Snapshot value scales with the CORPUS, not with the call. Reconstructing a
+//     33M-token monorepo graph and a 72K-token service graph are not the same act
+//     of work, and no flat per-call price can be right for both — the two are
+//     more than two orders of magnitude apart.
+//
+//  2. Savings are accumulated AT CALL TIME, not recomputed from call counts at
+//     render time. Corpus size, changed-file fraction and response size are only
+//     known when the call happens. Persisting the resulting token figure — rather
+//     than a weight to be re-applied later — also means every binary reports the
+//     same number for the same usage file, instead of a build that has never heard
+//     of a tool pricing it at defaultWeight.
 const (
-	// secondsPerManualOp is the assumed wall-clock cost of one manual lookup
-	// (open a file, read it, decide) that a single tool call replaces.
-	secondsPerManualOp = 30
+	// rediscoveryFactor is the fraction of a corpus an agent actually ingests
+	// while rebuilding this understanding by hand. It reads many files, greps
+	// the rest, and stops when it believes it understands enough — usually
+	// before it does. Crediting the full corpus would assume an exhaustiveness
+	// no agent exhibits.
+	rediscoveryFactor = 0.6
 
-	// tokensPerManualOp is the assumed context cost of one manual lookup —
-	// roughly the tokens of an average source file an agent would read.
-	tokensPerManualOp = 2000
+	// crossRepoPremiumFactor prices the extra work of resolving a new repo's
+	// edges against every repo already loaded. It applies to the PRIOR corpus,
+	// because that is what has to be re-examined to find the cross-repo edges —
+	// the result an agent cannot produce at all once the combined corpus exceeds
+	// its context window.
+	crossRepoPremiumFactor = 0.05
 
-	// defaultWeight is used for any tool name not in toolWeights, so the value
-	// model degrades gracefully if the tool set grows.
+	// refreshConfirmCredit is the per-repo credit for establishing that nothing
+	// changed. Re-snapshotting an unchanged repo is not redundant: it answers
+	// "is my understanding still valid?", which by hand means re-deriving the
+	// graph to discover it did not move. Real, but far below a first build.
+	refreshConfirmCredit = 2000
+
+	// tokensPerManualOp converts a query tool's ordinal weight into tokens. It is
+	// the MEDIAN parsed source file across the measured corpora (~800 tokens),
+	// not the mean, which outliers inflate by roughly 2.5x.
+	tokensPerManualOp = 800
+
+	// agentTokensPerSecond is end-to-end agent discovery throughput — tool round
+	// trips and reasoning included, not raw generation speed. It converts tokens
+	// an agent did not have to ingest into time a human did not have to wait.
+	agentTokensPerSecond = 2500
+
+	// reworkFactor is the non-determinism premium. An agent re-deriving your
+	// architecture from grep does not merely take longer; it gets things subtly
+	// wrong often enough that some of the work is done twice — the migration
+	// attempted again, the caller missed until review, the refactor undone.
+	// enola returns the same graph every time.
+	reworkFactor = 1.5
+
+	// agentContextWindow is the point past which the counterfactual stops being
+	// expensive and becomes impossible: a corpus larger than this cannot be held
+	// at once, so cross-repo edges within it are not derivable by re-reading at
+	// any budget. Entries over it keep their credit but are flagged.
+	agentContextWindow = 1_000_000
+
+	// charsPerTokenApprox converts response bytes to tokens, matching the
+	// engine's own heuristic (mcputil.approxTokensPerChar).
+	charsPerTokenApprox = 4
+
+	// defaultWeight prices any query tool not in toolWeights, so the model
+	// degrades gracefully if the tool set grows.
 	defaultWeight = 5
 )
 
-// toolWeights maps each tool to the number of manual operations one call of it
-// replaces. It covers the tools this engine registers (see pkg/cli.OSSTools);
-// a wrapper binary that adds its own MCP tools prices them via
-// RegisterToolWeights rather than by editing this table.
+// toolWeights maps each query tool to an ordinal judgement: how much manual
+// exploration one call displaces, relative to the other tools. It covers the
+// tools this engine registers (see pkg/cli.OSSTools); a wrapper binary that adds
+// its own MCP tools prices them via RegisterToolWeights rather than by editing
+// this table.
+//
+// generate_snapshot is deliberately absent: its value is corpus-derived (see
+// SnapshotValue) and cannot be expressed as a fixed number of lookups.
 //
 // weightsMu guards the map: registration happens once at startup, but reads run
 // from the MCP server's tool callback and, in wrapper binaries, from concurrent
@@ -40,19 +93,18 @@ const (
 var (
 	weightsMu   sync.RWMutex
 	toolWeights = map[string]int{
-		"show_symbol":       3,
-		"snapshot_receipt":  3,
-		"set_baseline":      4,
-		"query_facts":       8,
-		"compare_receipts":  10,
-		"traverse":          10,
-		"find_path":         12,
-		"explore":           15,
-		"diff_snapshot":     15,
-		"coverage_report":   20,
-		"impact_analysis":   25,
-		"query_insights":    30,
-		"generate_snapshot": 100,
+		"show_symbol":      3,
+		"snapshot_receipt": 3,
+		"set_baseline":     4,
+		"query_facts":      8,
+		"compare_receipts": 10,
+		"traverse":         10,
+		"find_path":        12,
+		"explore":          15,
+		"diff_snapshot":    15,
+		"coverage_report":  20,
+		"impact_analysis":  25,
+		"query_insights":   30,
 	}
 )
 
@@ -60,6 +112,10 @@ var (
 // model, so a wrapper binary that registers additional MCP tools can price them
 // instead of letting them fall back to defaultWeight. Call it during startup,
 // before the server begins serving. Later registrations win for a given tool.
+//
+// Note that the weight is applied when the call is recorded, and the resulting
+// token figure is what gets persisted — so a wrapper's pricing survives into
+// usage files that an OSS binary later reads and renders.
 func RegisterToolWeights(extra map[string]int) {
 	weightsMu.Lock()
 	defer weightsMu.Unlock()
@@ -68,9 +124,7 @@ func RegisterToolWeights(extra map[string]int) {
 	}
 }
 
-// weightFor returns the manual-ops-avoided weight for a tool. This is the single
-// lookup point for the value model; a future config- or license-sourced override
-// (e.g. per-customer tuning or usage gating) would slot in here.
+// weightFor returns the manual-ops-avoided weight for a query tool.
 func weightFor(tool string) int {
 	weightsMu.RLock()
 	defer weightsMu.RUnlock()
@@ -80,26 +134,159 @@ func weightFor(tool string) int {
 	return defaultWeight
 }
 
+// SnapshotValue describes what one generate_snapshot call actually did, which is
+// what its value is derived from. It is supplied by the server at call time.
+type SnapshotValue struct {
+	// CorpusTokens is the token size of the source that produced facts — the
+	// engine's own measurement, never an estimate.
+	CorpusTokens int
+
+	// PriorCorpusTokens is the combined corpus already loaded before this call,
+	// used to price cross-repo edge resolution. Zero for a first/fresh snapshot.
+	PriorCorpusTokens int
+
+	// Append is true when this repo joined an existing multi-repo graph.
+	Append bool
+
+	// Unchanged is true when the snapshot id matched the previous one for this
+	// repo — the graph did not move, and the call's value is the confirmation.
+	Unchanged bool
+
+	// ChangedFraction is the share of parsed files whose content moved since the
+	// previous snapshot, in [0,1]. Ignored when Unchanged is true.
+	//
+	// A NEGATIVE value means "no previous snapshot to compare against" — a first
+	// build, which re-derives everything. Zero is meaningfully different: it says
+	// the files are identical even though the snapshot id moved (a version or
+	// config change), and earns confirmation credit rather than a full rebuild.
+	ChangedFraction float64
+}
+
+// ToolCall is one recorded call, as the server observed it. Everything the value
+// model needs that cannot be recovered later lives here.
+type ToolCall struct {
+	Tool string
+	Repo string
+
+	// OK is false when the handler returned an error result — a validation
+	// failure, or a read tool called before any snapshot exists. Failed calls
+	// displace no work and are recorded as calls but credited nothing.
+	OK bool
+
+	// ResponseBytes is the size of the result the agent had to read. It is
+	// subtracted from the credit, which is what makes the output_mode ladder
+	// visible in the estimate: summary mode genuinely saves more than full mode.
+	ResponseBytes int
+
+	// Snapshot is non-nil only for generate_snapshot.
+	Snapshot *SnapshotValue
+}
+
+// TokensSaved prices a single call: the tokens an agent did not have to ingest,
+// net of what reading enola's own response cost. Never negative.
+func (c ToolCall) TokensSaved() int {
+	if !c.OK {
+		return 0
+	}
+
+	var gross int
+	if c.Snapshot != nil {
+		gross = c.Snapshot.tokens()
+	} else {
+		gross = weightFor(c.Tool) * tokensPerManualOp
+	}
+
+	net := gross - c.ResponseBytes/charsPerTokenApprox
+	if net < 0 {
+		return 0
+	}
+	return net
+}
+
+// tokens prices a snapshot from the corpus it indexed.
+func (s SnapshotValue) tokens() int {
+	// Nothing moved: the call's value is the confirmation itself.
+	if s.Unchanged || s.ChangedFraction == 0 {
+		return refreshConfirmCredit
+	}
+
+	// A first build (no previous snapshot) re-derives everything; a refresh
+	// re-derives only what moved, plus the cost of establishing that the rest
+	// did not.
+	fraction := 1.0
+	refresh := false
+	if s.ChangedFraction > 0 && s.ChangedFraction < 1 {
+		fraction = s.ChangedFraction
+		refresh = true
+	}
+
+	total := float64(s.CorpusTokens) * fraction * rediscoveryFactor
+	if s.Append {
+		total += float64(s.PriorCorpusTokens) * crossRepoPremiumFactor
+	}
+	if refresh {
+		total += refreshConfirmCredit
+	}
+
+	// Ceiling: a repo can never be credited more than its own corpus. Reading
+	// every line of it is the most an agent could possibly have ingested on its
+	// account, so that is the honest upper bound — without this, the cross-repo
+	// premium lets a tiny repo joining a large graph earn hundreds of times its
+	// own source. It also gives the model a property worth stating out loud:
+	// cumulative snapshot credit never exceeds the size of the code itself.
+	if s.CorpusTokens > 0 && total > float64(s.CorpusTokens) {
+		return s.CorpusTokens
+	}
+	return int(total)
+}
+
+// BeyondContext reports whether the corpus this call spanned exceeds what an
+// agent could hold at once — the point at which the counterfactual is not merely
+// expensive but impossible. Renderers flag these rather than presenting the
+// number alone, because "not reproducible by re-reading" is a stronger and more
+// honest claim than any figure.
+func (c ToolCall) BeyondContext() bool {
+	if c.Snapshot == nil {
+		return false
+	}
+	return c.Snapshot.CorpusTokens+c.Snapshot.PriorCorpusTokens > agentContextWindow
+}
+
+// TimeSaved converts tokens an agent did not ingest into time a human did not
+// spend waiting for it, including the rework a non-deterministic reconstruction
+// implies. This is the ONLY place tokens become time, so the two figures can
+// never drift apart.
+func TimeSaved(tokens int) time.Duration {
+	seconds := float64(tokens) / agentTokensPerSecond * reworkFactor
+	return time.Duration(seconds * float64(time.Second))
+}
+
 // ToolValue is the estimated value delivered by a single tool.
 type ToolValue struct {
-	Tool             string
-	Calls            int
-	ManualOpsAvoided int
-	TimeSaved        time.Duration
-	TokensSaved      int
+	Tool          string
+	Calls         int
+	TimeSaved     time.Duration
+	TokensSaved   int
+	BeyondContext bool // at least one call spanned more than a context window
 }
 
 // ValueReport aggregates per-tool value plus totals.
 type ValueReport struct {
 	Tools            []ToolValue // sorted by tool name
 	TotalCalls       int
-	TotalManualOps   int
 	TotalTimeSaved   time.Duration
 	TotalTokensSaved int
+	BeyondContext    bool
 }
 
-// ComputeValue turns raw tool-call counts into an estimated value report.
-func ComputeValue(counts map[string]int) ValueReport {
+// ComputeValue builds a report from accumulated per-tool figures: call counts and
+// the token credit recorded for them at call time.
+//
+// saved may be nil or partial — a usage file written by a build that predates
+// accumulation has counts but no token figures. Those tools are priced from
+// counts via the legacy path so an upgrade never blanks out existing history,
+// which is also why callers must not treat a zero as "no value".
+func ComputeValue(counts map[string]int, saved map[string]int) ValueReport {
 	names := make([]string, 0, len(counts))
 	for name := range counts {
 		names = append(names, name)
@@ -110,19 +297,44 @@ func ComputeValue(counts map[string]int) ValueReport {
 	rep.Tools = make([]ToolValue, 0, len(names))
 	for _, name := range names {
 		calls := counts[name]
-		ops := calls * weightFor(name)
+		tokens, ok := saved[name]
+		if !ok {
+			tokens = legacyTokens(name, calls)
+		}
 		tv := ToolValue{
-			Tool:             name,
-			Calls:            calls,
-			ManualOpsAvoided: ops,
-			TimeSaved:        time.Duration(ops) * secondsPerManualOp * time.Second,
-			TokensSaved:      ops * tokensPerManualOp,
+			Tool:        name,
+			Calls:       calls,
+			TokensSaved: tokens,
+			TimeSaved:   TimeSaved(tokens),
 		}
 		rep.Tools = append(rep.Tools, tv)
 		rep.TotalCalls += calls
-		rep.TotalManualOps += ops
-		rep.TotalTimeSaved += tv.TimeSaved
-		rep.TotalTokensSaved += tv.TokensSaved
+		rep.TotalTokensSaved += tokens
 	}
+	// Derive the total from the total token count rather than summing per-tool
+	// durations: accumulating rounded per-row values makes the TOTAL row disagree
+	// with its own column by a few hundred milliseconds.
+	rep.TotalTimeSaved = TimeSaved(rep.TotalTokensSaved)
 	return rep
+}
+
+// legacyCorpusTokens is the corpus assumed for a generate_snapshot recorded
+// before corpus measurement existed. It is the median of the measured corpora
+// rather than the largest, so upgrading never inflates existing history.
+const legacyCorpusTokens = 1_780_000
+
+// legacyTokens prices calls from a usage file written before per-call token
+// figures were recorded. Query tools are priced from their weight; snapshots get
+// a single median-corpus credit regardless of how many times they ran, because
+// such a file cannot say which of those calls were first builds and which were
+// refreshes. Crediting each one as a first build would multiply one corpus by
+// the call count, so the conservative reading is the only defensible one.
+func legacyTokens(tool string, calls int) int {
+	if tool == "generate_snapshot" {
+		if calls == 0 {
+			return 0
+		}
+		return int(float64(legacyCorpusTokens) * rediscoveryFactor)
+	}
+	return calls * weightFor(tool) * tokensPerManualOp
 }

--- a/pkg/status/value_test.go
+++ b/pkg/status/value_test.go
@@ -5,69 +5,302 @@ import (
 	"time"
 )
 
-func TestComputeValue(t *testing.T) {
+func TestComputeValueUsesRecordedCredit(t *testing.T) {
 	counts := map[string]int{
-		"generate_snapshot": 2, // weight 100 -> 200 ops
-		"query_facts":       3, // weight 8   -> 24 ops
-		"mystery_tool":      4, // unknown    -> defaultWeight 5 -> 20 ops
+		"generate_snapshot": 2,
+		"query_facts":       3,
+	}
+	saved := map[string]int{
+		"generate_snapshot": 1_200_000,
+		"query_facts":       7_000,
 	}
 
-	rep := ComputeValue(counts)
+	rep := ComputeValue(counts, saved)
 
+	if len(rep.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(rep.Tools))
+	}
 	// Tools are sorted by name.
-	if len(rep.Tools) != 3 {
-		t.Fatalf("expected 3 tools, got %d", len(rep.Tools))
-	}
 	if rep.Tools[0].Tool != "generate_snapshot" {
 		t.Errorf("expected first tool sorted as generate_snapshot, got %q", rep.Tools[0].Tool)
 	}
+	if rep.TotalCalls != 5 {
+		t.Errorf("TotalCalls: got %d, want 5", rep.TotalCalls)
+	}
+	// The report must render what was recorded, not reprice it from counts.
+	if rep.TotalTokensSaved != 1_207_000 {
+		t.Errorf("TotalTokensSaved: got %d, want 1207000", rep.TotalTokensSaved)
+	}
+	if want := TimeSaved(1_207_000); rep.TotalTimeSaved != want {
+		t.Errorf("TotalTimeSaved: got %s, want %s", rep.TotalTimeSaved, want)
+	}
+}
 
-	// Unknown tool falls back to defaultWeight.
-	var mystery ToolValue
+// A usage file written before per-call credit existed has counts but no token
+// figures. Upgrading must not blank out that history.
+func TestComputeValueLegacyFallback(t *testing.T) {
+	rep := ComputeValue(map[string]int{"query_facts": 3}, nil)
+	want := 3 * weightFor("query_facts") * tokensPerManualOp
+	if rep.TotalTokensSaved != want {
+		t.Errorf("legacy query credit: got %d, want %d", rep.TotalTokensSaved, want)
+	}
+
+	// Legacy snapshots are credited ONE median corpus regardless of call count:
+	// the historical file cannot say which were first builds and which were
+	// refreshes, and assuming all were first builds is the overcount this model
+	// exists to remove.
+	a := ComputeValue(map[string]int{"generate_snapshot": 1}, nil)
+	b := ComputeValue(map[string]int{"generate_snapshot": 40}, nil)
+	if a.TotalTokensSaved != b.TotalTokensSaved {
+		t.Errorf("legacy snapshot credit should not scale with call count: 1 call=%d, 40 calls=%d",
+			a.TotalTokensSaved, b.TotalTokensSaved)
+	}
+}
+
+// Recorded credit must win over the legacy path for tools that have it, while
+// tools that don't still fall back.
+func TestComputeValueMixedRecordedAndLegacy(t *testing.T) {
+	rep := ComputeValue(
+		map[string]int{"query_facts": 3, "explore": 2},
+		map[string]int{"query_facts": 42},
+	)
+	byTool := map[string]int{}
 	for _, tv := range rep.Tools {
-		if tv.Tool == "mystery_tool" {
-			mystery = tv
-		}
+		byTool[tv.Tool] = tv.TokensSaved
 	}
-	if mystery.ManualOpsAvoided != 4*defaultWeight {
-		t.Errorf("mystery_tool ops: got %d, want %d", mystery.ManualOpsAvoided, 4*defaultWeight)
+	if byTool["query_facts"] != 42 {
+		t.Errorf("recorded credit ignored: got %d, want 42", byTool["query_facts"])
 	}
-
-	// Totals: 200 + 24 + 20 = 244 manual ops.
-	wantOps := 200 + 24 + 20
-	if rep.TotalManualOps != wantOps {
-		t.Errorf("TotalManualOps: got %d, want %d", rep.TotalManualOps, wantOps)
-	}
-	if rep.TotalCalls != 9 {
-		t.Errorf("TotalCalls: got %d, want 9", rep.TotalCalls)
-	}
-	wantTime := time.Duration(wantOps) * secondsPerManualOp * time.Second
-	if rep.TotalTimeSaved != wantTime {
-		t.Errorf("TotalTimeSaved: got %s, want %s", rep.TotalTimeSaved, wantTime)
-	}
-	if rep.TotalTokensSaved != wantOps*tokensPerManualOp {
-		t.Errorf("TotalTokensSaved: got %d, want %d", rep.TotalTokensSaved, wantOps*tokensPerManualOp)
+	if want := 2 * weightFor("explore") * tokensPerManualOp; byTool["explore"] != want {
+		t.Errorf("legacy credit for explore: got %d, want %d", byTool["explore"], want)
 	}
 }
 
 func TestComputeValueEmpty(t *testing.T) {
-	rep := ComputeValue(map[string]int{})
+	rep := ComputeValue(map[string]int{}, nil)
 	if len(rep.Tools) != 0 || rep.TotalCalls != 0 || rep.TotalTokensSaved != 0 {
 		t.Errorf("empty counts should yield zero-value report, got %+v", rep)
 	}
 }
 
+// A failed call happened, so it is counted — but it displaced no work, so it
+// earns nothing. A "run generate_snapshot first" is a call, not a saving.
+func TestFailedCallEarnsNothing(t *testing.T) {
+	call := ToolCall{Tool: "query_insights", OK: false}
+	if got := call.TokensSaved(); got != 0 {
+		t.Errorf("failed call credit: got %d, want 0", got)
+	}
+	failedSnapshot := ToolCall{
+		Tool:     "generate_snapshot",
+		OK:       false,
+		Snapshot: &SnapshotValue{CorpusTokens: 30_000_000},
+	}
+	if got := failedSnapshot.TokensSaved(); got != 0 {
+		t.Errorf("failed snapshot credit: got %d, want 0", got)
+	}
+}
+
+// The response an agent has to read is subtracted, which is what makes the
+// output_mode ladder visible: a summary genuinely saves more than a full dump.
+func TestResponseCostIsSubtracted(t *testing.T) {
+	summary := ToolCall{Tool: "query_facts", OK: true, ResponseBytes: 400}
+	full := ToolCall{Tool: "query_facts", OK: true, ResponseBytes: 240_000}
+
+	if summary.TokensSaved() <= full.TokensSaved() {
+		t.Errorf("summary (%d) should save more than full (%d)",
+			summary.TokensSaved(), full.TokensSaved())
+	}
+	// A response larger than what it displaced nets zero, never negative.
+	if got := full.TokensSaved(); got < 0 {
+		t.Errorf("credit must not go negative, got %d", got)
+	}
+}
+
+func TestSnapshotCreditScalesWithCorpus(t *testing.T) {
+	small := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 72_000, ChangedFraction: 1}}
+	large := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 33_000_000, ChangedFraction: 1}}
+
+	if small.TokensSaved() >= large.TokensSaved() {
+		t.Fatalf("credit must scale with corpus: small=%d large=%d",
+			small.TokensSaved(), large.TokensSaved())
+	}
+	// The whole point: these are not within an order of magnitude of each other,
+	// which the old flat per-call weight made them.
+	if ratio := large.TokensSaved() / small.TokensSaved(); ratio < 100 {
+		t.Errorf("corpus ratio collapsed to %dx, expected the ~460x spread to survive", ratio)
+	}
+}
+
+// Re-snapshotting an unchanged repo is not waste — it establishes that nothing
+// moved — but it is worth far less than a first build.
+func TestUnchangedRefreshEarnsConfirmationOnly(t *testing.T) {
+	first := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 3_000_000, ChangedFraction: 1}}
+	refresh := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 3_000_000, Unchanged: true}}
+
+	if refresh.TokensSaved() != refreshConfirmCredit {
+		t.Errorf("unchanged refresh: got %d, want %d", refresh.TokensSaved(), refreshConfirmCredit)
+	}
+	if refresh.TokensSaved() >= first.TokensSaved()/100 {
+		t.Errorf("unchanged refresh (%d) should be far below a first build (%d)",
+			refresh.TokensSaved(), first.TokensSaved())
+	}
+}
+
+// A snapshot whose id moved but whose files are byte-identical (a version or
+// config bump) re-derives nothing, so it earns confirmation credit — not the
+// full-rebuild credit a naive "fraction defaults to 1" would hand it.
+func TestZeroChangeEarnsConfirmationOnly(t *testing.T) {
+	call := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 10_000_000, ChangedFraction: 0}}
+	if got := call.TokensSaved(); got != refreshConfirmCredit {
+		t.Errorf("zero-change refresh: got %d, want %d", got, refreshConfirmCredit)
+	}
+}
+
+// A first build has no previous snapshot to compare against, signalled by a
+// negative fraction, and must be priced as re-deriving the whole corpus.
+func TestNegativeFractionIsFirstBuild(t *testing.T) {
+	first := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 1_000_000, ChangedFraction: -1}}
+	want := int(1_000_000 * rediscoveryFactor)
+	if got := first.TokensSaved(); got != want {
+		t.Errorf("first build: got %d, want %d", got, want)
+	}
+}
+
+func TestPartialRefreshScalesWithChange(t *testing.T) {
+	corpus := 3_000_000
+	small := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: corpus, ChangedFraction: 0.01}}
+	big := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: corpus, ChangedFraction: 0.5}}
+	full := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: corpus, ChangedFraction: 1}}
+
+	if small.TokensSaved() >= big.TokensSaved() || big.TokensSaved() >= full.TokensSaved() {
+		t.Errorf("refresh credit should rise with changed fraction: %d < %d < %d",
+			small.TokensSaved(), big.TokensSaved(), full.TokensSaved())
+	}
+}
+
+func TestAppendEarnsCrossRepoPremium(t *testing.T) {
+	alone := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 500_000, ChangedFraction: 1}}
+	appended := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{
+			CorpusTokens: 500_000, ChangedFraction: 1,
+			Append: true, PriorCorpusTokens: 10_000_000,
+		}}
+
+	if appended.TokensSaved() <= alone.TokensSaved() {
+		t.Errorf("append should out-earn an independent snapshot: %d vs %d",
+			appended.TokensSaved(), alone.TokensSaved())
+	}
+}
+
+// A small repo joining a large graph must not out-earn its own source. Reading
+// every line of it is the ceiling on what an agent could have ingested for it.
+func TestCreditNeverExceedsOwnCorpus(t *testing.T) {
+	tiny := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{
+			CorpusTokens: 4_072, ChangedFraction: -1,
+			Append: true, PriorCorpusTokens: 50_000_000,
+		}}
+	if got := tiny.TokensSaved(); got > 4_072 {
+		t.Errorf("credit %d exceeds the repo's own corpus of 4072", got)
+	}
+}
+
+// The property that ceiling buys: across a whole graph, cumulative snapshot
+// credit never claims more tokens than the code actually contains.
+func TestClusterCreditStaysUnderCorpus(t *testing.T) {
+	corpora := []int{935_633, 1_518_104, 622_337, 415_054, 2_593_805, 2_129_228, 4_072, 229_116}
+	total, prior := 0, 0
+	for i, c := range corpora {
+		call := ToolCall{Tool: "generate_snapshot", OK: true,
+			Snapshot: &SnapshotValue{
+				CorpusTokens: c, ChangedFraction: -1,
+				Append: i > 0, PriorCorpusTokens: prior,
+			}}
+		total += call.TokensSaved()
+		prior += c
+	}
+	if total > prior {
+		t.Errorf("cluster credit %d exceeds cluster corpus %d", total, prior)
+	}
+}
+
+// Past a context window the counterfactual is not expensive, it is impossible —
+// renderers flag those rows rather than presenting the number alone.
+func TestBeyondContext(t *testing.T) {
+	within := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 500_000}}
+	beyond := ToolCall{Tool: "generate_snapshot", OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 600_000, PriorCorpusTokens: 10_000_000}}
+
+	if within.BeyondContext() {
+		t.Error("a corpus under the window must not be flagged")
+	}
+	if !beyond.BeyondContext() {
+		t.Error("a combined corpus over the window must be flagged")
+	}
+	// A query tool never carries the flag.
+	if (ToolCall{Tool: "query_facts", OK: true}).BeyondContext() {
+		t.Error("query tools must never be flagged beyond-context")
+	}
+}
+
+// The repo-local .enola metadata outlives the usage ledger: it survives clearing
+// ~/.enola and arrives with a fresh clone. So a snapshot the server reports as
+// "unchanged" must still be priced as a first build when this ledger has never
+// credited that repo — otherwise a stale meta file suppresses the credit forever.
+func TestStaleRepoMetaDoesNotSuppressFirstBuild(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := t.TempDir()
+
+	tr := NewTracker(repo)
+	tr.SetStartTime(time.Now())
+
+	// What the server reports when a leftover meta matches the current content.
+	unchanged := ToolCall{
+		Tool: "generate_snapshot", Repo: repo, OK: true,
+		Snapshot: &SnapshotValue{CorpusTokens: 5_000_000, Unchanged: true},
+	}
+	tr.Record(unchanged)
+
+	first := tr.GetStatus(repo).TokensSaved[snapshotTool]
+	if want := int(5_000_000 * rediscoveryFactor); first != want {
+		t.Fatalf("first build against an empty ledger: got %d, want %d", first, want)
+	}
+
+	// The SECOND identical call is a genuine refresh — the ledger has now seen
+	// this repo — so it earns confirmation credit, not another corpus.
+	tr.Record(unchanged)
+	total := tr.GetStatus(repo).TokensSaved[snapshotTool]
+	if got := total - first; got != refreshConfirmCredit {
+		t.Errorf("second call credit: got %d, want %d", got, refreshConfirmCredit)
+	}
+}
+
 func TestWeightForKnownTools(t *testing.T) {
-	// Every tool in the catalog should have an explicit (non-default) weight so
-	// the value model is intentional rather than falling through.
+	// Every query tool in the catalog should have an explicit (non-default)
+	// weight so the value model is intentional rather than falling through.
+	// generate_snapshot is deliberately absent: its value is corpus-derived.
 	for _, tool := range []string{
-		"generate_snapshot", "explore", "query_facts", "show_symbol", "traverse",
+		"explore", "query_facts", "show_symbol", "traverse",
 		"find_path", "impact_analysis", "coverage_report", "query_insights",
 		"set_baseline", "diff_snapshot", "snapshot_receipt", "compare_receipts",
 	} {
 		if _, ok := toolWeights[tool]; !ok {
 			t.Errorf("tool %q has no explicit weight in toolWeights", tool)
 		}
+	}
+	if _, ok := toolWeights["generate_snapshot"]; ok {
+		t.Error("generate_snapshot must not have a flat weight — its value is corpus-derived")
 	}
 }
 
@@ -89,7 +322,18 @@ func TestRegisterToolWeights(t *testing.T) {
 	}
 
 	// A registration must not disturb the built-in weights.
-	if got := weightFor("generate_snapshot"); got != 100 {
-		t.Errorf("generate_snapshot weight after registration: got %d, want 100", got)
+	if got := weightFor("query_insights"); got != 30 {
+		t.Errorf("query_insights weight after registration: got %d, want 30", got)
+	}
+}
+
+// Time is derived from tokens in exactly one place, so the two headline figures
+// can never drift apart.
+func TestTimeSavedTracksTokens(t *testing.T) {
+	if TimeSaved(0) != 0 {
+		t.Errorf("zero tokens must be zero time, got %s", TimeSaved(0))
+	}
+	if TimeSaved(2_000_000) <= TimeSaved(1_000_000) {
+		t.Error("time must rise with tokens")
 	}
 }


### PR DESCRIPTION
The estimate behind --status and the dashboard was a flat per-tool weight times two conversion constants. That made a snapshot of a 72K-token service and a 33M-token monorepo worth the same, credited failed calls at full value, and ignored the response an agent actually has to read — so the output_mode ladder, the main token-saving lever, never moved the number.

Re-anchor it on the counterfactual it claims to measure: what an agent would have had to ingest to reach the same answer with grep and file reads.

- Measure the corpus. Store.SourceBytesWithFacts sums exactly the files that produced facts, persisted as SnapshotMeta.SourceBytes. Summing the walked-file list instead folds in images, media and vendored databases — a 39x difference on a real repository.
- Derive snapshot credit from that corpus, plus a premium for cross-repo edges that need two corpora resident at once, and reduced tiers for a refresh: confirmation-only when file hashes are unchanged, scaled by the changed fraction otherwise.
- Cap credit at a repo's own corpus, so cumulative snapshot credit can never exceed the size of the code it was computed over.
- Flag corpora exceeding a context window, where the counterfactual is not expensive but impossible and a token figure understates it.
- Record credit per call and persist it beside the counts. Its inputs are not recoverable from a count afterwards, and storing the result keeps the figure identical across binaries rather than repriced by whichever one renders it.
- Move accounting into a middleware that runs after the handler, so a failed call earns nothing and the response size is subtracted. It is registered once on the shared MCP server, so wrapper-registered tools are covered without reporting their own calls.
- Decide "first build" from the usage ledger, not the repo-local .enola metadata, which outlives the ledger and arrives with a fresh clone.
- Reset the cross-repo corpus pool when a non-append snapshot resets the store, so the premium is charged against the loaded graph only.
- Fix ScanFootprint, which was unreferenced and summed every walked file.

Document the model in ARCHITECTURE.md — counterfactual, corpus anchor, formulas, constants, worked example, and what it deliberately does not model — and point README at it from each place that claims a saving.