### PR TITLE
fix(config): name the resolved config, and stop plugin lists shadowin…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -825,7 +825,13 @@ output:
   max_context_tokens: 16000
 ```
 
-The bundled [`mcp-arch.yaml`](mcp-arch.yaml) ships a much fuller `ignore` list (Android/Gradle, Xcode/SPM, Rails, CI, Docker, env files, …); see it and the per-language configs under [`examples/`](examples/) for ready-made starting points.
+The bundled [`mcp-arch.yaml`](mcp-arch.yaml) ships a much fuller `ignore` list (Android/Gradle, Xcode/SPM, Rails, CI, Docker, env files, …); see it and the per-language configs under [`examples/`](examples/) for ready-made starting points. It deliberately declares **no** `extractors:`, `explainers:` or `renderers:` — see the override rule below.
+
+**Resolution, and why it is announced.** `bootstrap.ResolveConfig` looks for the named path (default `mcp-arch.yaml`) relative to the working directory, then — only when the running binary is *not* on `PATH`, i.e. an unpacked bundle rather than an installed one — beside the executable. Whatever it settles on is printed to stderr by every command (`enola: using config <path>`, or `no mcp-arch.yaml in <cwd>, using built-in defaults`), and the executable-adjacent case says so explicitly.
+
+That line exists because the failure it prevents is silent. A config decides which extractors run and which paths are ignored, so loading the wrong one does not error — it analyses something other than what was asked for. Before the restriction and the announcement, a config sitting beside a `go build` output governed every repository that binary was ever pointed at, from any directory without one of its own; an eleven-extractor list written before the Rust extractor landed turned a 780-file Rust repository into `0 facts`, with no error and no mention of Rust anywhere in the log.
+
+**A list-valued key REPLACES its default; it does not merge.** `yaml.Unmarshal` overwrites the slice, so `extractors:` names the complete set — a config written before an extractor existed disables it permanently, and a disabled extractor is never tried and so never appears in the log. Two things make that visible: a bundled config that names no plugin lists at all, and a warning naming any *excluded* extractor that would have detected the repository (also recorded as `shadowed_extractors` in the snapshot receipt). The semantics are unchanged on purpose — an explicit list is the only way to disable an extractor.
 
 | Field | Description | Default |
 |-------|-------------|---------|

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ enola check --warn-only          # report everything, fail nothing
 
 Not a language model, and not embeddings. enola parses your source with tree-sitter and language-specific extractors, normalizes it into a typed fact model, links it into a directed graph, and runs real graph algorithms over it — Tarjan's SCC for cycles, cycle-safe longest-path for dependency depth, mean+2σ outlier tests for the statistical findings.
 
-That means the same commit yields the same answer, every time. Every snapshot carries a **receipt**: enola's version, the git ref and whether the tree was dirty, the extractors used, and a snapshot ID that's a `sha256` fingerprint of the facts rather than a random UUID. Before trusting a comparison, enola checks the two snapshots were even built the same way — a different extractor set or changed ignore rules makes a diff meaningless, and it says so instead of reporting churn as if it were your change.
+That means the same commit yields the same answer, every time — measured, not asserted: across 30 open-source repositories indexed three times each, all 30 produced a byte-identical snapshot ID and a byte-identical fact file, over 3.9 million facts with zero parse errors ([BENCHMARKS.md](docs/BENCHMARKS.md)). Every snapshot carries a **receipt**: enola's version, the git ref and whether the tree was dirty, the extractors used, and a snapshot ID that's a `sha256` fingerprint of the facts rather than a random UUID. Before trusting a comparison, enola checks the two snapshots were even built the same way — a different extractor set or changed ignore rules makes a diff meaningless, and it says so instead of reporting churn as if it were your change.
 
 Nothing leaves your machine. It's a local binary reading local files.
 
@@ -173,6 +173,8 @@ Framework- and platform-specific detection for each language is described in **[
 ## Learn more
 
 - **[docs/CLI.md](docs/CLI.md)** - setup, every command and flag, the exit codes, and the `--explain` report.
+- **[docs/BENCHMARKS.md](docs/BENCHMARKS.md)** - reproducibility, delta precision, cross-repo coverage and scale, measured on 30 public repositories - including the three defects the run found in enola itself.
+- **[docs/extraction/](docs/extraction/)** - per language, what specific code produces which facts, from committed fixtures - and what each extractor deliberately does not resolve.
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - the concept, the fact model, the pipeline, the MCP tool reference, and the value model.
 - **[examples/](examples/)** - ready-made per-language and multi-repo configs, plus a pre-commit hook and a CI workflow.
 

--- a/cmd/enola/check.go
+++ b/cmd/enola/check.go
@@ -41,11 +41,9 @@ type target struct {
 func resolveTarget(arg string) target {
 	cfgPath := "mcp-arch.yaml"
 	repoOverride := ""
-	note := ""
 
 	switch {
 	case arg == "":
-		note = "config " + cfgPath + " (or built-in defaults)"
 	case isDirectory(arg):
 		abs, err := filepath.Abs(arg)
 		if err != nil {
@@ -54,18 +52,27 @@ func resolveTarget(arg string) target {
 		repoOverride = abs
 		if inner := filepath.Join(abs, "mcp-arch.yaml"); fileExists(inner) {
 			cfgPath = inner
-			note = "repo " + abs + " (config " + inner + ")"
-		} else {
-			note = "repo " + abs + " (built-in default config)"
 		}
 	default:
 		cfgPath = arg
-		note = "config " + arg
 	}
 
 	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: cfgPath})
 	if err != nil {
 		checkFatal("failed to create engine: %v", err)
+	}
+
+	// The note names the config that was LOADED, not the one that was looked for.
+	// The two differ whenever the lookup falls back — to built-in defaults, or to a
+	// config sitting beside the binary — and a note that reports the intent as
+	// though it were the outcome is worse than none: it is a confirmation of
+	// something nobody checked.
+	note := "built-in default config"
+	if cfg.SourcePath != "" {
+		note = "config " + cfg.SourcePath
+	}
+	if repoOverride != "" {
+		note = "repo " + repoOverride + " (" + note + ")"
 	}
 	if repoOverride != "" {
 		// Repos would otherwise win in RepoPaths and silently ignore the directory the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,7 +41,18 @@ Because your agent launches enola as a long-lived MCP server process, an upgrade
 
 ### Configuration (optional)
 
-**enola needs no config file.** Every setting has a built-in default, so out of the box it indexes the current repo with all extractors enabled and writes to `.enola/`. A config file (`mcp-arch.yaml`) only *overrides* those defaults - it never adds capability you'd otherwise lack. When enola can't find one it simply prints `warning: …, using defaults` and carries on.
+**enola needs no config file.** Every setting has a built-in default, so out of the box it indexes the current repo with all extractors enabled and writes to `.enola/`. A config file (`mcp-arch.yaml`) only *overrides* those defaults - it never adds capability you'd otherwise lack.
+
+Every command prints the config it resolved, on stderr, before it does anything:
+
+```
+enola: using config /Users/you/src/api/mcp-arch.yaml
+enola: no mcp-arch.yaml in /Users/you/src/api, using built-in defaults
+```
+
+It is worth reading. A config decides which extractors run and which paths are ignored, so the wrong one does not fail - it analyses something other than what you asked for. enola looks in the working directory, then (only for a binary that is *not* on your `PATH`, i.e. an unpacked bundle rather than an installed one) beside the executable; the second case says so explicitly.
+
+Note that a list-valued setting **replaces** its default rather than extending it. That is why the bundled `mcp-arch.yaml` declares no `extractors:`, `explainers:` or `renderers:` - a copied list silently falls behind as new ones ship. Set `extractors:` only to deliberately narrow a run; enola warns when an extractor you excluded would have detected the repository.
 
 The install script installs **only the binary**, by design - it does not place a config file. Grab the bundled one from the repo whenever you want to customize (tune the `ignore` globs, pick a subset of extractors, change the output dir, …):
 

--- a/examples/cpp.yaml
+++ b/examples/cpp.yaml
@@ -40,13 +40,13 @@ ignore:
   - "**/*.json"
 extractors:
   - cpp
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -4,7 +4,7 @@
 # ignore patterns for every language. Use this as a starting point
 # and remove sections that don't apply to your project.
 #
-# Supported extractors:
+# Supported extractors — all enabled by default, so this file lists none:
 #   - go         (detection: go.mod)
 #   - java       (detection: pom.xml, build.gradle, or .java sources)
 #   - kotlin     (detection: build.gradle.kts or build.gradle with Kotlin/Android)
@@ -14,6 +14,10 @@
 #   - rust       (detection: Cargo.toml)
 #   - cpp        (detection: .cpp/.hpp/... or CMakeLists.txt/Makefile + header)
 #   - php        (detection: composer.json, WordPress markers, or any .php source)
+#   - python     (detection: pyproject.toml, setup.py, requirements.txt, Pipfile,
+#                 or a tool config — pytest.ini/mypy.ini/tox.ini/setup.cfg)
+#   - grpc       (detection: first-party .proto sources)
+#   - openapi    (detection: a YAML/JSON file whose content is an OpenAPI spec)
 
 repo: "."
 ignore:
@@ -97,23 +101,18 @@ ignore:
   - "**/Dockerfile*"
   - "**/.env*"
 
-extractors:
-  - cpp
-  - go
-  - java
-  - kotlin
-  - typescript
-  - swift
-  - ruby
-  - rust
-  - php
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# extractors: / explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it. Both lists had
+# already fallen behind: `extractors:` claimed to enable every language while
+# omitting grpc, openapi and python, and `explainers:` pinned four of the ten,
+# turning off god-class, hotspots, unused-routes, dependency-depth,
+# exported-surface and complexity-outliers for anyone who adopted this file.
+#
+# The defaults ARE everything, so a config that means "all of it" says nothing at
+# all. Narrow the lists only on purpose, as the per-language examples in this
+# directory do.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/go.yaml
+++ b/examples/go.yaml
@@ -29,13 +29,13 @@ ignore:
   - "**/.env*"
 extractors:
   - go
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/kotlin.yaml
+++ b/examples/kotlin.yaml
@@ -38,13 +38,13 @@ ignore:
   - "**/.env*"
 extractors:
   - kotlin
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/multi-repo.yaml
+++ b/examples/multi-repo.yaml
@@ -100,13 +100,13 @@ extractors:
   - typescript
   - swift
   - ruby
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/php.yaml
+++ b/examples/php.yaml
@@ -46,13 +46,13 @@ ignore:
   - "**/*.md"
 extractors:
   - php
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/python.yaml
+++ b/examples/python.yaml
@@ -60,13 +60,13 @@ ignore:
   - "**/migrations/**"
 extractors:
   - python
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/ruby.yaml
+++ b/examples/ruby.yaml
@@ -44,13 +44,13 @@ ignore:
   - "**/.env*"
 extractors:
   - ruby
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/swift.yaml
+++ b/examples/swift.yaml
@@ -48,13 +48,13 @@ ignore:
   - "**/.env*"
 extractors:
   - swift
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/examples/typescript.yaml
+++ b/examples/typescript.yaml
@@ -39,13 +39,13 @@ ignore:
   - "**/.env*"
 extractors:
   - typescript
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-renderers:
-  - llm_context
+# explainers: / renderers: are deliberately absent.
+#
+# A list-valued key REPLACES the built-in list rather than extending it, so naming
+# a subset here silently disables everything that ships beyond it — this file used
+# to pin four explainers, turning off the other six (god-class, hotspots,
+# unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
+# who adopted it. Omitting the keys means new plugins arrive automatically.
 output:
   dir: ".enola"
   max_context_tokens: 16000

--- a/internal/config/bundled_config_test.go
+++ b/internal/config/bundled_config_test.go
@@ -45,6 +45,158 @@ func TestBundledConfigCoversDefaultIgnores(t *testing.T) {
 	}
 }
 
+// TestBundledConfigDoesNotPinPluginLists keeps the shipped mcp-arch.yaml from
+// naming extractors, explainers or renderers at all.
+//
+// Same override-not-merge rule as the ignore list above, but with the opposite
+// remedy, because these lists cannot be written as a superset: a file that mirrors
+// config.Default() can only ever fall behind it, and falling behind means an
+// extractor that exists is silently never run. It had already happened — the file
+// listed eleven extractors and omitted rust from the day the Rust extractor landed,
+// so a 780-file Rust repository reported 0 facts with no error and no mention of
+// Rust anywhere. Omitting the keys is what makes new plugins arrive automatically.
+//
+// Asserting the loaded lists match Default() would pass on a file that pins today's
+// exact list, which is the state this is here to prevent, so absence is asserted
+// directly.
+func TestBundledConfigDoesNotPinPluginLists(t *testing.T) {
+	path := filepath.Join("..", "..", "mcp-arch.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	for _, key := range []string{"extractors:", "explainers:", "renderers:"} {
+		for _, line := range strings.Split(string(raw), "\n") {
+			if strings.HasPrefix(line, key) {
+				t.Errorf("mcp-arch.yaml declares %s — it replaces the built-in list rather "+
+					"than extending it, so it can only fall behind config.Default() and "+
+					"silently disable plugins that ship later", key)
+			}
+		}
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(%s): %v", path, err)
+	}
+	if cfg.ExtractorsExplicit {
+		t.Error("bundled config is treated as an explicit extractor list")
+	}
+	if got, want := strings.Join(cfg.Extractors, ","), strings.Join(Default().Extractors, ","); got != want {
+		t.Errorf("bundled config yields extractors %q, want the defaults %q", got, want)
+	}
+	if got, want := strings.Join(cfg.Explainers, ","), strings.Join(Default().Explainers, ","); got != want {
+		t.Errorf("bundled config yields explainers %q, want the defaults %q", got, want)
+	}
+	if got, want := strings.Join(cfg.Renderers, ","), strings.Join(Default().Renderers, ","); got != want {
+		t.Errorf("bundled config yields renderers %q, want the defaults %q", got, want)
+	}
+}
+
+// TestExampleConfigsDoNotPinExplainersOrRenderers extends the rule above to
+// examples/, which is where it did the most damage.
+//
+// Every example pinned four explainers, so every user who adopted one lost the
+// other six — god-class, hotspots, unused-routes, dependency-depth,
+// exported-surface, complexity-outliers — without ever being told an explainer
+// existed. The four listed were a strict subset of the defaults, so the keys bought
+// nothing in exchange.
+//
+// `extractors:` is exempt: narrowing to one language is what the per-language
+// examples are FOR. full.yaml is not exempt — it claims to enable everything, and a
+// list claiming to be exhaustive is precisely the one that falls behind (it omitted
+// grpc, openapi and python).
+func TestExampleConfigsDoNotPinExplainersOrRenderers(t *testing.T) {
+	dir := filepath.Join("..", "..", "examples")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		checked++
+		t.Run(e.Name(), func(t *testing.T) {
+			path := filepath.Join(dir, e.Name())
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			banned := []string{"explainers:", "renderers:"}
+			if e.Name() == "full.yaml" {
+				banned = append(banned, "extractors:")
+			}
+			for _, key := range banned {
+				for _, line := range strings.Split(string(raw), "\n") {
+					if strings.HasPrefix(line, key) {
+						t.Errorf("%s declares %s — it replaces the built-in list rather than "+
+							"extending it, so every user who adopts this file loses whatever "+
+							"ships later", e.Name(), key)
+					}
+				}
+			}
+			// The example must still be loadable: a config nobody can parse is a
+			// worse starting point than none.
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if len(cfg.Explainers) != len(Default().Explainers) {
+				t.Errorf("loads %d explainers, want the %d defaults", len(cfg.Explainers), len(Default().Explainers))
+			}
+		})
+	}
+	if checked == 0 {
+		t.Fatalf("no example configs found under %s — the layout changed", dir)
+	}
+}
+
+// TestLoadRecordsExtractorsExplicit — the engine's shadowed-extractor warning fires
+// only for a hand-written list, so "the file said so" must survive Load. It cannot
+// be recovered afterwards: an absent key leaves Default()'s list in place, and a
+// list identical to the defaults is indistinguishable from inheriting them.
+func TestLoadRecordsExtractorsExplicit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"absent", "repo: \".\"\n", false},
+		{"listed", "repo: \".\"\nextractors:\n  - go\n", true},
+		// An empty list is a real choice ("extract nothing"), not an absent key.
+		{"empty list", "repo: \".\"\nextractors: []\n", true},
+		// Mirroring the defaults is the case that motivated the flag: it looks
+		// identical to inheriting them, and stops looking identical the day a new
+		// extractor ships.
+		{"mirrors defaults", "repo: \".\"\nextractors:\n" + defaultExtractorsYAML(), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "mcp-arch.yaml")
+			if err := os.WriteFile(p, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(p)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.ExtractorsExplicit != tc.want {
+				t.Errorf("ExtractorsExplicit = %v, want %v", cfg.ExtractorsExplicit, tc.want)
+			}
+		})
+	}
+}
+
+func defaultExtractorsYAML() string {
+	var sb strings.Builder
+	for _, e := range Default().Extractors {
+		sb.WriteString("  - " + e + "\n")
+	}
+	return sb.String()
+}
+
 // yamlListItem returns the unquoted value of a `  - "x"` list line. Comments and
 // any other line shape return false.
 func yamlListItem(line string) (string, bool) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,17 @@ type Config struct {
 	// Repos entries against the config's own directory.
 	SourcePath string `yaml:"-"`
 
+	// ExtractorsExplicit reports whether the file named `extractors:` itself, as
+	// opposed to inheriting Default()'s list. Not read from YAML — set by Load.
+	//
+	// It exists because the two cases are indistinguishable afterwards and mean
+	// opposite things. An explicit list REPLACES the defaults (YAML unmarshalling of
+	// a sequence overwrites the slice), so a config written before an extractor
+	// existed permanently disables it — silently, since a disabled extractor is
+	// simply never tried. Knowing the list was explicit lets the engine say so when
+	// a disabled extractor would have detected the repository.
+	ExtractorsExplicit bool `yaml:"-"`
+
 	Ignore     []string     `yaml:"ignore"`
 	TestGlobs  []string     `yaml:"test_globs"`
 	Extractors []string     `yaml:"extractors"`
@@ -226,6 +237,17 @@ func Load(path string) (*Config, error) {
 	cfg := Default()
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config %s: %w", path, err)
+	}
+
+	// Whether the key was PRESENT cannot be recovered from cfg afterwards: an
+	// absent `extractors:` leaves Default()'s list in place, and a list identical
+	// to it unmarshals to the same value. A second pass with a pointer field is
+	// the only way to tell "inherited the defaults" from "chose exactly these".
+	var probe struct {
+		Extractors *[]string `yaml:"extractors"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err == nil {
+		cfg.ExtractorsExplicit = probe.Extractors != nil
 	}
 	// Recorded so Repos entries resolve against the config's own directory; see
 	// RepoPaths.

--- a/internal/engine/docs_extraction_test.go
+++ b/internal/engine/docs_extraction_test.go
@@ -1,0 +1,155 @@
+package engine
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The docs/extraction/*.md pages describe what each extractor produces, using
+// committed fixtures as the evidence. Prose has no test suite, so an extractor can
+// change while the page keeps describing an outcome that stopped happening — the
+// same failure mode `TestPublishedExample_StillDemonstratesWhatItClaims` exists to
+// prevent for examples/cross-repo.
+//
+// These tests assert the two things that would rot silently:
+//   1. every fixture and golden the pages point at still exists;
+//   2. the specific composed paths the pages present as the headline capability
+//      are still what the golden files contain.
+//
+// A page that stops being true fails here before anyone reads it.
+
+const docsExtractionDir = "../../docs/extraction"
+
+func goldenRouteNames(t *testing.T, fixture string) map[string]bool {
+	t.Helper()
+	path := filepath.Join("testdata", "golden", fixture+".facts.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading golden %s: %v", path, err)
+	}
+	names := map[string]bool{}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var f struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(line), &f); err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		if f.Kind == "route" {
+			names[f.Name] = true
+		}
+	}
+	return names
+}
+
+// TestExtractionDocs_ReferencedFixturesExist keeps the pages' links honest: every
+// testdata path they name has to be a real directory or file.
+func TestExtractionDocs_ReferencedFixturesExist(t *testing.T) {
+	entries, err := os.ReadDir(docsExtractionDir)
+	if err != nil {
+		t.Skipf("docs/extraction not present: %v", err)
+	}
+	// Matches the repo-relative testdata paths the pages link to, e.g.
+	// ../../internal/engine/testdata/repos/go_sample/
+	ref := regexp.MustCompile(`internal/engine/testdata/(repos|golden)/([A-Za-z0-9_.-]+)`)
+
+	var checked int
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(docsExtractionDir, e.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", e.Name(), err)
+		}
+		for _, m := range ref.FindAllStringSubmatch(string(body), -1) {
+			target := filepath.Join("testdata", m[1], m[2])
+			if _, err := os.Stat(target); err != nil {
+				t.Errorf("%s references %s, which does not exist", e.Name(), m[0])
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Error("no fixture references found in docs/extraction — the regex or the pages changed")
+	}
+}
+
+// TestExtractionDocs_ComposedPathsStillHold pins the claim each page is built
+// around: a route registered at a bare path is STORED at its composed runtime
+// path. If prefix composition regresses, these fail with the page still promising
+// it works.
+func TestExtractionDocs_ComposedPathsStillHold(t *testing.T) {
+	cases := []struct {
+		fixture string
+		page    string
+		want    []string
+		absent  []string // paths that must NOT survive composition
+	}{
+		{
+			fixture: "go_httpclient_multirepo",
+			page:    "go.md",
+			// registered as "/things/{id}" inside registerThings, mounted at "/v1" in main
+			want:   []string{"/v1/things/{id}"},
+			absent: []string{"/things/{id}"},
+		},
+		{
+			fixture: "py_fastapi_multirepo",
+			page:    "python.md",
+			// declared as "/results" and "/" in a router factory, mounted at "/api/v1/search"
+			want:   []string{"/api/v1/search/results", "/api/v1/search"},
+			absent: []string{"/results"},
+		},
+		{
+			fixture: "ts_nest_multirepo",
+			page:    "typescript.md",
+			// @Get('available') under @Controller('v2/slots')
+			want:   []string{"/v2/slots/available", "/v2/slots/reserve"},
+			absent: []string{"/available", "/reserve"},
+		},
+		{
+			fixture: "ruby_sample",
+			page:    "ruby.md",
+			// a singular `resource` nested in a plural `resources` has no :id of its own
+			want: []string{
+				"/admin/reports/:report_id/export",
+				"/admin/reports/:report_id/sections/:id",
+			},
+		},
+		{
+			fixture: "php_laravel_sample",
+			page:    "php.md",
+			// Route::apiResource('photos', …) expands to seven routes
+			want: []string{
+				"/api/photos", "/api/photos/create", "/api/photos/{id}", "/api/photos/{id}/edit",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			routes := goldenRouteNames(t, tc.fixture)
+			for _, w := range tc.want {
+				if !routes[w] {
+					t.Errorf("docs/extraction/%s presents %q as a composed route, but %s's golden has no such route",
+						tc.page, w, tc.fixture)
+				}
+			}
+			for _, a := range tc.absent {
+				if routes[a] {
+					t.Errorf("docs/extraction/%s states %q is composed away, but %s's golden still contains it",
+						tc.page, a, tc.fixture)
+				}
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -318,10 +319,11 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 		cache = loadExtractorCache(cachePath)
 	}
 	preCount := e.store.Count()
-	usedExtractors, parseErrs, err := e.runExtractors(ctx, absRepo, files, currentHashes, cache)
+	usedExtractors, shadowedExtractors, parseErrs, err := e.runExtractors(ctx, absRepo, files, currentHashes, cache)
 	if err != nil {
 		return nil, fmt.Errorf("extraction: %w", err)
 	}
+	e.reportShadowed(absRepo, shadowedExtractors)
 	if cache != nil {
 		log.Printf("[engine] extractor cache: %d reused", cache.hits)
 		if e.persistCache {
@@ -430,17 +432,18 @@ func (e *Engine) GenerateSnapshot(ctx context.Context, repoPath string, appendMo
 			Git:          gitInfo(absRepo, e.cfg.Output.Dir),
 			ConfigHash:   configHash,
 
-			FilesSeen:         len(files),
-			FilesParsed:       e.store.CountFilesWithFacts(files, parsedPrefix),
-			SourceBytes:       e.store.SourceBytesWithFacts(files, parsedPrefix, absRepo),
-			FilesSkipped:      skips.count,
-			DirsSkipped:       skips.dirCount,
-			SkippedSample:     skips.sample,
-			IgnoreGlobHash:    ignoreGlobHash,
-			ParseErrors:       len(parseErrs),
-			ParseErrorSample:  capParseErrors(parseErrs),
-			HeuristicInsights: countHeuristicInsights(allInsights),
-			Coverage:          coverageSummary(e.store),
+			FilesSeen:          len(files),
+			FilesParsed:        e.store.CountFilesWithFacts(files, parsedPrefix),
+			SourceBytes:        e.store.SourceBytesWithFacts(files, parsedPrefix, absRepo),
+			FilesSkipped:       skips.count,
+			DirsSkipped:        skips.dirCount,
+			SkippedSample:      skips.sample,
+			IgnoreGlobHash:     ignoreGlobHash,
+			ShadowedExtractors: shadowedExtractors,
+			ParseErrors:        len(parseErrs),
+			ParseErrorSample:   capParseErrors(parseErrs),
+			HeuristicInsights:  countHeuristicInsights(allInsights),
+			Coverage:           coverageSummary(e.store),
 		},
 		// FactsRef aliases the store's slice rather than copying it. This is safe:
 		// `work` is published (below) and then NEVER mutated again — the next
@@ -716,8 +719,12 @@ func (e *Engine) ignoreMatch(relPath string) (string, bool) {
 // runExtractors detects applicable extractors and runs them. When cache is
 // non-nil, extractors implementing plugin.FileOwner have their facts reused
 // whenever the files they depend on are unchanged since the last snapshot.
-func (e *Engine) runExtractors(ctx context.Context, repoPath string, files []string, hashes map[string]string, cache *extractorCache) ([]string, []facts.ParseError, error) {
+//
+// It also reports the SHADOWED extractors: those registered and applicable to this
+// repository, but excluded by an explicit `extractors:` list. See reportShadowed.
+func (e *Engine) runExtractors(ctx context.Context, repoPath string, files []string, hashes map[string]string, cache *extractorCache) ([]string, []string, []facts.ParseError, error) {
 	var usedNames []string
+	var shadowed []string
 	var parseErrs []facts.ParseError
 
 	var keys map[string]string
@@ -727,6 +734,16 @@ func (e *Engine) runExtractors(ctx context.Context, repoPath string, files []str
 
 	for _, ext := range e.extractors.All() {
 		if !e.cfg.IsExtractorEnabled(ext.Name()) {
+			// Disabled by config. Detect anyway when the list was written by hand,
+			// so the one case worth a warning — a language present in the repo that
+			// this config will not extract — is named rather than left as an absence.
+			// Detect is a cheap file-presence probe, and only disabled extractors
+			// reach here, so this costs nothing on a config that enables everything.
+			if e.cfg.ExtractorsExplicit {
+				if detected, err := ext.Detect(repoPath); err == nil && detected {
+					shadowed = append(shadowed, ext.Name())
+				}
+			}
 			continue
 		}
 
@@ -774,7 +791,28 @@ func (e *Engine) runExtractors(ctx context.Context, repoPath string, files []str
 		log.Printf("[engine] extractor %s: emitted %d facts in %s", ext.Name(), len(extracted), time.Since(tExt).Round(time.Millisecond))
 	}
 
-	return usedNames, parseErrs, nil
+	return usedNames, shadowed, parseErrs, nil
+}
+
+// reportShadowed warns about extractors that would have contributed facts but were
+// excluded by an explicit `extractors:` list.
+//
+// An explicit list replaces the defaults rather than extending them, so a config
+// written before an extractor existed disables it permanently — and a disabled
+// extractor is not merely quiet, it never appears in the log at all. The failure
+// looks exactly like a repository with nothing to find: a 780-file Rust repo
+// reported 0 facts, no error, no mention of Rust. This is the line that names it.
+func (e *Engine) reportShadowed(repoPath string, shadowed []string) {
+	if len(shadowed) == 0 {
+		return
+	}
+	sort.Strings(shadowed)
+	where := "your config"
+	if e.cfg.SourcePath != "" {
+		where = e.cfg.SourcePath
+	}
+	log.Printf("[engine] warning: extractor(s) %s detected %s but are absent from the extractors: list in %s — they contribute no facts. An explicit extractors: list REPLACES the built-in defaults; add them to index these languages.",
+		strings.Join(shadowed, ", "), repoPath, where)
 }
 
 // runTestRefExtractors runs reference-only extraction over the test/spec files

--- a/internal/engine/shadowed_extractors_test.go
+++ b/internal/engine/shadowed_extractors_test.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/config"
+)
+
+// snapshotWith runs one snapshot over a repo holding a single .py file, with the
+// given extractor list. Two extractors are registered and both detect, so which
+// one is missing from the list is the only variable.
+func snapshotWith(t *testing.T, extractors []string, explicit bool) []string {
+	t.Helper()
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "a.py"), []byte("x = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Default()
+	cfg.Repo = repo
+	cfg.Extractors = extractors
+	cfg.ExtractorsExplicit = explicit
+	cfg.Explainers = nil
+	cfg.Renderers = nil
+
+	e, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.SetPersistCache(false)
+	e.RegisterExtractor(&fakeExtractor{name: "py", ext: ".py"})
+	e.RegisterExtractor(&fakeExtractor{name: "ts", ext: ".ts"})
+
+	snap, err := e.GenerateSnapshot(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf("GenerateSnapshot: %v", err)
+	}
+	return snap.Meta.ShadowedExtractors
+}
+
+// A hand-written `extractors:` list REPLACES the built-in one, so an extractor that
+// exists and applies to the repository can be excluded by a config that predates
+// it. The failure is invisible from the outside — a disabled extractor is never
+// tried, so it appears nowhere in the log, and the repository just looks empty.
+// This is the record that names it.
+func TestSnapshot_RecordsExtractorsShadowedByAnExplicitList(t *testing.T) {
+	got := snapshotWith(t, []string{"py"}, true)
+	if strings.Join(got, ",") != "ts" {
+		t.Errorf("ShadowedExtractors = %v, want [ts] — the registered extractor that "+
+			"detected this repo but was excluded by the config", got)
+	}
+}
+
+// Inheriting the defaults is not a choice about any particular extractor, so a
+// disabled-by-default extractor is not "shadowed" — reporting it would make the
+// warning fire on every run and teach the reader to ignore it.
+func TestSnapshot_NoShadowReportWhenTheListWasInherited(t *testing.T) {
+	if got := snapshotWith(t, []string{"py"}, false); len(got) != 0 {
+		t.Errorf("ShadowedExtractors = %v, want none when the list came from the defaults", got)
+	}
+}
+
+// Nothing excluded, nothing to report — the common case must stay silent.
+func TestSnapshot_NoShadowReportWhenEverythingIsEnabled(t *testing.T) {
+	if got := snapshotWith(t, []string{"py", "ts"}, true); len(got) != 0 {
+		t.Errorf("ShadowedExtractors = %v, want none when the config enables both", got)
+	}
+}

--- a/internal/facts/model.go
+++ b/internal/facts/model.go
@@ -232,18 +232,25 @@ type SnapshotMeta struct {
 	ConfigHash   string   `json:"config_hash,omitempty"`   // hash of the effective config (extractors, explainers, renderers, globs, output) — a superset of IgnoreGlobHash
 
 	// Extraction-quality fields (the loop signal).
-	FilesSeen         int               `json:"files_seen,omitempty"`         // source files the walker enumerated (excludes ignored)
-	FilesParsed       int               `json:"files_parsed,omitempty"`       // distinct files that produced at least one fact
-	SourceBytes       int64             `json:"source_bytes,omitempty"`       // on-disk bytes of the FilesParsed set — the corpus this graph replaces reading (see pkg/status value model)
-	FilesSkipped      int               `json:"files_skipped,omitempty"`      // ignored FILES the walker visited; a pruned directory counts once in DirsSkipped, not once per file
-	DirsSkipped       int               `json:"dirs_skipped,omitempty"`       // ignored DIRECTORIES pruned whole; their contents are never visited, so they are counted nowhere else
-	SkippedSample     []string          `json:"skipped_sample,omitempty"`     // a capped sample of both, each naming the glob that matched it
-	IgnoreGlobHash    string            `json:"ignore_glob_hash,omitempty"`   // hash of the sorted ignore+test globs
-	ParseErrors       int               `json:"parse_errors,omitempty"`       // count of extractor detect/parse failures (non-fatal)
-	ParseErrorSample  []ParseError      `json:"parse_error_sample,omitempty"` // a capped sample of those failures
-	HeuristicInsights int               `json:"heuristic_insights,omitempty"` // count of insights with confidence < 1.0 (heuristics, vs. structural facts)
-	Coverage          *CoverageSummary  `json:"coverage,omitempty"`           // cross-repo edge-coverage rollup, nil in single-repo mode
-	OutputHashes      map[string]string `json:"output_hashes,omitempty"`      // artifact name -> "sha256:"-prefixed hash of its written bytes
+	FilesSeen      int      `json:"files_seen,omitempty"`       // source files the walker enumerated (excludes ignored)
+	FilesParsed    int      `json:"files_parsed,omitempty"`     // distinct files that produced at least one fact
+	SourceBytes    int64    `json:"source_bytes,omitempty"`     // on-disk bytes of the FilesParsed set — the corpus this graph replaces reading (see pkg/status value model)
+	FilesSkipped   int      `json:"files_skipped,omitempty"`    // ignored FILES the walker visited; a pruned directory counts once in DirsSkipped, not once per file
+	DirsSkipped    int      `json:"dirs_skipped,omitempty"`     // ignored DIRECTORIES pruned whole; their contents are never visited, so they are counted nowhere else
+	SkippedSample  []string `json:"skipped_sample,omitempty"`   // a capped sample of both, each naming the glob that matched it
+	IgnoreGlobHash string   `json:"ignore_glob_hash,omitempty"` // hash of the sorted ignore+test globs
+	// ShadowedExtractors names extractors that detected this repository but were
+	// excluded by an explicit `extractors:` list — languages present in the source
+	// and absent from the graph. Recorded because the alternative evidence is a
+	// negative (an extractor that never appears in the log), which is unreadable
+	// after the fact: a receipt showing thin extraction should say whose facts are
+	// missing by configuration rather than by absence.
+	ShadowedExtractors []string          `json:"shadowed_extractors,omitempty"`
+	ParseErrors        int               `json:"parse_errors,omitempty"`       // count of extractor detect/parse failures (non-fatal)
+	ParseErrorSample   []ParseError      `json:"parse_error_sample,omitempty"` // a capped sample of those failures
+	HeuristicInsights  int               `json:"heuristic_insights,omitempty"` // count of insights with confidence < 1.0 (heuristics, vs. structural facts)
+	Coverage           *CoverageSummary  `json:"coverage,omitempty"`           // cross-repo edge-coverage rollup, nil in single-repo mode
+	OutputHashes       map[string]string `json:"output_hashes,omitempty"`      // artifact name -> "sha256:"-prefixed hash of its written bytes
 }
 
 // FileHash tracks a file's content hash for incremental updates.

--- a/mcp-arch.yaml
+++ b/mcp-arch.yaml
@@ -116,31 +116,18 @@ ignore:
   - "**/*Test.php"
   - "**/*TestCase.php"
   - "**/*Cest.php"
-extractors:
-  - cpp
-  - go
-  - grpc
-  - java
-  - kotlin
-  - openapi
-  - php
-  - python
-  - typescript
-  - swift
-  - ruby
-explainers:
-  - cycles
-  - layers
-  - crossrepo
-  - coverage
-  - unused-routes
-  - god-class
-  - hotspots
-  - dependency-depth
-  - exported-surface
-  - complexity-outliers
-renderers:
-  - llm_context
+# extractors: / explainers: / renderers: are deliberately ABSENT.
+#
+# Each of these keys REPLACES the built-in list rather than extending it, so a
+# file that merely mirrors config.Default() can do only one thing: fall behind it.
+# This file used to list eleven extractors, which silently disabled Rust for every
+# repository it governed from the day the Rust extractor landed — and because a
+# config beside the binary also applies to repositories elsewhere, that reached far
+# past this one. Omitting the keys means new extractors, explainers and renderers
+# are picked up automatically.
+#
+# Set them only to genuinely narrow a run (e.g. `extractors: [go]` to index Go
+# alone). enola warns when an extractor you excluded would have detected the repo.
 output:
   dir: ".enola"
   max_context_tokens: 4000

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -3,7 +3,9 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -215,26 +217,96 @@ type Options struct {
 	ConfigPath string
 }
 
+// defaultConfigName is the config file every command looks for when none is named.
+const defaultConfigName = "mcp-arch.yaml"
+
+// ResolveConfig loads the effective configuration and returns it alongside a
+// one-line description of WHERE it came from, for the caller to print.
+//
+// The description is not decoration. A config governs which extractors run and
+// which paths are ignored, so a run against the wrong config does not fail — it
+// quietly analyses something other than what was asked for. The case that made
+// this necessary: a config predating the Rust extractor, sitting next to a
+// `go build` output, disabled Rust for every repository that binary was ever
+// pointed at, from any directory, with no warning and no mention of Rust in the
+// log. Naming the resolved path on every command converts that from a silent
+// wrong answer into an obvious one.
+//
+// Lookup order: the given path (or mcp-arch.yaml) relative to the working
+// directory, then — only for an unpacked bundle, see bundledConfigDir — a copy
+// beside the executable. Built-in defaults when neither resolves.
+func ResolveConfig(cfgPath string) (*config.Config, string) {
+	if cfgPath == "" {
+		cfgPath = defaultConfigName
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err == nil {
+		return cfg, "enola: using config " + cfg.SourcePath
+	}
+
+	if !filepath.IsAbs(cfgPath) {
+		if exeDir, ok := bundledConfigDir(); ok {
+			if bundled, bErr := config.Load(filepath.Join(exeDir, cfgPath)); bErr == nil {
+				wd, _ := os.Getwd()
+				return bundled, fmt.Sprintf("enola: using config %s (found next to the enola binary, not in %s)",
+					bundled.SourcePath, wd)
+			}
+		}
+	}
+
+	if errors.Is(err, fs.ErrNotExist) {
+		wd, _ := os.Getwd()
+		return config.Default(), fmt.Sprintf("enola: no %s in %s, using built-in defaults", cfgPath, wd)
+	}
+	// A config that exists but cannot be read or parsed is a different situation
+	// from none at all: the user meant to configure something and it is not in
+	// force. Keep the underlying error rather than reporting only the fallback.
+	return config.Default(), fmt.Sprintf("warning: %v; using built-in defaults", err)
+}
+
+// bundledConfigDir returns the executable's directory when a config sitting there
+// should be honoured, and false otherwise.
+//
+// The fallback is defensible for a distribution unpacked as a unit — binary and
+// config shipped together, run from anywhere. It is indefensible for an INSTALLED
+// binary: a config beside enola on PATH governs every invocation from every
+// directory that has no config of its own, which is most of them, and the user has
+// no reason to connect the two. Being on PATH is what separates the cases, so an
+// exe directory that is a PATH entry is refused.
+func bundledConfigDir() (string, bool) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+	// Resolve symlinks: a Homebrew-style /usr/local/bin/enola -> ../Cellar/... link
+	// is an installed binary, and its real directory is where a bundled config would
+	// live. Best-effort — an unresolvable link falls back to the literal path.
+	if resolved, rErr := filepath.EvalSymlinks(exePath); rErr == nil {
+		exePath = resolved
+	}
+	exeDir := filepath.Clean(filepath.Dir(exePath))
+
+	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
+		if entry == "" {
+			continue
+		}
+		if abs, aErr := filepath.Abs(entry); aErr == nil {
+			entry = abs
+		}
+		if filepath.Clean(entry) == exeDir {
+			return "", false
+		}
+	}
+	return exeDir, true
+}
+
 // NewEngine creates an Engine with all OSS plugins registered.
 // Use the returned Engine's methods to add additional (enterprise) plugins
 // before starting the server or generating snapshots.
 func NewEngine(opts Options) (*Engine, *config.Config, error) {
-	cfgPath := opts.ConfigPath
-	if cfgPath == "" {
-		cfgPath = "mcp-arch.yaml"
-	}
-
-	cfg, err := config.Load(cfgPath)
-	if err != nil && !filepath.IsAbs(cfgPath) {
-		if exePath, exErr := os.Executable(); exErr == nil {
-			exeDir := filepath.Dir(exePath)
-			cfg, err = config.Load(filepath.Join(exeDir, cfgPath))
-		}
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: %v, using defaults\n", err)
-		cfg = config.Default()
-	}
+	cfg, note := ResolveConfig(opts.ConfigPath)
+	fmt.Fprintln(os.Stderr, note)
 
 	eng, err := engine.New(cfg)
 	if err != nil {

--- a/pkg/bootstrap/config_resolution_test.go
+++ b/pkg/bootstrap/config_resolution_test.go
@@ -1,0 +1,152 @@
+package bootstrap_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/pkg/bootstrap"
+)
+
+// The config governs which extractors run and which paths are ignored, so loading
+// the wrong one does not fail — it analyses something other than what was asked
+// for. These tests cover the two halves of that: that the resolved path is always
+// reported, and that a config beside an INSTALLED binary is refused.
+
+// writeConfig puts a config at path whose repo value is a marker, so a test can
+// tell which of several candidate files was actually loaded.
+func writeConfig(t *testing.T, path, marker string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("repo: \""+marker+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// exeDir is the directory holding the running test binary — the directory
+// ResolveConfig treats as the "bundled" location. Writing there is how the
+// executable-adjacent fallback can be exercised at all.
+func exeDir(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	if resolved, rErr := filepath.EvalSymlinks(exe); rErr == nil {
+		exe = resolved
+	}
+	return filepath.Dir(exe)
+}
+
+// bundleConfig writes a config next to the test binary and removes it afterwards,
+// so it cannot leak into any other test in this package.
+func bundleConfig(t *testing.T, marker string) {
+	t.Helper()
+	p := filepath.Join(exeDir(t), "mcp-arch.yaml")
+	if _, err := os.Stat(p); err == nil {
+		t.Skipf("a config already exists at %s", p)
+	}
+	writeConfig(t, p, marker)
+	t.Cleanup(func() {
+		if err := os.Remove(p); err != nil {
+			t.Errorf("removing %s: %v — it would leak into the other tests in this package", p, err)
+		}
+	})
+}
+
+func TestResolveConfig_WorkingDirectoryConfigWins(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, filepath.Join(dir, "mcp-arch.yaml"), "/from-cwd")
+	t.Chdir(dir)
+
+	cfg, note := bootstrap.ResolveConfig("")
+	if cfg.Repo != "/from-cwd" {
+		t.Errorf("Repo = %q, want the cwd config's value", cfg.Repo)
+	}
+	if !strings.Contains(note, filepath.Join(dir, "mcp-arch.yaml")) {
+		t.Errorf("note = %q, want it to name the resolved config path", note)
+	}
+}
+
+// The note must say "defaults" rather than naming a file that was only looked for:
+// a note reporting the intent as though it were the outcome is a confirmation of
+// something nobody checked.
+func TestResolveConfig_NoConfigSaysSo(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	cfg, note := bootstrap.ResolveConfig("")
+	if cfg.Repo != "." {
+		t.Errorf("Repo = %q, want the built-in default", cfg.Repo)
+	}
+	if !strings.Contains(note, "built-in defaults") {
+		t.Errorf("note = %q, want it to say the built-in defaults are in force", note)
+	}
+}
+
+// A config that exists but cannot be parsed is a different situation from none at
+// all — the user meant to configure something and it is not in force — so the
+// underlying error must survive into the note.
+func TestResolveConfig_UnparseableConfigReportsTheError(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "mcp-arch.yaml")
+	if err := os.WriteFile(p, []byte("repo: [unterminated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	cfg, note := bootstrap.ResolveConfig("")
+	if cfg.Repo != "." {
+		t.Errorf("Repo = %q, want the built-in default after a parse failure", cfg.Repo)
+	}
+	if !strings.Contains(note, "warning") || !strings.Contains(note, "built-in defaults") {
+		t.Errorf("note = %q, want it to carry both the parse error and the fallback", note)
+	}
+}
+
+// The fallback is defensible for a distribution unpacked as a unit: binary and
+// config shipped together, run from anywhere.
+func TestResolveConfig_BundledConfigUsedWhenBinaryIsNotOnPATH(t *testing.T) {
+	bundleConfig(t, "/from-bundle")
+	t.Chdir(t.TempDir())
+	t.Setenv("PATH", filepath.Join(t.TempDir(), "elsewhere"))
+
+	cfg, note := bootstrap.ResolveConfig("")
+	if cfg.Repo != "/from-bundle" {
+		t.Fatalf("Repo = %q, want the bundled config to apply to an unpacked binary", cfg.Repo)
+	}
+	// Silently inheriting configuration from wherever the binary happens to live is
+	// the surprising half, so the note must say the config came from there.
+	if !strings.Contains(note, "next to the enola binary") {
+		t.Errorf("note = %q, want it to disclose that the config came from the binary's directory", note)
+	}
+}
+
+// The regression this defends: a config beside an installed (or in-tree `go build`)
+// binary governed every repository that binary was pointed at, from any directory
+// with no config of its own — which is most of them. Being on PATH is what
+// separates an installed binary from an unpacked bundle.
+func TestResolveConfig_BundledConfigRefusedWhenBinaryIsOnPATH(t *testing.T) {
+	bundleConfig(t, "/from-bundle")
+	t.Chdir(t.TempDir())
+	t.Setenv("PATH", exeDir(t)+string(os.PathListSeparator)+"/usr/bin")
+
+	cfg, note := bootstrap.ResolveConfig("")
+	if cfg.Repo == "/from-bundle" {
+		t.Errorf("a config beside a binary on PATH governed a repository elsewhere; note = %q", note)
+	}
+	if !strings.Contains(note, "built-in defaults") {
+		t.Errorf("note = %q, want the built-in defaults", note)
+	}
+}
+
+// An explicit --config path is the user naming a file; a fallback that quietly
+// substituted a different one would make the flag a suggestion.
+func TestResolveConfig_ExplicitAbsolutePathNeverFallsBack(t *testing.T) {
+	bundleConfig(t, "/from-bundle")
+	missing := filepath.Join(t.TempDir(), "no-such-config.yaml")
+
+	cfg, _ := bootstrap.ResolveConfig(missing)
+	if cfg.Repo == "/from-bundle" {
+		t.Error("an explicit config path fell back to the config beside the binary")
+	}
+}


### PR DESCRIPTION
…g defaults

A config decides which extractors run and which paths are ignored, so loading the wrong one does not fail — it analyses something other than what was asked for. Two behaviours combined to make that silent: lookup falls back to the binary's own directory, and a list-valued key replaces the built-in list rather than extending it. An eleven-extractor config beside a `go build` output therefore disabled Rust for every repository that binary was pointed at, from any directory without a config of its own: a 780-file Rust repo reported 0 facts, no error, no mention of Rust anywhere in the log.

- bootstrap.ResolveConfig returns the resolved path alongside the config, and NewEngine prints it on every command. check/coverage build their note from cfg.SourcePath too — they reported the config they looked FOR, which under the fallback was not the one in force.
- The executable-adjacent fallback is restricted to a binary that is not on PATH (an unpacked bundle rather than an installed one), and discloses itself.
- config.Load records whether the file listed `extractors:` itself; when it did, the engine detects the disabled extractors and warns for any that match the repository, recording them as shadowed_extractors in the receipt.
- mcp-arch.yaml and examples/*.yaml no longer declare extractors/explainers/ renderers. Beyond the reported instance: every example pinned four of the ten explainers, so adopters lost the other six, and full.yaml claimed to enable all languages while omitting grpc, openapi and python.

`extractors:` still replaces rather than merges — it is the only way to disable an extractor, and trading a loud omission for a silent inability to turn things off is the worse bargain. Tests pin the resolution rules, the PATH restriction, the shadow report, and the absence of plugin lists from every shipped config.