### PR TITLE
fix(diff): detect a stale current snapshot at the diff boundary

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -277,15 +277,43 @@ func compareMeta(base, cur facts.SnapshotMeta) Comparability {
 	// GeneratedAt was printed on line 3 and never compared. An 11-day-old baseline from
 	// the same enola version with the same extractors yields Comparable:true, zero
 	// warnings, and a confident 24-regression report for a change that touched no facts.
-	if age, ok := baselineAgeDays(base.GeneratedAt, cur.GeneratedAt); ok && age >= staleBaselineDays {
+	switch gap, ok := baselineGap(base.GeneratedAt, cur.GeneratedAt); {
+	case !ok:
+		// Unparseable or missing timestamp — the pre-receipt case, which already has
+		// its own softer note above. Nothing further to say.
+	case gap <= 0:
+		// The baseline is NEWER than the snapshot being compared, i.e. the "current"
+		// side is stale. This used to be silent: it shared the ok=false signal with
+		// "no timestamp recorded", so the provenance line rendered backwards and
+		// nothing flagged it.
+		c.Warnings = append(c.Warnings,
+			"the baseline is newer than the snapshot it is being compared against — the current snapshot "+
+				"predates the baseline, so it does not contain your change; re-run generate_snapshot")
+	case int(gap.Hours()/24) >= staleBaselineDays:
 		c.Warnings = append(c.Warnings, fmt.Sprintf(
 			"baseline is %d days older than the current snapshot — anything the repo itself changed in "+
 				"between will appear as part of this delta; re-pin the baseline (set_baseline) to compare only your change",
-			age))
+			int(gap.Hours()/24)))
 	}
 
 	c.Comparable = len(c.Warnings) == 0
 	return c
+}
+
+// AddWarning appends a comparability warning and clears Comparable, preserving the
+// `Comparable == (len(Warnings) == 0)` invariant that compareMeta establishes.
+//
+// It exists so callers outside this package can contribute a caveat without setting
+// the two fields independently — a caller that appended to Warnings and forgot
+// Comparable would render the caveat above the delta while still reporting the pair as
+// comparable in JSON. Used for facts that only the caller can know, notably whether
+// the current snapshot still matches the working tree (engine.Drift).
+func (d *SnapshotDiff) AddWarning(w string) {
+	if w == "" {
+		return
+	}
+	d.Comparability.Warnings = append(d.Comparability.Warnings, w)
+	d.Comparability.Comparable = false
 }
 
 // missingFrom returns the elements of want that are absent from have, sorted.
@@ -295,11 +323,16 @@ func compareMeta(base, cur facts.SnapshotMeta) Comparability {
 // multi-day refactor, and the caller is the only one who knows which they meant.
 const staleBaselineDays = 3
 
-// baselineAgeDays returns how many whole days older the baseline is than the current
-// snapshot. Both timestamps are RFC3339 UTC (facts.SnapshotMeta.GeneratedAt); an
-// unparseable or missing one yields ok=false, which is the pre-receipt baseline case
-// that already has its own warning.
-func baselineAgeDays(baseTS, curTS string) (int, bool) {
+// baselineGap returns how much older the baseline is than the current snapshot: a
+// positive duration when the baseline came first, non-positive when the pair is
+// inverted (a stale "current" side). Both timestamps are RFC3339 UTC
+// (facts.SnapshotMeta.GeneratedAt).
+//
+// ok=false means only that a timestamp was missing or unparseable — the pre-receipt
+// case, which has its own note. It deliberately does NOT fold in the inverted case:
+// conflating "cannot tell" with "baseline is newer" is what made an inverted pair
+// silent, so callers must distinguish the two.
+func baselineGap(baseTS, curTS string) (time.Duration, bool) {
 	b, err := time.Parse(time.RFC3339, baseTS)
 	if err != nil {
 		return 0, false
@@ -308,11 +341,7 @@ func baselineAgeDays(baseTS, curTS string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
-	d := c.Sub(b)
-	if d <= 0 {
-		return 0, false
-	}
-	return int(d.Hours() / 24), true
+	return c.Sub(b), true
 }
 
 func missingFrom(want, have []string) []string {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -554,3 +554,41 @@ func TestCompareMeta_StaleBaselineWarns(t *testing.T) {
 		}
 	}
 }
+
+// TestCompareMeta_BaselineNewerThanCurrentWarns covers the inverted pair, which used to
+// be silent: baselineAgeDays returns ok=false for a non-positive gap, sharing that
+// signal with "no timestamp recorded", so a baseline NEWER than the snapshot being
+// compared produced zero warnings. That is the sharpest form of a stale current
+// snapshot — the provenance line renders backwards ("Baseline <newer> → current
+// <older>") and nothing says so.
+func TestCompareMeta_BaselineNewerThanCurrentWarns(t *testing.T) {
+	meta := func(ts string) facts.SnapshotMeta {
+		return facts.SnapshotMeta{
+			RepoPath: "/repo", EnolaVersion: "dev", GeneratedAt: ts,
+			Extractors: []string{"go"},
+		}
+	}
+	// Baseline is 13 minutes NEWER than "current".
+	inverted := compareMeta(meta("2026-07-30T06:30:00Z"), meta("2026-07-30T06:17:24Z"))
+	var found bool
+	for _, w := range inverted.Warnings {
+		if strings.Contains(w, "newer") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a baseline newer than the current snapshot produced no warning: %v", inverted.Warnings)
+	}
+	if inverted.Comparable {
+		t.Error("an inverted baseline/current pair must not be reported as comparable")
+	}
+
+	// A missing timestamp is a DIFFERENT condition and keeps its own softer note; it
+	// must not start claiming the pair is inverted.
+	missing := compareMeta(meta(""), meta("2026-07-30T06:17:24Z"))
+	for _, w := range missing.Warnings {
+		if strings.Contains(w, "newer") {
+			t.Errorf("a missing baseline timestamp was reported as an inverted pair: %q", w)
+		}
+	}
+}

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Drift reports how a repository's files have moved since its snapshot was taken:
+// which were added, removed, or edited. It is the answer to "does the graph I am
+// about to diff still describe the code on disk?".
+//
+// It is deliberately a FILESYSTEM comparison, not a VCS one. The snapshot already
+// records a content hash per walked file (facts.SnapshotMeta.FileHashes), so the
+// question can be answered exactly, from enola's own data, for repos that are not
+// git working trees at all. The git-derived signals cannot answer it: a commit that
+// has not moved says nothing about the working tree, and Git.Dirty is a single
+// boolean, so a tree that was ALREADY modified when the snapshot ran cannot be
+// distinguished from the same tree modified further (see internal/engine/freshness.go
+// and the freshness dossier's GAP-FR-03).
+//
+// Unknown means the comparison could not be made — the snapshot recorded no file
+// hashes, which is the case for a pre-receipt snapshot or a restore whose
+// snapshot.meta.json failed to load. Callers must surface that as "cannot verify"
+// and never as a clean tree: silence and confirmation are different answers.
+type Drift struct {
+	Added    []string // walked now, absent from the snapshot
+	Removed  []string // in the snapshot, absent now
+	Modified []string // present in both, different content hash
+	Unknown  bool     // no recorded hashes to compare against
+}
+
+// Any reports whether any file was added, removed, or edited. It is false when
+// Unknown — an unanswerable comparison is not evidence of change.
+func (d Drift) Any() bool {
+	return len(d.Added) > 0 || len(d.Removed) > 0 || len(d.Modified) > 0
+}
+
+// Count is the total number of drifted paths.
+func (d Drift) Count() int {
+	return len(d.Added) + len(d.Removed) + len(d.Modified)
+}
+
+// Summary renders a one-line description for a comparability warning, naming counts
+// and a bounded sample of paths so the caller can see WHICH files moved without the
+// message becoming unbounded on a large refactor.
+func (d Drift) Summary(maxPaths int) string {
+	if d.Unknown {
+		return "the snapshot recorded no file hashes, so whether it still matches the working tree cannot be verified"
+	}
+	if !d.Any() {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if n := len(d.Modified); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d modified", n))
+	}
+	if n := len(d.Added); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d added", n))
+	}
+	if n := len(d.Removed); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d removed", n))
+	}
+	sample := make([]string, 0, maxPaths)
+	for _, group := range [][]string{d.Modified, d.Added, d.Removed} {
+		for _, p := range group {
+			if len(sample) >= maxPaths {
+				break
+			}
+			sample = append(sample, p)
+		}
+	}
+	msg := ""
+	for i, p := range parts {
+		if i > 0 {
+			msg += ", "
+		}
+		msg += p
+	}
+	if len(sample) > 0 {
+		msg += " (e.g. "
+		for i, p := range sample {
+			if i > 0 {
+				msg += ", "
+			}
+			msg += p
+		}
+		if d.Count() > len(sample) {
+			msg += ", …"
+		}
+		msg += ")"
+	}
+	return msg
+}
+
+// Drift re-walks repoPath under the current config and compares each file's content
+// hash against the hashes the loaded snapshot recorded, returning the exact set of
+// differences.
+//
+// This re-reads and re-hashes every walked file, which costs roughly the walk+hash
+// stages of a snapshot. That is why it is an on-demand call for the tools that are
+// ABOUT to make a claim about the change (diff_snapshot,
+// validate_architecture_change) rather than part of the per-tool-call freshness
+// banner: the banner is a cheap proactive nudge, this is an exact answer at a
+// decision point.
+//
+// The snapshot's recorded hashes cover the repo that snapshot indexed. In multi-repo
+// (append) mode that is the most recently indexed repo, so a caller asking about a
+// different repo in the graph gets Unknown rather than a wrong answer.
+func (e *Engine) Drift(repoPath string) (Drift, error) {
+	b := e.current.Load()
+	if b.snapshot == nil {
+		return Drift{Unknown: true}, nil
+	}
+
+	recorded := make(map[string]string, len(b.snapshot.Meta.FileHashes))
+	for _, fh := range b.snapshot.Meta.FileHashes {
+		recorded[fh.Path] = fh.Hash
+	}
+	if len(recorded) == 0 {
+		return Drift{Unknown: true}, nil
+	}
+
+	files, _, _, err := e.walkRepo(repoPath)
+	if err != nil {
+		return Drift{}, fmt.Errorf("walking %s: %w", repoPath, err)
+	}
+	current := e.computeFileHashes(repoPath, files)
+
+	var d Drift
+	for path, curHash := range current {
+		prevHash, existed := recorded[path]
+		switch {
+		case !existed:
+			d.Added = append(d.Added, path)
+		case prevHash != curHash:
+			d.Modified = append(d.Modified, path)
+		}
+	}
+	for path := range recorded {
+		if _, stillThere := current[path]; !stillThere {
+			d.Removed = append(d.Removed, path)
+		}
+	}
+
+	// Deterministic order: these paths reach a user-facing warning.
+	sort.Strings(d.Added)
+	sort.Strings(d.Removed)
+	sort.Strings(d.Modified)
+	return d, nil
+}

--- a/internal/engine/drift_test.go
+++ b/internal/engine/drift_test.go
@@ -1,0 +1,155 @@
+package engine_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/engine"
+	"github.com/enola-labs/enola/internal/extractors/goextractor"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// driftEngine snapshots a two-package Go repo and returns the engine holding it.
+func driftEngine(t *testing.T, repo string) *engine.Engine {
+	t.Helper()
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.RegisterExtractor(goextractor.New())
+	if _, err := eng.GenerateSnapshot(context.Background(), repo, false); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	return eng
+}
+
+func driftRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "go.mod"), "module driftmod\n\ngo 1.21\n")
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\n")
+	writeFile(t, filepath.Join(repo, "pkg", "b", "b.go"), "package b\n\nfunc B() {}\n")
+	return repo
+}
+
+// TestDrift_UnchangedTreeHasNoDrift is the false-positive guard: enola writes its own
+// output dir during the snapshot, so a naive comparison would report that as drift on
+// every call. The walker's ignore globs must keep it out.
+func TestDrift_UnchangedTreeHasNoDrift(t *testing.T) {
+	repo := driftRepo(t)
+	eng := driftEngine(t, repo)
+	if err := eng.WriteArtifacts(repo); err != nil {
+		t.Fatalf("write artifacts: %v", err)
+	}
+
+	d, err := eng.Drift(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Any() {
+		t.Errorf("untouched tree reported drift: added=%v removed=%v modified=%v", d.Added, d.Removed, d.Modified)
+	}
+}
+
+// TestDrift_DetectsModifiedFile is the base case: content changed, nothing else.
+func TestDrift_DetectsModifiedFile(t *testing.T) {
+	repo := driftRepo(t)
+	eng := driftEngine(t, repo)
+
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\nfunc Added() {}\n")
+
+	d, err := eng.Drift(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Any() {
+		t.Fatal("edited file produced no drift")
+	}
+	if len(d.Modified) != 1 || d.Modified[0] != filepath.Join("pkg", "a", "a.go") {
+		t.Errorf("Modified=%v, want exactly [pkg/a/a.go]", d.Modified)
+	}
+	if len(d.Added) != 0 || len(d.Removed) != 0 {
+		t.Errorf("unexpected added=%v removed=%v", d.Added, d.Removed)
+	}
+}
+
+// TestDrift_DetectsAddedAndRemoved covers the set difference, not just content.
+func TestDrift_DetectsAddedAndRemoved(t *testing.T) {
+	repo := driftRepo(t)
+	eng := driftEngine(t, repo)
+
+	writeFile(t, filepath.Join(repo, "pkg", "c", "c.go"), "package c\n\nfunc C() {}\n")
+	if err := os.Remove(filepath.Join(repo, "pkg", "b", "b.go")); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := eng.Drift(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Added) != 1 || d.Added[0] != filepath.Join("pkg", "c", "c.go") {
+		t.Errorf("Added=%v, want [pkg/c/c.go]", d.Added)
+	}
+	if len(d.Removed) != 1 || d.Removed[0] != filepath.Join("pkg", "b", "b.go") {
+		t.Errorf("Removed=%v, want [pkg/b/b.go]", d.Removed)
+	}
+}
+
+// TestDrift_DirtyAtSnapshotStillDetectsFurtherEdits is the whole point of this change,
+// and the case the git-boolean signal cannot express (new/74). The snapshot is taken
+// over a tree that is ALREADY modified; a later edit to a DIFFERENT file must still be
+// detected. No git involved — drift is a filesystem question, and this repo is not even
+// a git repo.
+func TestDrift_DirtyAtSnapshotStillDetectsFurtherEdits(t *testing.T) {
+	repo := driftRepo(t)
+
+	// Pre-existing "uncommitted work" at snapshot time.
+	writeFile(t, filepath.Join(repo, "pkg", "a", "a.go"), "package a\n\nfunc A() {}\nfunc WorkInProgress() {}\n")
+	eng := driftEngine(t, repo)
+
+	if d, err := eng.Drift(repo); err != nil {
+		t.Fatal(err)
+	} else if d.Any() {
+		t.Fatalf("precondition: snapshot should match the tree it was taken over, got %+v", d)
+	}
+
+	// Now drift a different file.
+	writeFile(t, filepath.Join(repo, "pkg", "b", "b.go"), "package b\n\nfunc B() {}\nfunc Later() {}\n")
+
+	d, err := eng.Drift(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Modified) != 1 || d.Modified[0] != filepath.Join("pkg", "b", "b.go") {
+		t.Errorf("Modified=%v, want [pkg/b/b.go] — a snapshot taken over an already-modified tree must still detect later edits", d.Modified)
+	}
+}
+
+// TestDrift_NoRecordedHashesIsUnknown guards the degradation path: a snapshot with no
+// FileHashes (pre-receipt, or a restore whose meta failed to load) must report "cannot
+// verify" rather than a false all-clear.
+func TestDrift_NoRecordedHashesIsUnknown(t *testing.T) {
+	repo := driftRepo(t)
+	cfg := config.Default()
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A snapshot with RepoPath but no FileHashes, as AutoLoadSnapshot used to produce.
+	eng.SetSnapshot(&facts.Snapshot{Meta: facts.SnapshotMeta{RepoPath: repo}})
+
+	d, err := eng.Drift(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Unknown {
+		t.Error("a snapshot with no recorded file hashes must report Unknown, not a clean tree")
+	}
+	if d.Any() {
+		t.Errorf("Unknown drift must not claim specific changes: %+v", d)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1654,6 +1654,14 @@ func (s *Server) registerTools() {
 		if args.Focus != "" {
 			d = d.Focused(s.normalizeToRelative(args.Focus))
 		}
+		// Whether the CURRENT snapshot still matches the working tree is something only
+		// the caller can establish, and it is the one caveat that invalidates the whole
+		// delta: if the tree moved since the snapshot, this diff describes neither the
+		// old state nor the new one. Checked here rather than in the freshness banner
+		// because it re-hashes the repo — affordable at a deliberate decision point,
+		// not on every tool call. Focused() preserves Comparability, so this is added
+		// after narrowing and still renders above the delta.
+		s.addDriftWarning(d, repoPath)
 
 		switch resolveOutputMode(args.OutputMode, modeSummary) {
 		case modeFull:
@@ -1719,6 +1727,40 @@ func (s *Server) registerTools() {
 		}
 		return textResult(capTokens(rc.Render(), args.MaxTokens, false)), nil, nil
 	})
+}
+
+// driftSamplePaths bounds how many drifted paths a comparability warning names, so the
+// message stays readable on a large refactor while still showing WHICH files moved.
+const driftSamplePaths = 5
+
+// addDriftWarning appends a comparability caveat when the loaded snapshot no longer
+// matches repoPath's working tree, so a delta computed from a stale snapshot cannot be
+// mistaken for a current one.
+//
+// A failure to determine drift is logged and otherwise ignored: the diff is still worth
+// returning, and inventing a caveat from an unreadable repo would be its own false
+// signal. A snapshot with no recorded file hashes reports Unknown, surfaced as "cannot
+// verify" rather than silence — an unanswerable check must not read as a clean bill of
+// health.
+func (s *Server) addDriftWarning(d *diff.SnapshotDiff, repoPath string) {
+	if d == nil || repoPath == "" {
+		return
+	}
+	dr, err := s.eng.Drift(repoPath)
+	if err != nil {
+		log.Printf("[server] could not determine drift for %s: %v", repoPath, err)
+		return
+	}
+	switch {
+	case dr.Unknown:
+		d.AddWarning("could not verify that the current snapshot still matches the working tree — " +
+			dr.Summary(driftSamplePaths))
+	case dr.Any():
+		d.AddWarning(fmt.Sprintf(
+			"the working tree has changed since the current snapshot was taken: %s — this delta "+
+				"describes neither the snapshot's state nor the tree's; re-run generate_snapshot and diff again",
+			dr.Summary(driftSamplePaths)))
+	}
 }
 
 // resolveBaselineDir maps a baseline selector ('pinned'/”/'previous'/explicit

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -58,6 +58,18 @@ func (e *Engine) Snapshot() *facts.Snapshot {
 	return e.eng.Snapshot()
 }
 
+// Drift is the set of files that moved since the snapshot was taken. Aliased rather
+// than redefined so its methods (Any, Count, Summary) come with it and the two
+// packages cannot drift apart.
+type Drift = engine.Drift
+
+// Drift reports whether the loaded snapshot still matches repoPath's working tree, by
+// re-walking and re-hashing. It re-reads every walked file, so it belongs at a
+// deliberate decision point (a diff, a validation) rather than on a hot read path.
+func (e *Engine) Drift(repoPath string) (Drift, error) {
+	return e.eng.Drift(repoPath)
+}
+
 // ActiveRepo returns the absolute repo path of the currently loaded snapshot,
 // or "" if none is loaded. Used to attribute tool usage to the repo a call
 // actually operated on.


### PR DESCRIPTION
diff_snapshot and validate_architecture_change both labelled one side "current" without ever checking that it still matched the working tree. The only age check was relative — baseline vs current — so two equally stale snapshots compared clean, and an inverted pair was silent because a non-positive gap shared its signal with "no timestamp recorded".

Engine.Drift re-walks under the current config and re-hashes, comparing against the snapshot's recorded file hashes, and both tools now surface a comparability warning naming the drifted files. This is a filesystem comparison, not a VCS one: the snapshot already records a hash per walked file, so it answers exactly and works for repos that are not git working trees.

Exact drift also removes the need for a wall-clock threshold — unchanged content makes age irrelevant, and changed content makes it beside the point. The per-tool-call freshness banner is unchanged; this runs only at a deliberate decision point, where re-hashing is affordable.

Known limit, documented: recorded hashes cover the repo a snapshot indexed, so in append mode drift checks the most-recently-indexed repo and reports "cannot verify" for the others.

Fact output is unchanged; no cacheVersion bump.