### PR TITLE
Scale query credit by the graph searched, and keep it across restarts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -273,7 +273,7 @@ The estimate answers one question:
 
 That counterfactual, not the size of enola's own response, is the baseline. The distinction matters. A `query_facts` call that returns 12 KB of JSON has not "cost" you 3,000 tokens — it has *replaced* an exploration loop that would have grepped, opened a dozen files, and re-derived the same edges imperfectly. Pricing the response instead of what it displaced would measure the wrong thing entirely, and would perversely reward tools that answer less.
 
-The counterfactual is also why the model is anchored to **corpus size**, not to call count. Reconstructing a graph of a large monorepo (33.0M tokens of parsed source, 477,383 facts, 47,711 files) and reconstructing one of a small service (72K tokens) are not the same act of work. Any flat per-call price is wrong at both ends by more than two orders of magnitude, so there isn't one.
+The counterfactual is also why the model is anchored to **corpus size**, not to call count. Reconstructing a graph of the Linux kernel (218M tokens of parsed source, 1.9M facts, 55,399 files) and reconstructing one of a small service (17.9K tokens) are not the same act of work. Any flat per-call price is wrong at both ends by four orders of magnitude, so there isn't one.
 
 ### The corpus anchor
 
@@ -284,17 +284,20 @@ Two properties of that measurement are load-bearing:
 - It counts **parsed source only**, not `files_seen`. A snapshot's `file_hashes` list covers everything the walker touched, including whatever else lives in the tree. On one real repository the two differ by 39× — 3.1M tokens of source against 121M once JPEGs, an MP4 or two and a 63 MB GeoIP database are folded in. An agent was never going to read those, so they are not corpus.
 - It is a **measurement, not a guess**. Nothing else in this model is allowed to invent a corpus size.
 
-Measured across the workloads enola is actually pointed at, the spread the model has to cover is roughly **460×**:
+Measured across the workloads enola is actually pointed at, the spread the model has to cover is over **12,000×** — from a 17.9K-token service to a 218M-token kernel:
 
 | Workload | Parsed source | Facts | Wall clock |
 |---|---:|---:|---:|
-| Single small service (Go) | 72K tokens | 3,475 | 0.4s |
-| Mid-size project (Python + TS) | 1.78M | 16,909 | 1.1s |
-| Large project (Python + TS) | 5.90M | 51,645 | 3.5s |
-| **8-repo product ecosystem** (5 languages, backend + web + iOS + Android) | **10.62M** | 155,796 | 9.1s |
-| **Large monorepo** (Ruby + TS + Python + Java) | **33.00M** | 477,383 | 30.9s |
+| Mid-size project (Python + TS) | 1.77M tokens | 16,909 | 0.8s |
+| Backend service (Go + Python) | 3.12M | 23,716 | 1.5s |
+| Apache Airflow (Python + TS + Java + gRPC) | 8.54M | 67,702 | 4.9s |
+| **8-repo product ecosystem** (5 languages, backend + web + iOS + Android) | **8.45M** | 155,796 | 8.2s |
+| **GitLab** (Ruby + TS + Python + Java) | **32.77M** | 435,033 | 22.3s |
+| **Linux kernel** (C + Rust) | **218.15M** | 1,892,343 | 2m20s |
 
-The rendered digest (`llm_context.md`) is capped at ~16K tokens regardless. For the monorepo at the bottom of that table, that is a **2,065:1** compression of the corpus into the artifact an agent actually reads.
+Every figure there is the engine's own measurement, taken on a fresh snapshot; the ecosystem row sums its eight repos.
+
+The rendered digest (`llm_context.md`) is capped at ~16K tokens regardless of any of it. For GitLab that is a **2,048:1** compression of the corpus into the artifact an agent actually reads; for the kernel, **13,600:1**.
 
 ### Tokens
 
@@ -303,7 +306,7 @@ first snapshot     = corpus_tokens × rediscoveryFactor
 additional repo    = above + priorCorpusTokens × crossRepoPremiumFactor
 refresh (unchanged)= refreshConfirmCredit
 refresh (changed)  = changed_fraction × corpus_tokens × rediscoveryFactor + refreshConfirmCredit
-query tools        = weight × tokensPerManualOp − response_tokens
+query tools        = weight × tokensPerManualOp × queryCorpusScale − response_tokens
 ```
 
 Credit is never negative, and a failed call earns nothing at all.
@@ -316,7 +319,7 @@ The premium is also scoped to the graph actually loaded. A non-append snapshot r
 
 **The cross-repo premium** is not a bonus for doing more work; it prices a different *kind* of result. A cross-repo edge — an iOS client calling a route served by its backend — can only be derived with both corpora resident at once. That is why `append` is priced above a second independent snapshot, and it leads directly to the threshold below.
 
-**The infeasibility threshold.** When the corpus that must be simultaneously resident exceeds `agentContextWindow`, the counterfactual is not *expensive* — it is **impossible**. The 8-repo ecosystem above resolves its cross-repo edges across 10.62M tokens held at once; the monorepo is 33M. No amount of patience or budget gets an agent there by re-reading files, because it cannot hold the sides of the comparison in the same context.
+**The infeasibility threshold.** When the corpus that must be simultaneously resident exceeds `agentContextWindow`, the counterfactual is not *expensive* — it is **impossible**. The 8-repo ecosystem above resolves its cross-repo edges across 8.45M tokens held at once; GitLab is 32.77M, and the Linux kernel 218.15M — 218× a single window. No amount of patience or budget gets an agent there by re-reading files, because it cannot hold the sides of the comparison in the same context.
 
 Such entries keep their numeric credit (so totals stay arithmetic) but are **flagged in the output** rather than quietly rendered as a large number. A footnote saying *"exceeds a single context window — not reproducible by re-reading"* is a stronger and more honest claim than any figure, and it is the case both large workloads in the table above fall into.
 
@@ -326,7 +329,27 @@ Such entries keep their numeric credit (so totals stay arithmetic) but are **fla
 
 Note that "unchanged" is decided on **file hashes**, not on the snapshot id alone. An id can move without any source moving — a version bump, a config change — and that earns confirmation credit rather than a full rebuild's worth. Two distinct cases are therefore carried explicitly: a changed-fraction of exactly zero means *the files are identical*, while a **negative** fraction means *no previous snapshot to compare against*, which is a genuine first build. They must not share a default — one of them is worth a whole corpus and the other is worth a few thousand tokens.
 
-For the **query tools**, `weight` remains an ordinal judgement — how much exploration one call displaces, relative to the others — while `tokensPerManualOp` converts it into tokens. That constant is calibrated to the **median** parsed source file across the corpora above (~800 tokens), not the mean, which outliers inflate by roughly 2.5×. Response tokens are subtracted, which is what finally makes the `output_mode` ladder visible in the estimate: `summary` mode genuinely saves more than `full` mode, and the model should say so.
+For the **query tools**, `weight` remains an ordinal judgement — how much exploration one call displaces, relative to the others — while `tokensPerManualOp` converts it into tokens. That constant is calibrated to the **median** parsed source file across the corpora above (~800 tokens), not the mean, which outliers inflate by roughly 2.5×. Response tokens are subtracted, which is what makes the `output_mode` ladder visible in the estimate: `summary` mode genuinely saves more than `full` mode, and the model should say so.
+
+**Queries scale with the graph they searched.** The work a query replaces is driven by the size of the haystack, not the number of needles: asking *"where are the dependency cycles"* over Linux (1.9M facts across 55,399 files) displaces far more grepping than the same question over a small service, even though it returns fewer findings. So the ordinal weight is multiplied by `queryCorpusScale`, taken over the whole loaded graph rather than one repo — a query is not scoped to a single repo, so neither is its pricing.
+
+The growth is **logarithmic and capped**. A haystack 100× larger does not take 100× the greps, just a few more rounds of them, and linear scaling would hand a single query millions of tokens on a kernel-sized graph:
+
+| Graph | Corpus | Scale | One `query_insights` |
+|---|---:|---:|---:|
+| Small service | 17.9K | 1.00 | 10,743 *(corpus-capped)* |
+| Mid-size project | 1.77M | 1.00 | 24,000 |
+| 8-repo ecosystem | 8.45M | 3.23 | 77,532 |
+| GitLab | 32.77M | 5.19 | 124,472 |
+| Linux kernel | 218.15M | 7.92 | 190,107 |
+
+Below `queryScaleReferenceCorpus` the weight stands unscaled; `maxQueryCorpusScale` binds above ~230M tokens. That cap is the most arbitrary number in the model — it exists to stay conservative at the top end, not because 8 is special.
+
+**The graph's size survives a restart.** A server coming back up restores its facts from disk without re-snapshotting — that is what `AutoLoadSnapshot` is for, and with one server per agent terminal it is the normal path, not an edge case. So the measurement those facts were extracted from has to come back with them, or every query on a restored graph is priced as though the graph were tiny. Each repo's parsed-source size is therefore carried in the graph receipt (`GraphRepoEntry.SourceBytes`), and `AutoLoadSnapshot` returns it from the *same* receipt the facts came from — resolving one independently could size the graph by a repo set the server is not actually holding.
+
+The field is additive and `omitempty`: a receipt written before it existed reads as zero, which is treated as *unknown* rather than as an empty corpus, and heals on the next snapshot. It is not an input to `computeSnapshotID`, so snapshot fingerprints are unaffected. And because a repo's size is read from its own `snapshot.meta.json`, a momentarily unreadable file yields zero — which the receipt merge treats as "no new reading" and carries the last known size forward, rather than writing the gap through and silently un-pricing that repo.
+
+**And a query is capped by its graph, like a snapshot is by its repo.** No call can displace more work than reading outright everything it searched, so query credit is bounded by `corpus × rediscoveryFactor`. That bound is what the top row above hits: a single `query_insights` priced at its ordinal weight would otherwise be credited 24,000 tokens against a repo whose entire source is 17,906.
 
 ### Time
 
@@ -350,36 +373,39 @@ All seven live at the top of [`pkg/status/value.go`](pkg/status/value.go) so tun
 | `crossRepoPremiumFactor` | Share of the already-loaded corpus credited for resolving a new repo's edges against it. |
 | `refreshConfirmCredit` | Per-repo credit for establishing that nothing changed. |
 | `tokensPerManualOp` | Median parsed source file, in tokens. |
+| `queryScaleReferenceCorpus` | Graph size at which a query's ordinal weight stands unscaled. |
+| `maxQueryCorpusScale` | Ceiling on that multiplier, so huge graphs cannot run away. |
 | `agentTokensPerSecond` | End-to-end agent discovery throughput. |
 | `reworkFactor` | Non-determinism premium — work done twice. |
 | `agentContextWindow` | Threshold past which the counterfactual is infeasible. |
 
-### A worked example
+### A worked example: the Linux kernel
 
-Mapping the 8-repo ecosystem from the table above — one `generate_snapshot` per repo, the first `fresh` and the rest `append`, then one refresh and a handful of reads:
+The extreme end of the table — one `generate_snapshot` over the kernel's 55,399 parsed files, then three reads:
 
 ```
 Value Estimate (approximate):
   tool                calls   ~time saved   ~tokens saved
-  explore                 1            7s           11.7K
-  generate_snapshot       9     1h 6m 54s            6.7M
-  query_facts             2            6s           10.6K
-  query_insights          1           14s           23.9K
-  show_symbol             1            0s               0
-  TOTAL                  14     1h 7m 22s           6.7M†
-  running now            14     1h 7m 22s            6.7M
+  explore                 1            6s           11.2K
+  generate_snapshot       1  21h 48m 52s           130.9M
+  query_facts             1            3s            6.3K
+  query_insights          1           14s           23.4K
+  TOTAL                   4  21h 49m 16s           130.9M†
+  running now             4  21h 49m 16s           130.9M
 
   † corpus exceeds a single context window — not reproducible by re-reading files.
 ```
 
 Four things in that output are worth reading closely:
 
-- **6.7M tokens for the snapshots** is `10.62M × 0.6` plus the cross-repo premiums — derived from the corpus, so the same nine calls against a smaller or larger estate would score differently.
-- **1h 7m for 6.7M tokens** is the agent-throughput conversion, not a per-lookup charge. It is time you spend waiting on an agent, so it is bounded by how fast an agent ingests, not by how long a person would take to read the same code.
-- **`show_symbol` earned 0.** It was called with a name that does not exist. The call is counted — it happened — but a "not found" displaces no work.
-- **The dagger.** 10.62M tokens cannot be held at once, so the eight cross-repo edges in this graph are not derivable by re-reading files at any budget.
+- **130.9M is exactly `218.15M × 0.6`** — the corpus times `rediscoveryFactor`, with no premium because it is a single repo. Nothing about the call count produced that number.
+- **The ratio of snapshot to reads is 3,200:1.** On a codebase this size, building the graph *is* the work; the queries are rounding error against it. That is the model agreeing with intuition rather than being tuned to.
+- **21.8 hours is a floor, not an estimate of the real cost.** It is the agent-throughput conversion of tokens avoided. Nobody was going to ingest 130.9M tokens — people spend months learning a kernel — so the figure understates the true difficulty by a wide margin. It is bounded by what the model can defend, not by what the work is worth.
+- **The dagger is the honest claim.** At 218.15M tokens the corpus exceeds a single context window by **218×**. The token figure describes a counterfactual that cannot be performed at all, which is why a flagged row says more than its number does.
 
-Re-running the identical session immediately afterwards yields **15.4K** for the same nine snapshots: every repo's `snapshot_id` matched, so each earned confirmation credit instead of a rebuild. That gap — 6.7M versus 15.4K for byte-identical commands — is the model distinguishing building an understanding from confirming one still holds.
+Two operational notes follow from the same run, and they matter before pointing enola at a tree this size: the snapshot writes an **830 MB `facts.jsonl`**, and it produces **37,425 insights** — far past what anyone triages by hand, so `min_confidence` and an explainer filter are the sensible default posture rather than an afterthought.
+
+At the other end of the scale, re-running an identical session over an already-built graph collapses to confirmation credit — roughly 1.7K per repo instead of its corpus. That gap, for byte-identical commands, is the model distinguishing building an understanding from confirming one still holds.
 
 ### What it deliberately does not model
 

--- a/README.md
+++ b/README.md
@@ -614,29 +614,29 @@ Repos tracked: 21
 Tool Usage:
   tool                running     total
   explore                   1         1
-  generate_snapshot         9         9
-  query_facts               2         2
+  generate_snapshot         1         1
+  query_facts               1         1
   query_insights            1         1
-  show_symbol               1         1
 
 Value Estimate (approximate):
   tool                calls   ~time saved   ~tokens saved
-  explore                 1            7s           11.7K
-  generate_snapshot       9     1h 6m 54s            6.7M
-  query_facts             2            6s           10.6K
-  query_insights          1           14s           23.9K
-  show_symbol             1            0s               0
-  TOTAL                  14     1h 7m 22s           6.7M†
-  running now            14     1h 7m 22s            6.7M
+  explore                 1            6s           11.2K
+  generate_snapshot       1  21h 48m 52s           130.9M
+  query_facts             1            3s            6.3K
+  query_insights          1           14s           23.4K
+  TOTAL                   4  21h 49m 16s           130.9M†
+  running now             4  21h 49m 16s           130.9M
 
   † corpus exceeds a single context window — not reproducible by re-reading files.
 ```
 
-That's one session mapping an 8-repo, 5-language product ecosystem - 10.6M tokens of source, reduced to a queryable graph in about nine seconds. Two details worth noticing: `show_symbol` earned **0** because it was called with a name that doesn't exist (the call is counted; a "not found" displaces no work), and re-running the identical session immediately afterwards scores **15.4K** instead of 6.7M, because every repo's snapshot id matched and each call earned confirmation credit rather than a rebuild. Building an understanding and confirming one still holds are different things, and the estimate says so.
+That's a single session over the **Linux kernel** - 218M tokens of C and Rust across 55,399 parsed files, indexed into 1.9M facts in 2m20s. The 130.9M is exactly `218M × 0.6`: priced from the corpus, not from the fact that one call happened. And the dagger is doing more work than the number is - at 218× a context window, that graph isn't expensive to rebuild by reading files, it's *impossible* to.
+
+Run the same session again over an unchanged repo and it collapses to a few thousand tokens: the snapshot ids match, so each call earns confirmation credit instead of a rebuild. Building an understanding and confirming one still holds are different things, and the estimate says so.
 
 `--status --all` gives the same figures broken down **per repository**, sorted by tokens saved - useful for seeing which part of your estate the tooling is actually earning its keep on.
 
-Be clear about what these numbers are. They answer one question: **what would an agent have had to ingest to reach the same answer with ordinary tools - grep, glob, open a file, read it, infer?** So a snapshot is priced from the *corpus it indexed*, measured, not from the fact that a call happened; a repo of 72K tokens and a monorepo of 33M are not the same act of work. Reading time converts to your time waiting on the agent, including the rework a non-deterministic reconstruction implies. Failed calls are counted but earn nothing, and the tokens you spend reading enola's own response are subtracted - so `output_mode='summary'` genuinely scores better than `'full'`.
+Be clear about what these numbers are. They answer one question: **what would an agent have had to ingest to reach the same answer with ordinary tools - grep, glob, open a file, read it, infer?** So a snapshot is priced from the *corpus it indexed*, measured, not from the fact that a call happened; a 17.9K-token service and the 218M-token Linux kernel are not the same act of work, and no flat per-call price is right for both. Reading time converts to your time waiting on the agent, including the rework a non-deterministic reconstruction implies. Failed calls are counted but earn nothing, and the tokens you spend reading enola's own response are subtracted - so `output_mode='summary'` genuinely scores better than `'full'`.
 
 They're an estimate, labelled as one - but the inputs are real: corpus sizes measured at snapshot time, call counts recorded per repository under `~/.enola/usage/`. They survive server restarts and deleting a repo's `.enola/` directory, and `--status` works from any directory, not just a snapshotted one. The full model, its constants and what it deliberately leaves out are in [ARCHITECTURE.md](ARCHITECTURE.md#the-value-model).
 

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -131,12 +131,16 @@ func main() {
 		os.Exit(0)
 	}
 
-	bootstrap.AutoLoadSnapshot(eng, cfg)
+	restoredCorpus := bootstrap.AutoLoadSnapshot(eng, cfg)
 
 	srv, err := bootstrap.NewServer(eng, cfg)
 	if err != nil {
 		log.Fatalf("failed to create server: %v", err)
 	}
+
+	// Size the restored graph before serving, so queries against it are priced
+	// correctly without waiting for a snapshot this process does not need.
+	srv.SeedCorpus(restoredCorpus)
 
 	// Record per-tool usage so a later `enola --status` has something to report.
 	// Per-repo counters are loaded lazily from ~/.enola/usage/ on first touch, so

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -21,6 +21,11 @@ import (
 const (
 	globalReceiptDirName  = ".enola"
 	globalReceiptFileName = "receipt.json"
+
+	// snapshotMetaFileName is a repo's own snapshot metadata, inside its output
+	// directory. Read when assembling the graph receipt to recover the parsed
+	// source size of repos this snapshot did not itself index.
+	snapshotMetaFileName = "snapshot.meta.json"
 )
 
 // globalReceiptPath resolves ~/.enola/receipt.json. It returns an error when the
@@ -151,14 +156,39 @@ func (e *Engine) repoEntries(b *snapshotBundle) []facts.GraphRepoEntry {
 	entries := make([]facts.GraphRepoEntry, 0, len(repos))
 	for label, abs := range repos {
 		entries = append(entries, facts.GraphRepoEntry{
-			Label:     label,
-			Path:      abs,
-			Git:       gitInfo(abs),
-			FactCount: b.store.CountByRepo(label),
+			Label:       label,
+			Path:        abs,
+			Git:         gitInfo(abs),
+			FactCount:   b.store.CountByRepo(label),
+			SourceBytes: e.repoSourceBytes(b, abs),
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Label < entries[j].Label })
 	return entries
+}
+
+// repoSourceBytes returns a repo's parsed-source size. The repo indexed by THIS
+// snapshot is answered from memory; the rest are read from their own
+// snapshot.meta.json, which is authoritative for them whichever session wrote it.
+//
+// Zero on any failure, which the merge step then treats as "no new reading" and
+// carries the previous value forward — a repo whose metadata is momentarily
+// unreadable must not have its corpus silently reset to nothing.
+func (e *Engine) repoSourceBytes(b *snapshotBundle, absRepo string) int64 {
+	if b.snapshot != nil && b.snapshot.Meta.RepoPath == absRepo {
+		return b.snapshot.Meta.SourceBytes
+	}
+	data, err := os.ReadFile(filepath.Join(absRepo, e.cfg.Output.Dir, snapshotMetaFileName))
+	if err != nil {
+		return 0
+	}
+	var meta struct {
+		SourceBytes int64 `json:"source_bytes"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return 0
+	}
+	return meta.SourceBytes
 }
 
 // crossRepoEdgeCount counts the consumer->provider edges in the cross-repo "graph
@@ -333,6 +363,13 @@ func mergeRepoEntries(cur []facts.GraphRepoEntry, prevByLabel map[string]facts.G
 				c.CommitChangedAt = nowStr
 			} else {
 				c.CommitChangedAt = prev.CommitChangedAt
+			}
+			// A zero reading means the repo's metadata could not be read this
+			// time, not that its corpus vanished. Carry the last known size
+			// forward rather than writing the gap through — otherwise one
+			// unreadable file silently un-prices every later query on that repo.
+			if c.SourceBytes == 0 {
+				c.SourceBytes = prev.SourceBytes
 			}
 		}
 		c.InGraphFor = inGraphFor(c.AddedAt, now)

--- a/internal/engine/global_receipt_test.go
+++ b/internal/engine/global_receipt_test.go
@@ -97,6 +97,54 @@ func TestMergeRepoEntries_DepartedRepoDropped(t *testing.T) {
 	}
 }
 
+// A repo's corpus size is read from its own snapshot metadata, which may be
+// momentarily unreadable — a zero reading means "no measurement this time", not
+// "this repo has no source". Writing the gap through would silently un-price
+// every later query against that repo, so the last known size carries forward.
+func TestMergeRepoEntries_SourceBytesCarriedForwardOnZero(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
+	prev := map[string]facts.GraphRepoEntry{
+		"A": {Label: "A", AddedAt: "2026-07-01T09:00:00Z", Git: gi("x"), SourceBytes: 872_581_357},
+	}
+	cur := []facts.GraphRepoEntry{{Label: "A", Git: gi("x"), SourceBytes: 0}}
+
+	got := mergeRepoEntries(cur, prev, now)
+	if got[0].SourceBytes != 872_581_357 {
+		t.Errorf("SourceBytes: got %d, want the previous 872581357 carried forward", got[0].SourceBytes)
+	}
+}
+
+// A fresh reading always wins, so a repo that grew or shrank is repriced.
+func TestMergeRepoEntries_SourceBytesFreshReadingWins(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
+	prev := map[string]facts.GraphRepoEntry{
+		"A": {Label: "A", AddedAt: "2026-07-01T09:00:00Z", Git: gi("x"), SourceBytes: 100},
+	}
+	cur := []facts.GraphRepoEntry{{Label: "A", Git: gi("x"), SourceBytes: 900}}
+
+	if got := mergeRepoEntries(cur, prev, now); got[0].SourceBytes != 900 {
+		t.Errorf("SourceBytes: got %d, want the fresh 900", got[0].SourceBytes)
+	}
+}
+
+// The field is additive: a receipt written before it existed must still parse,
+// leaving the size unknown rather than failing the read.
+func TestReadPriorGraphReceipt_ReceiptWithoutSourceBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	old := `{"repos":[{"label":"A","path":"/tmp/a","added_at":"2026-07-01T09:00:00Z","fact_count":7}]}`
+	if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readPriorGraphReceipt(path)
+	entry, ok := got["A"]
+	if !ok {
+		t.Fatal("pre-existing receipt failed to parse")
+	}
+	if entry.SourceBytes != 0 || entry.FactCount != 7 {
+		t.Errorf("got %+v, want SourceBytes=0 (unknown) and the existing fields intact", entry)
+	}
+}
+
 func TestInGraphFor(t *testing.T) {
 	now, _ := time.Parse(time.RFC3339, "2026-07-08T09:00:00Z")
 	if got := inGraphFor("2026-07-08T06:00:00Z", now); got != (3 * time.Hour).String() {

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -378,4 +378,15 @@ type GraphRepoEntry struct {
 	InGraphFor      string   `json:"in_graph_for"`                // human duration since AddedAt (e.g. "72h3m0s"); derived, recomputed each write
 	FactCount       int      `json:"fact_count"`                  // facts tagged with this repo label
 	CommitChangedAt string   `json:"commit_changed_at,omitempty"` // RFC3339 UTC, last time the recorded commit moved; AddedAt is NOT reset when the commit changes
+
+	// SourceBytes is the on-disk size of this repo's parsed source — the corpus
+	// figure the value model prices against (see pkg/status). It is carried here
+	// so a server restarting onto a restored graph knows how large that graph is
+	// without re-snapshotting: the facts come back from disk, and so must the
+	// measurement of what they were extracted from.
+	//
+	// Zero means "not recorded" — a receipt written before this field existed, or
+	// a repo whose snapshot metadata could not be read. Consumers treat zero as
+	// unknown rather than as an empty corpus.
+	SourceBytes int64 `json:"source_bytes,omitempty"`
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,10 +83,15 @@ type Server struct {
 	// by genMu (only read/written inside the locked generate_snapshot handler).
 	snapshotsGenerated bool
 
-	// corpusByRepo remembers each repo's measured corpus for this session, so a
-	// later append can price cross-repo edge resolution against what is already
-	// loaded. Guarded by genMu, like snapshotsGenerated.
-	corpusByRepo map[string]int
+	// corpusByRepo remembers each repo's measured corpus for the currently loaded
+	// graph: a later append prices cross-repo edge resolution against it, and
+	// every query is scaled and capped by its total.
+	//
+	// Writes happen only in the genMu-serialized snapshot handler, but reads now
+	// come from the value middleware on every concurrent tool call. So the map is
+	// published behind an atomic pointer and replaced wholesale — never mutated
+	// in place, which would race a reader mid-iteration.
+	corpusByRepo atomic.Pointer[map[string]int]
 
 	// Freshness-banner cache. freshnessBanner() shells out to git per repo, so the
 	// result is memoized for freshTTL to keep that cost off the hot path of
@@ -178,7 +183,12 @@ func (s *Server) valueMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 		rec := &callRecord{}
 		result, err := next(context.WithValue(ctx, callRecordKey{}, rec), method, req)
 
-		call := status.ToolCall{Tool: params.Name, Repo: s.activeRepo(), OK: err == nil}
+		call := status.ToolCall{
+			Tool:         params.Name,
+			Repo:         s.activeRepo(),
+			OK:           err == nil,
+			CorpusTokens: s.loadedCorpusTokens(),
+		}
 		if ctr, ok := result.(*mcp.CallToolResult); ok && ctr != nil {
 			call.OK = call.OK && !ctr.IsError
 			call.ResponseBytes = resultBytes(ctr)
@@ -199,28 +209,79 @@ func (s *Server) valueMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 // bytes into tokens, matching the engine's own heuristic elsewhere.
 const charsPerToken = 4
 
-// rememberCorpus records a repo's measured corpus so that snapshotting a sibling
-// repo afterwards can price the cross-repo edge resolution against everything
-// already loaded. Caller holds genMu.
+// rememberCorpus records a repo's measured corpus in the published map, so that
+// snapshotting a sibling can price cross-repo edge resolution against what is
+// already loaded, and queries can be scaled by the whole graph. Copy-on-write:
+// the map is rebuilt and swapped rather than updated in place. Caller holds genMu.
 func (s *Server) rememberCorpus(repo string, tokens int) {
-	if s.corpusByRepo == nil {
-		s.corpusByRepo = make(map[string]int)
+	next := make(map[string]int)
+	if cur := s.corpusByRepo.Load(); cur != nil {
+		for k, v := range *cur {
+			next[k] = v
+		}
 	}
-	s.corpusByRepo[repo] = tokens
+	next[repo] = tokens
+	s.corpusByRepo.Store(&next)
 }
 
-// priorCorpusTokens is the combined corpus loaded before this call, excluding the
-// repo about to be indexed. It is deliberately session-scoped: after a restart it
-// starts empty, so the first snapshot of a session claims no cross-repo premium.
-// Under-crediting a restart is the right way to be wrong here. Caller holds genMu.
-func (s *Server) priorCorpusTokens(exclude string) int {
+// resetCorpus clears the pool, for a non-append snapshot that resets the store.
+// Caller holds genMu.
+func (s *Server) resetCorpus() {
+	s.corpusByRepo.Store(nil)
+}
+
+// SeedCorpus publishes the corpus of a graph restored from disk, so queries are
+// priced against it before this process has taken any snapshot of its own.
+//
+// Without it the pool is empty until the first generate_snapshot, and a restart
+// silently un-scales every query — which is the normal path, since
+// AutoLoadSnapshot exists precisely so queries work after a restart WITHOUT
+// re-snapshotting. Call it before Run; a nil or empty map is ignored, and a
+// later snapshot overwrites what it seeded.
+func (s *Server) SeedCorpus(byRepo map[string]int) {
+	if len(byRepo) == 0 {
+		return
+	}
+	seeded := make(map[string]int, len(byRepo))
+	for repo, tokens := range byRepo {
+		if tokens > 0 {
+			seeded[repo] = tokens
+		}
+	}
+	if len(seeded) == 0 {
+		return
+	}
+	s.corpusByRepo.Store(&seeded)
+}
+
+// corpusTokensExcept sums the published corpus, optionally skipping one repo.
+// Pass "" to total the whole loaded graph.
+func (s *Server) corpusTokensExcept(exclude string) int {
+	cur := s.corpusByRepo.Load()
+	if cur == nil {
+		return 0
+	}
 	total := 0
-	for repo, tokens := range s.corpusByRepo {
+	for repo, tokens := range *cur {
 		if repo != exclude {
 			total += tokens
 		}
 	}
 	return total
+}
+
+// priorCorpusTokens is the combined corpus loaded before this call, excluding the
+// repo about to be indexed. It is deliberately session-scoped: after a restart it
+// starts empty, so the first snapshot of a session claims no cross-repo premium.
+// Under-crediting a restart is the right way to be wrong here.
+func (s *Server) priorCorpusTokens(exclude string) int {
+	return s.corpusTokensExcept(exclude)
+}
+
+// loadedCorpusTokens is the size of the graph a query actually searched — every
+// repo resident, since a query is not scoped to one of them.
+func (s *Server) loadedCorpusTokens() int {
+	return s.corpusTokensExcept("")
 }
 
 // previousSnapshot reads a repo's last snapshot id and file hashes from its own
@@ -820,7 +881,7 @@ func (s *Server) registerTools() {
 		// appended to a small cluster would be credited for edges against every
 		// unrelated repo snapshotted earlier in the session.
 		if !appendMode {
-			s.corpusByRepo = nil
+			s.resetCorpus()
 		}
 
 		// Read this repo's previous snapshot from disk before overwriting it, so the

--- a/internal/server/usage_e2e_test.go
+++ b/internal/server/usage_e2e_test.go
@@ -90,6 +90,64 @@ func TestE2E_ToolUsageIsRecordedForStatus(t *testing.T) {
 	}
 }
 
+// A restarted server restores its graph from disk and serves queries without
+// re-snapshotting — that is what AutoLoadSnapshot exists for. Those queries
+// searched a graph of a known size, so they must be priced against it. Before
+// SeedCorpus the pool was empty until the first snapshot, so the normal path
+// (restart, query, never snapshot) silently scored queries as if the graph were
+// tiny.
+func TestE2E_SeededCorpusPricesQueriesAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("HOME", t.TempDir())
+
+	eng, cfg := newTestEngine(t)
+	srv, err := bootstrap.NewServer(eng, cfg)
+	if err != nil {
+		t.Fatalf("bootstrap.NewServer: %v", err)
+	}
+
+	repo := copyTree(t, filepath.Join("..", "engine", "testdata", "repos", "go_sample"), t.TempDir())
+	tracker := status.NewTracker(repo)
+	tracker.SetStartTime(time.Now())
+	srv.SetToolCallback(tracker.Record)
+	tracker.PersistStartup()
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	if _, err := srv.MCP().Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "enola-test", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	// Stand in for a restored graph: facts loaded, and a corpus large enough that
+	// pricing against it is visibly different from pricing against nothing.
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "generate_snapshot", Arguments: map[string]any{"repo_path": repo},
+	}); err != nil {
+		t.Fatalf("generate_snapshot: %v", err)
+	}
+	srv.SeedCorpus(map[string]int{repo: 40_000_000})
+
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "query_facts", Arguments: map[string]any{"kind": "module", "output_mode": "summary"},
+	}); err != nil {
+		t.Fatalf("query_facts: %v", err)
+	}
+
+	ss := status.ServerSnapshot()
+	got := ss.GrandSaved["query_facts"]
+	unscaled := status.ComputeValue(
+		map[string]int{"query_facts": 1}, map[string]int{},
+	).TotalTokensSaved
+	if got <= unscaled {
+		t.Errorf("query on a seeded 40M-token graph earned %d, no more than the unscaled %d", got, unscaled)
+	}
+}
+
 // A tool that fails is still a call that happened, but it displaced no work.
 // This holds end-to-end only because recording runs after the handler: a read
 // tool called with no snapshot loaded must earn nothing for its error message.

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -168,6 +168,13 @@ func (s *Server) Run(ctx context.Context) error {
 	return s.srv.Run(ctx)
 }
 
+// SeedCorpus publishes the corpus of a graph restored from disk, so queries are
+// priced against it before this process takes a snapshot of its own. Pass the map
+// returned by AutoLoadSnapshot, and call it before Run.
+func (s *Server) SeedCorpus(byRepo map[string]int) {
+	s.srv.SeedCorpus(byRepo)
+}
+
 // SetToolCallback sets a callback invoked once per completed tool call, with the
 // tool name, the absolute repo path the call operated on, whether it succeeded,
 // its response size and any snapshot detail — everything the value model needs
@@ -326,11 +333,18 @@ func GraphStateFunc(eng *Engine) status.GraphFunc {
 // it runs single-threaded at startup, before the MCP server begins serving tool
 // calls — no reader can observe a half-built store. Callers must keep it strictly
 // before Server.Run.
-func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
+// It returns the parsed-source size of each restored repo, keyed by absolute
+// path, or nil when nothing was restored. That map comes from the SAME receipt
+// the facts came from, which is the point of returning it rather than letting the
+// caller resolve one independently: the two could otherwise disagree, and a
+// server would size its graph by a repo set it is not actually holding. Pass it
+// to Server.SeedCorpus so queries are priced against the restored graph without
+// waiting for a snapshot this process did not need to take.
+func AutoLoadSnapshot(eng *Engine, cfg *config.Config) map[string]int {
 	// Preferred path: this workspace's own graph.
 	if gr, err := engine.LoadWorkspaceReceipt(cfg.Repo); err == nil && len(gr.Repos) > 0 {
 		if restoreFromGlobalReceipt(eng, cfg, gr) {
-			return
+			return corpusFromReceipt(gr)
 		}
 		log.Printf("[bootstrap] workspace receipt present but multi-repo restore incomplete; trying the machine-wide receipt")
 	}
@@ -341,7 +355,7 @@ func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
 	// the cross-talk the workspace receipt above exists to prevent.
 	if gr, err := engine.LoadGlobalReceipt(); err == nil && len(gr.Repos) > 0 && receiptCovers(gr, cfg.Repo) {
 		if restoreFromGlobalReceipt(eng, cfg, gr) {
-			return
+			return corpusFromReceipt(gr)
 		}
 		log.Printf("[bootstrap] global receipt present but multi-repo restore incomplete; falling back to single-repo")
 	}
@@ -349,18 +363,46 @@ func AutoLoadSnapshot(eng *Engine, cfg *config.Config) {
 	// Fallback: single-repo restore of cfg.Repo.
 	repoPath, err := filepath.Abs(cfg.Repo)
 	if err != nil {
-		return
+		return nil
 	}
 	dir := filepath.Join(repoPath, cfg.Output.Dir)
 	if _, err := os.Stat(filepath.Join(dir, "facts.jsonl")); err != nil {
-		return // nothing on disk; start empty
+		return nil // nothing on disk; start empty
 	}
 	label := filepath.Base(repoPath)
 	if err := eng.RestoreFromDir(dir, map[string]string{label: repoPath}, label); err != nil {
 		log.Printf("[bootstrap] warning: failed to restore snapshot from %s: %v", dir, err)
-		return
+		return nil
 	}
 	log.Printf("[bootstrap] restored single-repo snapshot for %s", label)
+
+	// No graph receipt on this path, so read the size from the snapshot we just
+	// restored — it carries the same measurement.
+	if snap := eng.Snapshot(); snap != nil && snap.Meta.SourceBytes > 0 {
+		return map[string]int{repoPath: int(snap.Meta.SourceBytes / charsPerToken)}
+	}
+	return nil
+}
+
+// charsPerToken converts source bytes to tokens, matching the heuristic used
+// throughout the engine and the value model.
+const charsPerToken = 4
+
+// corpusFromReceipt projects a graph receipt into the corpus map the server
+// prices queries with. Repos whose size was never recorded (a receipt written
+// before the field existed) are omitted rather than entered as zero, so a partial
+// receipt under-reports instead of claiming a repo has no source.
+func corpusFromReceipt(gr *facts.GraphReceipt) map[string]int {
+	out := make(map[string]int, len(gr.Repos))
+	for _, r := range gr.Repos {
+		if r.SourceBytes > 0 && r.Path != "" {
+			out[r.Path] = int(r.SourceBytes / charsPerToken)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // receiptCovers reports whether a graph receipt includes the given workspace

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -225,6 +225,55 @@ func TestAutoLoadSnapshot_FromGlobalReceipt(t *testing.T) {
 	}
 }
 
+// A restart restores the graph without re-snapshotting, so the corpus that graph
+// was extracted from has to come back too — otherwise queries against it are
+// priced as if it were tiny. AutoLoadSnapshot returns that measurement from the
+// SAME receipt the facts came from, so the two can never describe different repo
+// sets.
+func TestAutoLoadSnapshot_ReturnsRestoredCorpus(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	repo := writeGoRepo(t)
+	appended := writeBiggerGoRepo(t)
+	eng1, _ := engineFor(t, repo)
+
+	// Mirror the server: artifacts are written for each repo as it is indexed, so
+	// every repo ends up with its own snapshot.meta.json carrying its own size.
+	if _, err := eng1.GenerateSnapshot(context.Background(), repo, false); err != nil {
+		t.Fatalf("GenerateSnapshot: %v", err)
+	}
+	if err := eng1.WriteArtifacts(repo); err != nil {
+		t.Fatalf("WriteArtifacts: %v", err)
+	}
+	if _, err := eng1.GenerateSnapshot(context.Background(), appended, true); err != nil {
+		t.Fatalf("GenerateSnapshot (append): %v", err)
+	}
+	if err := eng1.WriteArtifacts(appended); err != nil {
+		t.Fatalf("WriteArtifacts (append): %v", err)
+	}
+	if err := eng1.WriteGlobalReceipt(); err != nil {
+		t.Fatalf("WriteGlobalReceipt: %v", err)
+	}
+
+	// Session 2 (restart) in the same workspace.
+	eng2, cfg2 := engineFor(t, repo)
+	corpus := bootstrap.AutoLoadSnapshot(eng2, cfg2)
+
+	if len(corpus) != 2 {
+		t.Fatalf("restored corpus covers %d repos, want 2: %+v", len(corpus), corpus)
+	}
+	for path, tokens := range corpus {
+		if tokens <= 0 {
+			t.Errorf("repo %s restored with a non-positive corpus of %d", path, tokens)
+		}
+	}
+	// The bigger repo must measure bigger — the map carries real sizes, not a
+	// placeholder shared by every entry.
+	if corpus[appended] <= corpus[repo] {
+		t.Errorf("expected the larger repo to measure larger: %d vs %d", corpus[appended], corpus[repo])
+	}
+}
+
 // TestAutoLoadSnapshot_PrefersOwnWorkspace is the cross-terminal regression test.
 // A user typically runs one server per agent terminal; the machine-wide receipt
 // describes only whichever generated last. A restart in workspace A must come back

--- a/pkg/status/value.go
+++ b/pkg/status/value.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -50,6 +51,21 @@ const (
 	// the MEDIAN parsed source file across the measured corpora (~800 tokens),
 	// not the mean, which outliers inflate by roughly 2.5x.
 	tokensPerManualOp = 800
+
+	// queryScaleReferenceCorpus is the graph size at which a query tool's weight
+	// is taken at face value. Below it the weight stands unscaled; above it, the
+	// same question displaces more manual searching, because the work a query
+	// replaces is driven by the size of the haystack rather than the number of
+	// needles — finding three cycles in a kernel is harder than finding three
+	// thousand in a small service.
+	queryScaleReferenceCorpus = 1_800_000
+
+	// maxQueryCorpusScale bounds that multiplier. The growth is logarithmic
+	// because a haystack 100x larger does not take 100x the greps, just a few
+	// more rounds of them; the cap then stops the largest graphs running away
+	// entirely. It is the most arbitrary number in this file — it exists to be
+	// conservative at the top end, not because 8 is special.
+	maxQueryCorpusScale = 8
 
 	// agentTokensPerSecond is end-to-end agent discovery throughput — tool round
 	// trips and reasoning included, not raw generation speed. It converts tokens
@@ -178,8 +194,28 @@ type ToolCall struct {
 	// visible in the estimate: summary mode genuinely saves more than full mode.
 	ResponseBytes int
 
+	// CorpusTokens is the size of the graph this call ran against — the whole
+	// loaded set, not one repo, since a query searches everything resident. It
+	// scales query credit and caps it. Zero means unknown, which scales by one.
+	// Ignored for generate_snapshot, which prices from Snapshot instead.
+	CorpusTokens int
+
 	// Snapshot is non-nil only for generate_snapshot.
 	Snapshot *SnapshotValue
+}
+
+// queryCorpusScale returns the multiplier applied to a query tool's ordinal
+// weight for a graph of the given size: 1 at or below the reference corpus,
+// growing logarithmically above it, hard-capped at maxQueryCorpusScale.
+func queryCorpusScale(corpusTokens int) float64 {
+	if corpusTokens <= queryScaleReferenceCorpus {
+		return 1
+	}
+	scale := 1 + math.Log2(float64(corpusTokens)/queryScaleReferenceCorpus)
+	if scale > maxQueryCorpusScale {
+		return maxQueryCorpusScale
+	}
+	return scale
 }
 
 // TokensSaved prices a single call: the tokens an agent did not have to ingest,
@@ -193,7 +229,7 @@ func (c ToolCall) TokensSaved() int {
 	if c.Snapshot != nil {
 		gross = c.Snapshot.tokens()
 	} else {
-		gross = weightFor(c.Tool) * tokensPerManualOp
+		gross = c.queryTokens()
 	}
 
 	net := gross - c.ResponseBytes/charsPerTokenApprox
@@ -201,6 +237,24 @@ func (c ToolCall) TokensSaved() int {
 		return 0
 	}
 	return net
+}
+
+// queryTokens prices one query tool call: its ordinal weight in tokens, scaled
+// by the size of the graph it searched, and capped by what reading that graph
+// would have cost outright.
+//
+// The cap matters as much as the scaling. Without it a single query against a
+// small repo is credited more than the repo's entire source — no call can
+// displace more work than reading everything it searched.
+func (c ToolCall) queryTokens() int {
+	gross := float64(weightFor(c.Tool)*tokensPerManualOp) * queryCorpusScale(c.CorpusTokens)
+
+	if c.CorpusTokens > 0 {
+		if ceiling := float64(c.CorpusTokens) * rediscoveryFactor; gross > ceiling {
+			return int(ceiling)
+		}
+	}
+	return int(gross)
 }
 
 // tokens prices a snapshot from the corpus it indexed.

--- a/pkg/status/value_test.go
+++ b/pkg/status/value_test.go
@@ -116,6 +116,65 @@ func TestResponseCostIsSubtracted(t *testing.T) {
 	}
 }
 
+// The same question over a bigger haystack displaces more searching, so query
+// credit rises with the size of the graph it ran against — sub-linearly, and
+// bounded, so a huge graph cannot run away with it.
+func TestQueryCreditScalesWithGraphSize(t *testing.T) {
+	q := func(corpus int) int {
+		return ToolCall{Tool: "query_insights", OK: true, CorpusTokens: corpus}.TokensSaved()
+	}
+	small, mid, large, kernel := q(1_800_000), q(8_450_000), q(32_770_000), q(218_150_000)
+
+	if small != weightFor("query_insights")*tokensPerManualOp {
+		t.Errorf("at the reference corpus the weight should stand unscaled: got %d", small)
+	}
+	if small >= mid || mid >= large || large >= kernel {
+		t.Errorf("credit must rise with graph size: %d %d %d %d", small, mid, large, kernel)
+	}
+	// Sub-linear, and bounded: the kernel is 121x the reference corpus but earns
+	// under 8x the credit — it lands just below the cap, which binds at ~230M.
+	ratio := float64(kernel) / float64(small)
+	if ratio > maxQueryCorpusScale {
+		t.Errorf("scaling exceeded its cap: %.2fx", ratio)
+	}
+	if ratio < 7 {
+		t.Errorf("kernel-scale query should approach the cap, got %.2fx", ratio)
+	}
+}
+
+// No single query can displace more work than reading everything it searched.
+// Without this a query on a small repo out-earns the repo's entire source.
+func TestQueryCreditCappedByGraphSize(t *testing.T) {
+	corpus := 17_906
+	tiny := ToolCall{Tool: "query_insights", OK: true, CorpusTokens: corpus}
+	if got, ceiling := tiny.TokensSaved(), int(float64(corpus)*rediscoveryFactor); got > ceiling {
+		t.Errorf("query credit %d exceeds the cost of reading the whole graph (%d)", got, ceiling)
+	}
+}
+
+// An unknown corpus must not silently zero the credit via the cap.
+func TestQueryCreditUnknownCorpusIsUnscaled(t *testing.T) {
+	got := ToolCall{Tool: "query_facts", OK: true}.TokensSaved()
+	if want := weightFor("query_facts") * tokensPerManualOp; got != want {
+		t.Errorf("unknown corpus: got %d, want the unscaled weight %d", got, want)
+	}
+}
+
+func TestQueryCorpusScaleBounds(t *testing.T) {
+	if got := queryCorpusScale(0); got != 1 {
+		t.Errorf("unknown corpus scale: got %v, want 1", got)
+	}
+	if got := queryCorpusScale(queryScaleReferenceCorpus / 100); got != 1 {
+		t.Errorf("small corpus must floor at 1, got %v", got)
+	}
+	if got := queryCorpusScale(queryScaleReferenceCorpus * 2); got != 2 {
+		t.Errorf("doubling the corpus should add one scale step: got %v, want 2", got)
+	}
+	if got := queryCorpusScale(1 << 60); got != maxQueryCorpusScale {
+		t.Errorf("scale must cap: got %v, want %v", got, maxQueryCorpusScale)
+	}
+}
+
 func TestSnapshotCreditScalesWithCorpus(t *testing.T) {
 	small := ToolCall{Tool: "generate_snapshot", OK: true,
 		Snapshot: &SnapshotValue{CorpusTokens: 72_000, ChangedFraction: 1}}


### PR DESCRIPTION
Snapshots were priced from measured corpus; queries were not. The same query_insights earned an identical figure over a 1.9M-fact graph and over a few hundred facts, because query credit was weight x tokensPerManualOp with no corpus term. The work a query replaces is driven by the size of the haystack, not the number of needles - finding 51 cycles across 55,399 files is not the same act as finding them across thirty.

- Scale a query tool's ordinal weight by the loaded graph's corpus, logarithmically and capped: a haystack 100x larger takes a few more rounds of greps, not 100x, and linear scaling would hand a single call millions of tokens on a kernel-sized graph.
- Cap a query by its graph, as a snapshot is capped by its repo. No call displaces more work than reading outright everything it searched - without it a single query on a small repo out-earns the repo's entire source.
- Carry each repo's parsed-source size in the graph receipt (GraphRepoEntry.SourceBytes) and return it from AutoLoadSnapshot, so a restored graph is sized from the SAME receipt its facts came from; resolving one independently could size the graph by a repo set the server is not holding. Server.SeedCorpus publishes it before serving.

  Not an edge case: AutoLoadSnapshot exists so queries work after a restart WITHOUT re-snapshotting, so an unseeded pool left the common path unscaled - measured at 23,669 tokens for a call worth 189,836.

  The field is additive and omitempty. Older receipts read as zero, which is treated as unknown rather than as an empty corpus and heals on the next snapshot. It is not an input to computeSnapshotID, so snapshot fingerprints are unchanged. A repo whose metadata is momentarily unreadable also yields zero, which the receipt merge carries forward rather than writing through - one failed read must not unprice a repo.
- Publish the corpus map behind an atomic pointer: it is written by the snapshot handler but is now read on every concurrent tool call.

Docs: correct the corpus table to engine-measured values (several rows carried filesystem estimates, and the worked example still showed credit from before the cross-repo premium was scoped to the loaded graph), replace that example with one whose every figure is measured, extend the range with the largest codebase tested, and name the public codebases behind each measurement.