### PR TITLE
feat(diff): identify a repository by remote, not by absolute path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,93 @@ jobs:
       - name: Golden + determinism
         run: go test -count=1 -run 'TestGolden|TestDeterminism' ./internal/engine/...
 
+  # Enola grading Enola: the gate this repo ships, run on this repo's own changes.
+  #
+  # ADVISORY — this job reports the verdict and always succeeds. It is here to prove the
+  # gate works on a real PR stream and to surface structural regressions for a human to
+  # judge, not to block merges yet. To make it enforcing, delete the `exit 0` at the end
+  # of "Grade the change" (see the comment there).
+  #
+  # The baseline comes from the PR's own merge base rather than a published artifact.
+  # That costs one extra index — which for this repo is ~200ms — and in exchange needs no
+  # cross-workflow artifact plumbing, no third-party action, and no push trigger. A repo
+  # large enough for that trade to hurt should use the publish/restore shape in
+  # examples/ci/architecture-gate.yml instead.
+  architecture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # merge-base needs history; the default depth-1 clone has none
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Built ONCE, from the PR head, and kept outside the tree so it survives the
+      # checkouts below. Using one binary for both snapshots keeps the enola version and
+      # config hash identical on the two sides — rebuilding at the merge base would make
+      # them differ and the gate would (correctly) decline to grade.
+      - name: Build enola from this PR
+        run: go build -o /tmp/enola ./cmd/enola
+
+      - name: Pin a baseline from the merge base
+        run: |
+          # Be explicit about fetching the base branch: actions/checkout leaves a PR on a
+          # merge ref, and origin/<base> is not guaranteed to be present.
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+          # Record the head as an explicit SHA: `git checkout -` is unreliable after a
+          # --detach, and returning to the wrong commit would grade the base against
+          # itself and always report clean.
+          head=$(git rev-parse HEAD)
+          base=$(git merge-base "$head" "origin/${{ github.base_ref }}")
+          echo "Baseline: $base"
+          echo "PR head:  $head"
+
+          git checkout --quiet --detach "$base"
+          /tmp/enola baseline pin
+          # .enola/ is gitignored, so the pinned baseline survives the checkout back.
+          git checkout --quiet --detach "$head"
+
+      - name: Grade the change
+        run: |
+          # Run without --warn-only so the verdict text stays honest about what the
+          # policy WOULD do; the job's advisory status comes from the exit 0 below.
+          set +e
+          /tmp/enola check 2>/dev/null | tee verdict.txt
+          code=${PIPESTATUS[0]}
+          set -e
+
+          {
+            echo '### Architecture'
+            case "$code" in
+              0) echo 'No structural regression.' ;;
+              1) echo '**Structural regression introduced** — advisory for now, see the verdict below.' ;;
+              2) echo 'The gate could not run (exit 2).' ;;
+              3) echo 'Declined to grade: the baseline was not comparable (exit 3). Not a statement about this change.' ;;
+              *) echo "Unexpected exit $code." ;;
+            esac
+            echo '```'
+            cat verdict.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Advisory: report, never block. Delete this line to make the gate enforcing —
+          # the exit code above is already the verdict.
+          exit 0
+
+      - name: Upload the verdict
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: architecture-verdict
+          path: verdict.txt
+          if-no-files-found: ignore
+
   # golangci-lint v2 (action @v8). The repo baseline is clean, so this gates the
   # whole tree — any new finding fails the build. Linter set in .golangci.yml.
   lint:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -595,7 +595,7 @@ The engine lives in [`internal/diff`](internal/diff/diff.go) (pure `Compute` + d
 
 | Kind | Raised when | Treated as |
 |------|-------------|-----------|
-| `different_repo` | the two snapshots are of different repositories | blocking |
+| `different_repo` | the two snapshots are of different repositories (see [Repository identity](#repository-identity-portable-baselines) — *not* merely a different path) | blocking |
 | `version_mismatch` | different enola versions (extractor changes read as churn) | blocking |
 | `extractor_set` | a language present on one side only | blocking |
 | `ignore_globs` | the set of files parsed changed | blocking |
@@ -607,6 +607,19 @@ The engine lives in [`internal/diff`](internal/diff/diff.go) (pure `Compute` + d
 `Kinds` is a **set**, not a per-message list, so `Warnings` keeps its type and JSON shape for every existing consumer (the dashboard, `output_mode='full'`, and out-of-module readers via `pkg/diff`). Callers that know their category should use `AddWarningKind` rather than `AddWarning`.
 
 > Note on timestamps: `GeneratedAt` is RFC3339, i.e. **second** resolution, so a baseline pinned and then diffed inside the same second yields a zero gap. Zero is *simultaneous*, not inverted — `inverted_pair` requires a strictly negative gap. Treating zero as inverted made a no-op check on an untouched repository report "the current snapshot does not contain your change".
+
+#### Repository identity (portable baselines)
+
+A baseline is only useful in CI if it can be **pinned on one machine and graded on another**. That makes "are these the same repository?" a question about *identity*, not *location* — and comparing absolute `RepoPath` answered it with location. A baseline pinned at `/home/runner/work/app/app` and restored against `/Users/dev/src/app` always tripped `different_repo`, which the gate treats as blocking, so a downloaded baseline artifact could never grade. (The delta underneath was correct the whole time; only the verdict was wrong.)
+
+`facts.SameRepo` ([`internal/facts/repoidentity.go`](internal/facts/repoidentity.go)) decides it from two signals, strongest first:
+
+1. **Normalized git remotes**, when both snapshots have one. `facts.NormalizeRemote` reduces a remote URL to `host/path` — scheme, credentials, port and a trailing `.git` removed, lowercased — so every way of cloning one repository collapses to one identity: `git@github.com:org/app.git`, `https://github.com/org/app`, and a CI URL carrying an injected token all normalize to `github.com/org/app`. Without that, a runner cloning over HTTPS and a developer over SSH would read as two repositories.
+2. **The checkout directory name**, otherwise. Weaker — two unrelated repositories both checked out as `api/` look alike — but it is what exists for a repo with no remote, and it is strictly better than the absolute path it replaces. It compares the last segment across *either* separator, because a baseline written on a Linux runner and read on Windows carries the separator of the machine that **wrote** it.
+
+`GitInfo.Remote` is populated by one more read-only `git remote get-url origin` alongside the three calls already in `gitInfo()`, and degrades to empty exactly as they do (no git, no repo, no origin). It is normalized again on read, so a baseline written by an older build — carrying a raw URL, or no remote at all — still compares correctly. **A remote rather than the root commit**: `git rev-list --max-parents=0` looks like the purer identity, but it is unreachable in a shallow clone, which is what `actions/checkout` does by default.
+
+Both absolute paths stay in the warning text, and it names which signal decided, because the remedies differ: differing remotes mean the wrong baseline was fetched; differing directory names on one repository mean a checkout was renamed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -697,7 +697,9 @@ New coupling (4):
 
 Lists cap at 12 entries with a `--detail` pointer, and `declares` edges - the mechanical one-per-new-symbol link to their module - always sort last, since they say nothing about what got coupled.
 
-Ready-made wiring: [`examples/hooks/pre-commit`](examples/hooks/pre-commit) (blocks only on exit `1`; a missing or incomparable baseline skips the gate rather than blocking someone over setup they haven't done) and [`examples/ci/architecture-gate.yml`](examples/ci/architecture-gate.yml) (a GitHub Action that pins a baseline from the PR's merge base).
+**Baselines are portable.** A baseline is identified by the repository's normalized git remote (falling back to the checkout directory name), not by the absolute path it was pinned at - so one pinned on a CI runner grades against a checkout anywhere else. That's what makes the CI shape cheap: the default branch publishes `.enola/baseline/` once, every PR restores it and diffs against it, and no job ever indexes the base a second time.
+
+Ready-made wiring: [`examples/hooks/pre-commit`](examples/hooks/pre-commit) (blocks only on exit `1`; a missing or incomparable baseline skips the gate rather than blocking someone over setup they haven't done) and [`examples/ci/architecture-gate.yml`](examples/ci/architecture-gate.yml) (publish-on-main, restore-on-PR).
 
 ### What it saved you - `--status`
 

--- a/cmd/enola/check.go
+++ b/cmd/enola/check.go
@@ -324,6 +324,12 @@ func describeBaseline(snap *facts.Snapshot) {
 			state = "dirty (uncommitted changes)"
 		}
 		fmt.Printf("  Git:       %s @ %s — %s\n", orUnknown(r.Git.Ref), shortCommit(r.Git.Commit), state)
+		// The repository identity a restored baseline is matched on. Shown because
+		// "which repo does this baseline describe?" is the question `show` exists to
+		// answer, and after an import the answer is no longer obvious from the path.
+		if r.Git.Remote != "" {
+			fmt.Printf("  Remote:    %s\n", r.Git.Remote)
+		}
 	}
 	fmt.Printf("  Facts:     %d · Insights: %d\n", len(snap.Facts), len(snap.Insights))
 	fmt.Printf("  Snapshot:  %s\n", orUnknown(m.Receipt().SnapshotID))

--- a/examples/ci/architecture-gate.yml
+++ b/examples/ci/architecture-gate.yml
@@ -6,68 +6,98 @@
 #
 # HOW THE BASELINE GETS HERE
 # --------------------------
-# The gate needs something to compare against. This workflow pins a baseline from the PR's
-# own merge-base checkout, which requires no artifact plumbing and works on a fresh clone.
+# The gate needs a "before" to compare against. The default branch publishes its snapshot
+# once; every PR restores that artifact and diffs against it. The PR job therefore indexes
+# the tree ONCE — it never re-indexes the base — and needs no merge-base checkout and no
+# full-history clone.
 #
-# `fetch-depth: 0` is required. actions/checkout defaults to a depth-1 clone, which has no
-# merge-base to check out, and the gate would silently have nothing to compare against.
+# This works because a baseline is portable: `enola check` identifies a repository by its
+# normalized git remote (falling back to the checkout directory name), not by the absolute
+# path it was snapshotted at, so a baseline pinned on one runner grades against a checkout
+# anywhere else.
 #
-# A faster arrangement — publish the snapshot from the default branch once and restore it
-# here instead of re-indexing the base — needs baselines to survive moving between
-# machines, which they do not yet: comparability compares the absolute repo path, so a
-# baseline pinned under one checkout path declines to grade under another.
+# Sizing: roughly 550 KB of gzipped artifact per ~17k facts. For a very large monorepo,
+# prefer actions/cache over a per-run artifact.
 name: architecture
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 jobs:
-  gate:
+  # Publishes the baseline every time the default branch moves. PRs consume the most
+  # recent successful run of this job.
+  publish-baseline:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install enola
         run: |
           curl -fsSL https://raw.githubusercontent.com/enola-labs/enola/main/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Pin a baseline from the merge base
+      - name: Pin the baseline
+        run: enola baseline pin
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: enola-baseline
+          path: .enola/baseline/
+          retention-days: 30
+
+  gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install enola
         run: |
-          # Record the PR head as an explicit SHA before moving: `git checkout -` is
-          # unreliable after a --detach, and returning to the wrong commit would make the
-          # gate grade the base branch against itself and always report clean.
-          head=$(git rev-parse HEAD)
-          base=$(git merge-base "$head" "origin/${{ github.base_ref }}")
-          echo "Baseline commit: $base"
-          echo "PR head:         $head"
+          curl -fsSL https://raw.githubusercontent.com/enola-labs/enola/main/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-          git checkout --quiet --detach "$base"
-          enola --generate
-          enola baseline pin
-
-          # .enola/ is untracked, so the pinned baseline survives the checkout back.
-          git checkout --quiet --detach "$head"
+      # The baseline comes from the newest successful publish-baseline run on the default
+      # branch. `continue-on-error` covers the first-ever run, before any baseline has been
+      # published — see the next step.
+      - name: Fetch the published baseline
+        id: baseline
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: architecture.yml
+          branch: main
+          name: enola-baseline
+          path: baseline
+          if_no_artifact_found: fail
 
       - name: Grade the change
-        run: enola check
+        run: |
+          if [ "${{ steps.baseline.outcome }}" != "success" ]; then
+            echo "No published baseline yet — skipping the gate."
+            echo "It will start enforcing once publish-baseline has run on the default branch."
+            exit 0
+          fi
+          enola check --baseline baseline
 
       # `enola check` exit codes:
       #   0 clean · 1 regression (job fails) · 2 error · 3 declined (not comparable)
       #
-      # Codes 2 and 3 fail the job here by design: in CI they mean the gate did not
-      # actually run, and a gate that silently passes when it could not run is worse than
-      # no gate. Add `|| [ $? -eq 3 ]` if you would rather treat "declined" as a pass
-      # while rolling this out.
+      # Codes 2 and 3 fail the job by design: in CI they mean the gate did not actually
+      # run, and a gate that silently passes when it could not run is worse than no gate.
+      # Add `|| [ $? -eq 3 ]` if you would rather treat "declined" as a pass while rolling
+      # this out — a stale baseline does NOT produce 3, it warns and still grades, so 3
+      # really does mean the comparison was unsound.
 
       - name: Publish the verdict as JSON
-        if: always()
-        run: enola check --json > architecture-verdict.json || true
+        if: always() && steps.baseline.outcome == 'success'
+        run: enola check --baseline baseline --json > architecture-verdict.json || true
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: architecture-verdict
           path: architecture-verdict.json
+          if-no-files-found: ignore

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -296,6 +296,31 @@ func Compute(baseline, current *facts.Snapshot) *SnapshotDiff {
 	return d
 }
 
+// repoMismatchDetail says which signal decided that two snapshots are of different
+// repositories, and always carries both absolute paths.
+//
+// Naming the signal matters because the remedy differs: differing remotes mean the wrong
+// baseline was fetched, while differing directory names on the same repository mean a
+// checkout was renamed — recoverable by giving the checkout the expected name, or by
+// pushing a remote so the stronger signal applies. A bare "different repositories" left
+// the reader to guess which.
+func repoMismatchDetail(base, cur facts.SnapshotMeta) string {
+	baseRemote, curRemote := remoteOf(base), remoteOf(cur)
+	if baseRemote != "" && curRemote != "" {
+		return fmt.Sprintf("remote %s vs %s; paths %s vs %s",
+			baseRemote, curRemote, orDash(base.RepoPath), orDash(cur.RepoPath))
+	}
+	return fmt.Sprintf("%s vs %s — no git remote recorded on both sides, so the checkout "+
+		"directory name was compared", orDash(base.RepoPath), orDash(cur.RepoPath))
+}
+
+func remoteOf(m facts.SnapshotMeta) string {
+	if m.Git == nil {
+		return ""
+	}
+	return facts.NormalizeRemote(m.Git.Remote)
+}
+
 // compareMeta checks that two snapshots were generated over equivalent inputs and
 // returns comparability warnings for each mismatch that would distort the delta.
 // An auto-loaded baseline carries an empty Meta (only RepoPath) — its unknown
@@ -304,10 +329,14 @@ func Compute(baseline, current *facts.Snapshot) *SnapshotDiff {
 func compareMeta(base, cur facts.SnapshotMeta) Comparability {
 	var c Comparability
 
-	if base.RepoPath != "" && cur.RepoPath != "" && base.RepoPath != cur.RepoPath {
+	// Identity, not location. Comparing absolute paths made a baseline taken on a CI
+	// runner incomparable with the same repository on a workstation, which blocked the
+	// whole point of a portable baseline artifact. facts.SameRepo prefers the normalized
+	// git remote and falls back to the checkout directory name.
+	if !facts.SameRepo(base, cur) {
 		c.add(WarnDifferentRepo,
-			"baseline and current are different repositories (%s vs %s) — the delta is unlikely to be meaningful",
-			base.RepoPath, cur.RepoPath)
+			"baseline and current are different repositories (%s) — the delta is unlikely to be meaningful",
+			repoMismatchDetail(base, cur))
 	}
 
 	if base.EnolaVersion == "" || cur.EnolaVersion == "" {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -593,6 +593,49 @@ func TestCompareMeta_BaselineNewerThanCurrentWarns(t *testing.T) {
 	}
 }
 
+// TestCompareMeta_RelocatedBaselineIsComparable is the portable-baseline guarantee at the
+// comparability boundary: a baseline pinned on a CI runner and restored on a workstation
+// must GRADE, not decline.
+//
+// Comparing absolute RepoPath meant a downloaded baseline artifact always tripped
+// "different repositories" — which pkg/check treats as blocking — so the CI story could
+// not work at all, however correct the delta underneath it was.
+func TestCompareMeta_RelocatedBaselineIsComparable(t *testing.T) {
+	at := func(path, remote string) facts.SnapshotMeta {
+		return facts.SnapshotMeta{
+			RepoPath: path, EnolaVersion: "dev", GeneratedAt: "2026-07-30T06:17:24Z",
+			Extractors: []string{"go"},
+			Git:        &facts.GitInfo{Remote: remote},
+		}
+	}
+
+	ci := at("/home/runner/work/app/app", "https://github.com/org/app.git")
+	local := at("/Users/dev/src/app", "git@github.com:org/app.git")
+
+	got := compareMeta(ci, local)
+	if got.HasKind(WarnDifferentRepo) {
+		t.Errorf("a relocated baseline of the same repo was reported as a different repository: %v", got.Warnings)
+	}
+	if !got.Comparable {
+		t.Errorf("expected comparable, got warnings: %v", got.Warnings)
+	}
+
+	// The guard must still fire for a genuinely different repository, or it would be
+	// worth nothing: the gate would happily diff two unrelated graphs.
+	other := at("/home/runner/work/app/app", "https://github.com/org/unrelated.git")
+	mismatch := compareMeta(other, local)
+	if !mismatch.HasKind(WarnDifferentRepo) {
+		t.Errorf("genuinely different repositories were not flagged: %v", mismatch.Warnings)
+	}
+	// And the message must name the signal AND both paths, so the remedy is obvious.
+	joined := strings.Join(mismatch.Warnings, " ")
+	for _, want := range []string{"remote", "github.com/org/unrelated", "github.com/org/app", "/Users/dev/src/app"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("mismatch warning omitted %q: %v", want, mismatch.Warnings)
+		}
+	}
+}
+
 // TestCompareMeta_SameSecondIsNotInverted — GeneratedAt is RFC3339, i.e. second
 // resolution, so a baseline pinned and then diffed within the same second produces a
 // ZERO gap. Zero is simultaneous, not inverted.

--- a/internal/engine/receipt.go
+++ b/internal/engine/receipt.go
@@ -96,6 +96,14 @@ func gitInfo(repoPath, outputDir string) *facts.GitInfo {
 	if ref, err := runGit(repoPath, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
 		info.Ref = ref
 	}
+	// The repository's identity, as opposed to this revision's. Recorded so a baseline
+	// pinned under one checkout path can be recognized as the same repository under
+	// another — the property that lets a CI baseline artifact be restored and diffed.
+	// Absent origin, no remotes at all, or a detached/bare setup all just leave it empty,
+	// matching how the rest of this function degrades.
+	if remote, err := runGit(repoPath, "remote", "get-url", "origin"); err == nil {
+		info.Remote = facts.NormalizeRemote(remote)
+	}
 	// --porcelain prints one line per changed/untracked path; any output => dirty.
 	// The ':(exclude)' pathspec drops our own output dir; '.' is the positive
 	// pathspec it subtracts from. An outputDir configured outside the repo simply

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -259,6 +259,17 @@ type GitInfo struct {
 	Ref    string `json:"ref,omitempty"`    // branch or symbolic ref (e.g. "main")
 	Commit string `json:"commit,omitempty"` // full commit SHA of HEAD
 	Dirty  bool   `json:"dirty"`            // true when the working tree has uncommitted changes
+
+	// Remote is the origin URL, normalized to a comparable identity
+	// ("github.com/org/repo" — no scheme, credentials, port or ".git" suffix). Empty
+	// when there is no remote, no git, or no origin.
+	//
+	// It exists so two snapshots of the SAME repository taken at different absolute
+	// paths — a CI runner's checkout and a developer's working copy — can be recognized
+	// as comparable. Commit identifies a revision; this identifies the repository.
+	// A remote is used rather than the root commit because the root commit is
+	// unreachable in a shallow clone, which is what CI checkouts default to.
+	Remote string `json:"remote,omitempty"`
 }
 
 // ParseError records a non-fatal extraction failure — an extractor that could

--- a/internal/facts/repoidentity.go
+++ b/internal/facts/repoidentity.go
@@ -1,0 +1,110 @@
+package facts
+
+import "strings"
+
+// NormalizeRemote reduces a git remote URL to a comparable repository identity:
+// host plus path, lowercased, with the scheme, any credentials, any port and a trailing
+// ".git" removed. "" for input it cannot make sense of.
+//
+//	git@github.com:org/repo.git            -> github.com/org/repo
+//	https://github.com/org/repo.git        -> github.com/org/repo
+//	https://x-token:abc@github.com/org/repo -> github.com/org/repo
+//	ssh://git@github.com:22/org/repo       -> github.com/org/repo
+//
+// The point is that the SAME repository must normalize identically however it was
+// cloned — a CI runner using an HTTPS URL with a token and a developer using SSH are
+// looking at one repository, and a comparison that says otherwise would decline to grade
+// every CI diff.
+//
+// Lowercasing the path as well as the host is deliberate. Hosts are case-insensitive by
+// spec; repository paths are case-insensitive on the major forges, so "Org/Repo" and
+// "org/repo" are one repository, and treating them as two would produce exactly the
+// false mismatch this function exists to prevent. The cost is that a forge which does
+// distinguish them would see two repositories as one — a far rarer situation, and one
+// that fails toward comparing rather than toward refusing.
+func NormalizeRemote(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+
+	// scheme://[user[:pass]@]host[:port]/path
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+		if at := strings.LastIndex(s, "@"); at >= 0 {
+			s = s[at+1:]
+		}
+		// Strip a port, but only from the host segment — a path may legitimately
+		// contain a colon.
+		if slash := strings.Index(s, "/"); slash >= 0 {
+			host, path := s[:slash], s[slash:]
+			if c := strings.LastIndex(host, ":"); c >= 0 {
+				host = host[:c]
+			}
+			s = host + path
+		}
+	} else if at := strings.LastIndex(s, "@"); at >= 0 {
+		// scp-like: [user@]host:path — the colon separates host from path, and unlike
+		// the URL form it is NOT a port, so it becomes the path separator.
+		s = s[at+1:]
+		if c := strings.Index(s, ":"); c >= 0 {
+			s = s[:c] + "/" + s[c+1:]
+		}
+	}
+
+	s = strings.TrimSuffix(strings.TrimRight(s, "/"), ".git")
+	s = strings.TrimRight(s, "/")
+	return strings.ToLower(s)
+}
+
+// SameRepo reports whether two snapshots describe the same repository, without relying
+// on the absolute path they were taken at.
+//
+// A baseline pinned on a CI runner at /home/runner/work/app/app and a working copy at
+// /Users/dev/src/app are the same repository, and comparing absolute paths said they were
+// not — which made every restored baseline artifact decline to grade.
+//
+// Two signals, strongest first:
+//
+//  1. Normalized remotes, when BOTH sides have one. This is a real identity: it survives
+//     relocation, re-cloning and a shallow checkout.
+//  2. Otherwise the checkout directory name. Weaker — two unrelated repositories both
+//     checked out as "api" look alike — but it is what is available for a repo with no
+//     remote, and it is the case the absolute-path comparison already got wrong.
+//
+// A missing RepoPath on either side yields true: nothing can be concluded, and inventing
+// a mismatch out of absent data would block a diff for no reason.
+func SameRepo(a, b SnapshotMeta) bool {
+	if ra, rb := remoteIdentity(a), remoteIdentity(b); ra != "" && rb != "" {
+		return ra == rb
+	}
+	if a.RepoPath == "" || b.RepoPath == "" {
+		return true
+	}
+	return repoDirName(a.RepoPath) == repoDirName(b.RepoPath)
+}
+
+// remoteIdentity returns the normalized remote recorded on a snapshot, if any.
+func remoteIdentity(m SnapshotMeta) string {
+	if m.Git == nil {
+		return ""
+	}
+	// Normalized at capture, but normalize again: a snapshot written by an older build
+	// carries the raw URL, and a baseline outliving the build that wrote it is the whole
+	// point of a portable artifact.
+	return NormalizeRemote(m.Git.Remote)
+}
+
+// repoDirName is the last path segment of a repository path, accepting either separator.
+// filepath.Base alone is not enough here: a baseline pinned on a Linux CI runner and read
+// on a Windows workstation (or the reverse) carries the separator of the machine that
+// WROTE it, and filepath.Base uses the separator of the machine reading it — so one of
+// the two directions would compare a whole path against a single segment and always
+// report a mismatch.
+func repoDirName(path string) string {
+	p := strings.TrimRight(path, `/\`)
+	if i := strings.LastIndexAny(p, `/\`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/internal/facts/repoidentity_test.go
+++ b/internal/facts/repoidentity_test.go
@@ -1,0 +1,193 @@
+package facts
+
+import "testing"
+
+// TestNormalizeRemote is the table the whole portable-baseline story rests on: the SAME
+// repository must normalize identically however it was cloned. A CI runner using an HTTPS
+// URL with an injected token and a developer using SSH are looking at one repository, and
+// a normalizer that disagreed would decline to grade every CI diff.
+func TestNormalizeRemote(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"scp-like ssh", "git@github.com:org/repo.git", "github.com/org/repo"},
+		{"scp-like without .git", "git@github.com:org/repo", "github.com/org/repo"},
+		{"https", "https://github.com/org/repo.git", "github.com/org/repo"},
+		{"https without .git", "https://github.com/org/repo", "github.com/org/repo"},
+		{"http", "http://github.com/org/repo.git", "github.com/org/repo"},
+		{"ssh url", "ssh://git@github.com/org/repo.git", "github.com/org/repo"},
+		{"ssh url with port", "ssh://git@github.com:22/org/repo.git", "github.com/org/repo"},
+		{"https with token", "https://x-access-token:ghs_abc123@github.com/org/repo.git", "github.com/org/repo"},
+		{"https with user:pass", "https://user:pa55@gitlab.com/grp/sub/repo.git", "gitlab.com/grp/sub/repo"},
+		{"uppercase host and path", "https://GitHub.com/Org/Repo.git", "github.com/org/repo"},
+		{"trailing slash", "https://github.com/org/repo/", "github.com/org/repo"},
+		{"nested group path", "git@gitlab.com:grp/sub/repo.git", "gitlab.com/grp/sub/repo"},
+		{"surrounding whitespace", "  git@github.com:org/repo.git\n", "github.com/org/repo"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"local path remote", "/srv/git/repo.git", "/srv/git/repo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeRemote(tc.in); got != tc.want {
+				t.Errorf("NormalizeRemote(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeRemote_CloneFormsAgree is the property that actually matters, stated
+// directly: every way of cloning one repository collapses to one identity.
+func TestNormalizeRemote_CloneFormsAgree(t *testing.T) {
+	forms := []string{
+		"git@github.com:org/repo.git",
+		"https://github.com/org/repo.git",
+		"https://github.com/org/repo",
+		"ssh://git@github.com:22/org/repo.git",
+		"https://x-access-token:ghs_abc@github.com/org/repo.git",
+		"https://GitHub.com/Org/Repo/",
+	}
+	want := NormalizeRemote(forms[0])
+	for _, f := range forms[1:] {
+		if got := NormalizeRemote(f); got != want {
+			t.Errorf("clone form %q normalized to %q, want %q — the same repo must have one identity", f, got, want)
+		}
+	}
+}
+
+// TestNormalizeRemote_DistinctReposStayDistinct — collapsing everything to one identity
+// would be worse than the bug being fixed: unrelated repositories would compare as the
+// same and the gate would diff two unrelated graphs.
+func TestNormalizeRemote_DistinctReposStayDistinct(t *testing.T) {
+	distinct := []string{
+		"git@github.com:org/repo.git",
+		"git@github.com:org/other.git",
+		"git@github.com:otherorg/repo.git",
+		"git@gitlab.com:org/repo.git",
+	}
+	seen := map[string]string{}
+	for _, r := range distinct {
+		id := NormalizeRemote(r)
+		if prev, dup := seen[id]; dup {
+			t.Errorf("%q and %q both normalized to %q", prev, r, id)
+		}
+		seen[id] = r
+	}
+}
+
+func metaAt(path, remote string) SnapshotMeta {
+	m := SnapshotMeta{RepoPath: path}
+	if remote != "" {
+		m.Git = &GitInfo{Remote: remote}
+	}
+	return m
+}
+
+// TestSameRepo covers the decision itself. The first case is the bug this phase exists to
+// fix: a baseline pinned on a CI runner and a working copy on a laptop are one repository.
+func TestSameRepo(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b SnapshotMeta
+		want bool
+	}{
+		{
+			"same repo, different absolute paths, matching remotes",
+			metaAt("/home/runner/work/app/app", "git@github.com:org/app.git"),
+			metaAt("/Users/dev/src/app", "https://github.com/org/app.git"),
+			true,
+		},
+		{
+			"different remotes are different repos even at the same path",
+			metaAt("/w/app", "git@github.com:org/app.git"),
+			metaAt("/w/app", "git@github.com:org/other.git"),
+			false,
+		},
+		{
+			"no remotes: same directory name is treated as the same repo",
+			metaAt("/home/runner/work/app/app", ""),
+			metaAt("/Users/dev/src/app", ""),
+			true,
+		},
+		{
+			"no remotes: different directory names are different repos",
+			metaAt("/w/app", ""),
+			metaAt("/w/other", ""),
+			false,
+		},
+		{
+			"remote on one side only falls back to the directory name",
+			metaAt("/home/runner/work/app/app", "git@github.com:org/app.git"),
+			metaAt("/Users/dev/src/app", ""),
+			true,
+		},
+		{
+			"remote on one side only, names differ, so it is a mismatch",
+			metaAt("/w/app", "git@github.com:org/app.git"),
+			metaAt("/w/other", ""),
+			false,
+		},
+		{
+			"matching remotes outrank differing directory names",
+			metaAt("/w/app", "git@github.com:org/app.git"),
+			metaAt("/tmp/app-baseline-checkout", "git@github.com:org/app.git"),
+			true,
+		},
+		{
+			"an empty RepoPath concludes nothing rather than inventing a mismatch",
+			metaAt("", ""),
+			metaAt("/w/app", ""),
+			true,
+		},
+		{"both empty", metaAt("", ""), metaAt("", ""), true},
+		{
+			"trailing separator does not create a mismatch",
+			metaAt("/w/app/", ""),
+			metaAt("/w/app", ""),
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SameRepo(tc.a, tc.b); got != tc.want {
+				t.Errorf("SameRepo = %v, want %v", got, tc.want)
+			}
+			// The relation must be symmetric: which snapshot is the baseline is an
+			// accident of the caller, and a one-way verdict would make the gate's
+			// behaviour depend on argument order.
+			if got := SameRepo(tc.b, tc.a); got != tc.want {
+				t.Errorf("SameRepo is not symmetric: reversed = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSameRepo_CrossPlatformSeparators — a baseline pinned on a Linux CI runner and read
+// on a Windows workstation carries the separator of the machine that WROTE it, while
+// filepath.Base would use the separator of the machine READING it. One direction would
+// then compare a whole path against a single segment and always report a mismatch.
+func TestSameRepo_CrossPlatformSeparators(t *testing.T) {
+	linux := metaAt("/home/runner/work/app/app", "")
+	windows := metaAt(`C:\Users\dev\src\app`, "")
+
+	if !SameRepo(linux, windows) {
+		t.Error("a Linux-written baseline and a Windows working copy of the same repo must compare as the same")
+	}
+	if SameRepo(linux, metaAt(`C:\Users\dev\src\other`, "")) {
+		t.Error("different repo names across platforms must still be a mismatch")
+	}
+}
+
+// TestSameRepo_NormalizesLegacyRawRemotes — a snapshot written before remotes were
+// normalized at capture carries the raw URL. A baseline outliving the build that wrote it
+// is the entire point of a portable artifact, so identity must not depend on the writer.
+func TestSameRepo_NormalizesLegacyRawRemotes(t *testing.T) {
+	legacy := metaAt("/old/app", "git@github.com:Org/App.git") // raw, as an older build stored it
+	current := metaAt("/new/app", "github.com/org/app")        // normalized at capture
+
+	if !SameRepo(legacy, current) {
+		t.Error("a raw remote from an older snapshot must normalize to the same identity as a current one")
+	}
+}


### PR DESCRIPTION
A baseline is only useful in CI if it can be pinned on one machine and graded on another. Comparability answered "are these the same repository?" by comparing absolute RepoPath, which answers a question about location instead. A baseline pinned at /home/runner/work/app/app and restored against /Users/dev/src/app always raised different_repo, which the gate treats as blocking — so a restored baseline artifact could never grade. The delta underneath was correct the whole time; only the verdict was wrong.

Record the origin remote on GitInfo, normalized to host/path with scheme, credentials, port and a trailing .git removed, and decide sameness from it when both sides have one, falling back to the checkout directory name. Normalization is what makes this work in practice: a runner cloning over HTTPS with an injected token and a developer cloning over SSH are looking at one repository, and an unnormalized comparison would decline to grade every CI diff.

A remote rather than the root commit. `git rev-list --max-parents=0` is the purer identity and works locally, but it is unreachable in a shallow clone, which is what CI checkouts default to — it would fail in exactly the environment this targets. Git stays a witness: one more read-only call beside the three already there, degrading to empty the same way.

Two details that only show up across machines:

- Remotes are normalized again on read, not just at capture, so a baseline written by an older build — carrying a raw URL, or no remote at all — still compares correctly. A baseline outliving the build that wrote it is the point of a portable artifact.
- The directory-name fallback accepts either separator. A baseline written on a Linux runner and read on Windows carries the separator of the machine that wrote it, while filepath.Base uses the reader's, so one direction would compare a whole path against a single segment and always mismatch.

The mismatch message names which signal decided and keeps both paths: a remote mismatch means the wrong baseline was fetched, a name mismatch on one repository means a checkout was renamed, and the remedies differ.

Also:
- CI gains an advisory `architecture` job: enola grading enola on every PR, reporting the verdict to the step summary and never failing the build
- the example workflow becomes publish-on-main / restore-on-PR, so the base branch is never re-indexed and no merge-base checkout is needed
- baseline show reports the remote — after a restore, "which repo is this?" is no longer obvious from the path