### PR TITLE
fix(engine): exclude enola's output dir from git dirtiness

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -427,7 +427,7 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 
 			EnolaVersion: version.Version,
 			SnapshotID:   computeSnapshotID(factsBuf.Bytes(), version.Version, configHash),
-			Git:          gitInfo(absRepo),
+			Git:          gitInfo(absRepo, e.cfg.Output.Dir),
 			ConfigHash:   configHash,
 
 			FilesSeen:         len(files),

--- a/internal/engine/freshness.go
+++ b/internal/engine/freshness.go
@@ -70,7 +70,11 @@ func (e *Engine) Staleness(maxAge time.Duration, now time.Time) Staleness {
 		if r.Path == "" || r.Git == nil {
 			continue // non-git or unknown: covered by the age signal only
 		}
-		cur := gitInfo(r.Path)
+		// Same outputDir exclusion as the snapshot-time capture in receipt.go. The two
+		// MUST agree: recording "clean" while reading the live tree as dirty (because
+		// enola's own output dir is untracked) would make the arm below fire on every
+		// single snapshot.
+		cur := gitInfo(r.Path, e.cfg.Output.Dir)
 		if cur == nil {
 			continue
 		}

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -158,7 +158,7 @@ func (e *Engine) repoEntries(b *snapshotBundle) []facts.GraphRepoEntry {
 		entries = append(entries, facts.GraphRepoEntry{
 			Label:       label,
 			Path:        abs,
-			Git:         gitInfo(abs),
+			Git:         gitInfo(abs, e.cfg.Output.Dir),
 			FactCount:   b.store.CountByRepo(label),
 			SourceBytes: e.repoSourceBytes(b, abs),
 		})

--- a/internal/engine/receipt.go
+++ b/internal/engine/receipt.go
@@ -76,7 +76,18 @@ func computeConfigHash(cfg *config.Config) string {
 // gitInfo captures the repository's VCS state. It returns nil when repoPath is
 // not a git working tree or git is unavailable, so a non-git or sandboxed run
 // degrades to no git section rather than erroring.
-func gitInfo(repoPath string) *facts.GitInfo {
+//
+// outputDir is the engine's output directory (cfg.Output.Dir), excluded from the
+// dirtiness check. enola writes its own artifacts there and --porcelain lists
+// untracked paths, so without the exclusion any repo that does not gitignore that
+// directory records dirty:true from its first snapshot onward — the cache save
+// creates it before this function runs, and it pre-exists every later run. That
+// wrong baseline silently disables the git-drift half of the staleness check, whose
+// "newly dirty" arm can only fire when the recorded state was clean (see
+// freshness.go). The walker already excludes the same directory from analysis, so
+// keeping it out here makes the flag describe the SOURCE rather than enola's own
+// output. Pass "" to check the whole tree.
+func gitInfo(repoPath, outputDir string) *facts.GitInfo {
 	commit, err := runGit(repoPath, "rev-parse", "HEAD")
 	if err != nil || commit == "" {
 		return nil
@@ -86,7 +97,14 @@ func gitInfo(repoPath string) *facts.GitInfo {
 		info.Ref = ref
 	}
 	// --porcelain prints one line per changed/untracked path; any output => dirty.
-	if status, err := runGit(repoPath, "status", "--porcelain"); err == nil && strings.TrimSpace(status) != "" {
+	// The ':(exclude)' pathspec drops our own output dir; '.' is the positive
+	// pathspec it subtracts from. An outputDir configured outside the repo simply
+	// matches nothing, which is harmless.
+	statusArgs := []string{"status", "--porcelain"}
+	if outputDir != "" {
+		statusArgs = append(statusArgs, "--", ".", ":(exclude)"+outputDir)
+	}
+	if status, err := runGit(repoPath, statusArgs...); err == nil && strings.TrimSpace(status) != "" {
 		info.Dirty = true
 	}
 	return info

--- a/internal/engine/restore_test.go
+++ b/internal/engine/restore_test.go
@@ -201,6 +201,123 @@ func writeForeignGlobalReceipt(t *testing.T, home, foreignRepoPath, generatedAt 
 	}
 }
 
+// TestSnapshotGit_OwnOutputDirIsNotTreeDirt is the regression for enola recording its
+// OWN artifacts as working-tree dirt. gitInfo decides dirtiness from any
+// `git status --porcelain` output, and --porcelain lists untracked paths — so the
+// .enola/ directory the snapshot itself creates (extractor-cache save, engine.go:328,
+// which runs BEFORE the receipt reads git state) made a pristine committed repo record
+// dirty: true.
+//
+// The repo here deliberately does NOT gitignore the output dir, which is the case that
+// regresses. The second snapshot matters as much as the first: by then .enola/ already
+// exists before the run begins, so call ordering is no longer the operative cause and
+// only excluding the directory fixes it.
+func TestSnapshotGit_OwnOutputDirIsNotTreeDirt(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "go.mod"), "module dirtmod\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\n")
+	initGitRepo(t, repo)
+
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.RegisterExtractor(goextractor.New())
+
+	for _, run := range []string{"first", "second"} {
+		snap, err := eng.GenerateSnapshot(context.Background(), repo, false)
+		if err != nil {
+			t.Fatalf("%s snapshot: %v", run, err)
+		}
+		if err := eng.WriteArtifacts(repo); err != nil {
+			t.Fatalf("%s WriteArtifacts: %v", run, err)
+		}
+		if snap.Meta.Git == nil {
+			t.Fatalf("%s run: no git info recorded", run)
+		}
+		if snap.Meta.Git.Dirty {
+			t.Errorf("%s run: committed-clean repo recorded dirty:true — enola's own %s/ counted as tree dirt",
+				run, cfg.Output.Dir)
+		}
+	}
+}
+
+// TestSnapshotGit_RealChangeStillDirty guards the fix above against over-suppressing:
+// excluding the output dir must not blind the flag to actual uncommitted source changes.
+func TestSnapshotGit_RealChangeStillDirty(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "go.mod"), "module dirtmod2\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\n")
+	initGitRepo(t, repo)
+
+	// A real, uncommitted modification to a TRACKED file.
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\nfunc B() {}\n")
+
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.RegisterExtractor(goextractor.New())
+
+	snap, err := eng.GenerateSnapshot(context.Background(), repo, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Meta.Git == nil {
+		t.Fatal("no git info recorded")
+	}
+	if !snap.Meta.Git.Dirty {
+		t.Error("a modified tracked file must still record dirty:true")
+	}
+}
+
+// TestStaleness_DetectsEditAfterCleanSnapshotWithoutGitignore is the payoff. A repo that
+// does not gitignore the output dir previously recorded dirty:true at snapshot time,
+// which killed the `!r.Git.Dirty && cur.Dirty` arm for its whole life — so a later edit
+// produced no staleness signal at all. With the baseline recorded correctly, the arm is
+// live again.
+func TestStaleness_DetectsEditAfterCleanSnapshotWithoutGitignore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "go.mod"), "module dirtmod3\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\n")
+	initGitRepo(t, repo)
+
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.RegisterExtractor(goextractor.New())
+	if _, err := eng.GenerateSnapshot(context.Background(), repo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Edit a tracked file after the snapshot, leaving it uncommitted.
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\nfunc Added() {}\n")
+
+	now := time.Now()
+	st := eng.Staleness(24*time.Hour, now)
+	if st.TooOld {
+		t.Fatalf("snapshot is seconds old, TooOld should be false (Age=%s)", st.Age)
+	}
+	if len(st.Changed) != 1 || st.Changed[0].Reason != "uncommitted changes" {
+		t.Errorf("got Changed=%+v, want one \"uncommitted changes\" for the edited repo", st.Changed)
+	}
+}
+
 // initGitRepo creates a git repo with one commit and returns its HEAD.
 func initGitRepo(t *testing.T, repo string) string {
 	t.Helper()


### PR DESCRIPTION
gitInfo set Dirty on any `git status --porcelain` output, and --porcelain lists untracked paths. The snapshot creates <repo>/.enola itself, before the receipt reads git state, so any repo that does not gitignore it recorded dirty:true for a fully committed checkout — and from the second snapshot on, the directory pre-exists the run.

That wrong baseline disabled the staleness check's VCS arm, which can only fire when the recorded state was clean, leaving those repos with no git-drift signal at all.

The status query now excludes the configured output dir via a pathspec, in gitInfo itself so the snapshot-time capture and the live check share one definition of dirty. Splitting them would record clean against a live dirty and fire on every snapshot.

Fact output is unchanged; no cacheVersion bump.