### PR TITLE
fix(config): derive the ignore glob from output.dir instead of hard-c…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -831,6 +831,12 @@ The bundled [`mcp-arch.yaml`](mcp-arch.yaml) ships a much fuller `ignore` list (
 
 That line exists because the failure it prevents is silent. A config decides which extractors run and which paths are ignored, so loading the wrong one does not error — it analyses something other than what was asked for. Before the restriction and the announcement, a config sitting beside a `go build` output governed every repository that binary was ever pointed at, from any directory without one of its own; an eleven-extractor list written before the Rust extractor landed turned a 780-file Rust repository into `0 facts`, with no error and no mention of Rust anywhere in the log.
 
+A config that is **missing** falls back to the built-in defaults. A config that is **present and unusable** — unparseable, or naming an `output.dir` that cannot be honoured — is a fatal error instead, because the fallback's `repo: "."` is the working directory: a typo would otherwise make enola analyse whichever repository you were standing in and present it as an answer about the one the config named. Same rule the CLI already applies to an explicitly-named path that does not exist.
+
+**The output directory ignores itself, wherever it is.** `config.Normalize` — run by both `config.Load` and `engine.New`, so a config assembled in code is treated identically — appends `<output.dir>/**` to the ignore list. `.enola/**` remains in the defaults as a literal as well, so a repository that used the default before changing it does not start indexing its own history.
+
+That derivation is load-bearing rather than tidy. The literal used to be the *only* entry, sitting between `.next/**` and `dist/**` as though it were another build-artifact glob, agreeing with `Output.Dir` only by coincidence. Set `output.dir` to anything else and each snapshot walked the previous one's artifacts — `facts.jsonl`, `insights.json`, `llm_context.md`, plus the `previous/` rotation from run 2 onward — so an unchanged tree produced a different snapshot every run. Reproducibility is the property the baseline diff rests on, and comparability checking cannot catch this: the config is identical on both sides.
+
 **A list-valued key REPLACES its default; it does not merge.** `yaml.Unmarshal` overwrites the slice, so `extractors:` names the complete set — a config written before an extractor existed disables it permanently, and a disabled extractor is never tried and so never appears in the log. Two things make that visible: a bundled config that names no plugin lists at all, and a warning naming any *excluded* extractor that would have detected the repository (also recorded as `shadowed_extractors` in the snapshot receipt). The semantics are unchanged on purpose — an explicit list is the only way to disable an extractor.
 
 | Field | Description | Default |
@@ -841,7 +847,7 @@ That line exists because the failure it prevents is silent. A config decides whi
 | `extractors` | Enabled extractors | `["cpp", "go", "grpc", "java", "kotlin", "openapi", "php", "python", "typescript", "swift", "ruby", "rust"]` |
 | `explainers` | Enabled explainers | `["cycles", "layers", "crossrepo", "coverage", "unused-routes", "god-class", "hotspots", "dependency-depth", "exported-surface", "complexity-outliers"]` |
 | `renderers` | Enabled renderers | `["llm_context"]` |
-| `output.dir` | Output directory for artifacts | `".enola"` |
+| `output.dir` | Output directory for artifacts. Must name a **subdirectory of the repository** — it is joined to the repository path, so an absolute value would nest that whole path inside the repo rather than write where it says. An ignore glob is derived from it automatically (see below) | `".enola"` |
 | `output.max_context_tokens` | Token budget for `llm_context.md` | `16000` |
 | `dashboard.port` | The fixed **shared URL** port every server competes for, in addition to its own ephemeral one. A negative value serves only the ephemeral port. `ENOLA_DASHBOARD_PORT` overrides it (`off` disables). | `7171` |
 | `incremental` | Reuse each extractor's cached facts across snapshots when its files are unchanged; set `false` to force full re-extraction every run | `true` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,7 +149,12 @@ func Default() *Config {
 			"**/test_*.py",
 			"**/tests/**/*.py",
 			"**/test/**/*.py",
-			".enola/**",
+			// enola's own output. This is the DEFAULT location only; the glob for the
+			// configured one is derived in Normalize, which is what makes a custom
+			// output.dir safe. The literal stays because a repository that used the
+			// default before changing it still has artifacts here, and indexing its own
+			// history is exactly the failure the derived glob exists to prevent.
+			defaultOutputDir + "/**",
 			// Build / cache artifacts. These are generated output (often transpiled
 			// JS, e.g. Next.js .next/) and must never be indexed as source — doing so
 			// pollutes query_facts with thousands of spurious facts. The **/<dir>/**
@@ -220,7 +225,7 @@ func Default() *Config {
 		Explainers: []string{"cycles", "layers", "crossrepo", "coverage", "unused-routes", "god-class", "hotspots", "dependency-depth", "exported-surface", "complexity-outliers"},
 		Renderers:  []string{"llm_context"},
 		Output: OutputConfig{
-			Dir:              ".enola",
+			Dir:              defaultOutputDir,
 			MaxContextTokens: 16000,
 		},
 	}
@@ -257,15 +262,71 @@ func Load(path string) (*Config, error) {
 		cfg.SourcePath = path
 	}
 
-	// Ensure required defaults
-	if cfg.Output.Dir == "" {
-		cfg.Output.Dir = ".enola"
+	if err := cfg.Normalize(); err != nil {
+		return nil, fmt.Errorf("in config %s: %w", path, err)
 	}
-	if cfg.Output.MaxContextTokens == 0 {
-		cfg.Output.MaxContextTokens = 16000
+	return cfg, nil
+}
+
+// defaultOutputDir is where artifacts go unless output.dir says otherwise. It is
+// also present as a literal in Default().Ignore, and deliberately so — see Normalize.
+const defaultOutputDir = ".enola"
+
+// Normalize fills in required defaults, validates them, and derives the settings
+// that follow from other settings. Idempotent, and called both by Load and by the
+// engine, so a config built in code gets the same treatment as one read from a file.
+//
+// Its real job is the output directory. `.enola/**` used to be a hard-coded literal
+// in the default ignore list, sitting between `.next/**` and `dist/**` as though it
+// were another build-artifact glob, and agreeing with Output.Dir only by coincidence.
+// Point output.dir anywhere else and the next snapshot walked the previous one's
+// artifacts — facts.jsonl, insights.json, llm_context.md, plus the previous/ rotation
+// from run 2 onward — so an unchanged tree produced a different snapshot every run.
+// Reproducibility is the property the baseline diff rests on, and this broke it for a
+// reason that has nothing to do with enola's determinism, on a setting users are
+// invited to change, with a symptom that points nowhere near the cause.
+//
+// The literal `.enola/**` stays in Default().Ignore as well: a repository that once
+// used the default and later changed it must not start indexing its own history.
+func (c *Config) Normalize() error {
+	if c.Output.Dir == "" {
+		c.Output.Dir = defaultOutputDir
+	}
+	if c.Output.MaxContextTokens == 0 {
+		c.Output.MaxContextTokens = 16000
 	}
 
-	return cfg, nil
+	dir, err := cleanOutputDir(c.Output.Dir)
+	if err != nil {
+		return err
+	}
+	c.Output.Dir = dir
+
+	glob := dir + "/**"
+	if !contains(c.Ignore, glob) {
+		c.Ignore = append(c.Ignore, glob)
+	}
+	return nil
+}
+
+// cleanOutputDir validates output.dir and returns it in slash form.
+//
+// It must be a subdirectory of the repository, because that is the only thing the
+// rest of the code can express: Output.Dir is JOINED to the repository path in half a
+// dozen places, so an absolute path silently produced a directory nested inside the
+// repo (/repo/private/tmp/.../out) rather than the location asked for, and an ignore
+// glob derived from it could not describe the artifacts either. An error naming the
+// constraint beats a path that looks accepted and means something else.
+func cleanOutputDir(dir string) (string, error) {
+	if filepath.IsAbs(dir) {
+		return "", fmt.Errorf("output.dir %q must be a path inside the repository, not an absolute one "+
+			"(it is joined to the repository path, so an absolute value would nest the whole path inside the repo)", dir)
+	}
+	clean := filepath.ToSlash(filepath.Clean(dir))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("output.dir %q must name a subdirectory of the repository", dir)
+	}
+	return clean, nil
 }
 
 // RepoPaths returns the absolute repository paths this run covers, in the order

--- a/internal/config/output_dir_test.go
+++ b/internal/config/output_dir_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadYAML(t *testing.T, yaml string) (*Config, error) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "mcp-arch.yaml")
+	if err := os.WriteFile(p, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return Load(p)
+}
+
+// The ignore glob for enola's own output must be DERIVED from output.dir, not
+// assumed to be `.enola/**`. The two agreed only by coincidence, and the coincidence
+// ends the moment a user takes up the invitation to configure the directory.
+func TestLoad_DerivesIgnoreGlobFromOutputDir(t *testing.T) {
+	cfg, err := loadYAML(t, "repo: \".\"\noutput:\n  dir: \".enola-bench\"\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(cfg.Ignore, ".enola-bench/**") {
+		t.Errorf("no ignore glob derived for output.dir; the next snapshot would walk this "+
+			"one's artifacts. ignore = %v", cfg.Ignore)
+	}
+	if !contains(cfg.Ignore, ".enola/**") {
+		t.Error("the literal .enola/** was dropped; a repo that used the default before " +
+			"switching would start indexing its own history")
+	}
+}
+
+// Nested directories are ordinary: `x/y/**` matches `x/y` and everything under it.
+func TestLoad_DerivesIgnoreGlobForANestedOutputDir(t *testing.T) {
+	cfg, err := loadYAML(t, "repo: \".\"\noutput:\n  dir: \"build/enola\"\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(cfg.Ignore, "build/enola/**") {
+		t.Errorf("ignore = %v, want a derived build/enola/** entry", cfg.Ignore)
+	}
+}
+
+// The default location must not gain a second, identical entry. A duplicate would
+// change the ignore-glob hash for every existing user and decline every diff against
+// a baseline pinned before the upgrade — a migration cost for no behaviour change.
+func TestNormalize_DoesNotDuplicateTheDefaultGlob(t *testing.T) {
+	cfg := Default()
+	before := len(cfg.Ignore)
+	for range 3 {
+		if err := cfg.Normalize(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(cfg.Ignore) != before {
+		t.Errorf("ignore grew from %d to %d entries on a default config", before, len(cfg.Ignore))
+	}
+}
+
+// Normalize runs from both config.Load and engine.New, so it has to be safe to
+// repeat on a config that already went through it.
+func TestNormalize_IsIdempotentForACustomDir(t *testing.T) {
+	cfg := Default()
+	cfg.Output.Dir = "out/enola"
+	for range 3 {
+		if err := cfg.Normalize(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n := 0
+	for _, g := range cfg.Ignore {
+		if g == "out/enola/**" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("derived glob appears %d times after three Normalize calls, want 1", n)
+	}
+}
+
+// output.dir is joined to the repository path in half a dozen places, so an absolute
+// value silently produced a directory nested INSIDE the repo (/repo/private/tmp/…/out)
+// rather than the location asked for. Erroring names the constraint; accepting it
+// writes the artifacts somewhere the user did not choose and cannot easily find.
+func TestLoad_RejectsAnOutputDirItCannotHonour(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "out")
+	for _, tc := range []struct{ name, dir string }{
+		{"absolute", abs},
+		{"parent", ".."},
+		{"escaping", "../elsewhere"},
+		{"repo root", "."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadYAML(t, "repo: \".\"\noutput:\n  dir: \""+tc.dir+"\"\n")
+			if err == nil {
+				t.Fatalf("output.dir %q was accepted", tc.dir)
+			}
+			if !strings.Contains(err.Error(), "output.dir") {
+				t.Errorf("error does not name the setting at fault: %v", err)
+			}
+		})
+	}
+}
+
+// A path written with redundant segments must normalize, so the glob and the joined
+// directory describe the same place.
+func TestLoad_CleansTheOutputDir(t *testing.T) {
+	cfg, err := loadYAML(t, "repo: \".\"\noutput:\n  dir: \"./out/./enola\"\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Output.Dir != "out/enola" {
+		t.Errorf("Output.Dir = %q, want the cleaned form", cfg.Output.Dir)
+	}
+	if !contains(cfg.Ignore, "out/enola/**") {
+		t.Errorf("ignore = %v, want the glob to match the cleaned directory", cfg.Ignore)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -68,6 +68,14 @@ type Engine struct {
 // New creates a new Engine with the given config.
 // Extractors, explainers, and renderers must be registered after creation.
 func New(cfg *config.Config) (*Engine, error) {
+	// Normalize here as well as in config.Load: a config assembled in code — by a
+	// test, by a wrapper, by anything that did not read a file — must get the same
+	// derived ignore glob for its output directory, or it indexes its own artifacts.
+	// Idempotent, so the file path pays nothing for it.
+	if err := cfg.Normalize(); err != nil {
+		return nil, err
+	}
+
 	// The build-scratch store and the initial published store are the same empty
 	// store, so AutoLoadSnapshot (which mutates Store() in place before serving)
 	// and the first generate both start from a consistent, non-nil bundle.

--- a/internal/engine/output_dir_test.go
+++ b/internal/engine/output_dir_test.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/config"
+)
+
+// A snapshot of an unchanged tree must be the same snapshot. That is the property
+// the whole baseline diff rests on — a clean diff means something only if a rerun
+// over identical inputs is identical.
+//
+// It used to fail for anyone who set output.dir, for a reason having nothing to do
+// with determinism: `.enola/**` was a hard-coded literal in the default ignore list,
+// agreeing with Output.Dir only by coincidence. Point output.dir elsewhere and each
+// run walked the previous run's artifacts — facts.jsonl, insights.json,
+// llm_context.md, plus the previous/ rotation from run 2 onward — so files_seen grew
+// every time. Comparability checking cannot catch it either: the config is identical
+// on both sides.
+func TestSnapshot_CustomOutputDirIsNotIndexedAsSource(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "go.mod", "module example.com/out\n\ngo 1.25\n")
+	writeRepoFile(t, repo, "pkg/x.go", "package pkg\n\nfunc X() string { return \"x\" }\n")
+
+	cfg := config.Default()
+	cfg.Repo = repo
+	cfg.Output.Dir = ".enola-bench"
+	cfg.Explainers = nil
+
+	e, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var seen []int
+	for range 3 {
+		snap, err := e.GenerateSnapshot(context.Background(), repo, false)
+		if err != nil {
+			t.Fatalf("GenerateSnapshot: %v", err)
+		}
+		// Artifacts have to be WRITTEN for the defect to appear at all: it is the
+		// previous run's output on disk that the next walk picks up.
+		if err := e.WriteArtifacts(repo); err != nil {
+			t.Fatalf("WriteArtifacts: %v", err)
+		}
+		seen = append(seen, snap.Meta.FilesSeen)
+	}
+
+	for i, n := range seen {
+		if n != seen[0] {
+			t.Errorf("files_seen across three runs of an unchanged tree: %v — run %d walked "+
+				"%d files instead of %d, which is the previous run's artifacts being indexed "+
+				"as source", seen, i+1, n, seen[0])
+			break
+		}
+	}
+}
+
+// The engine must derive the glob even for a config nobody loaded from a file — a
+// wrapper, a test, anything assembled in code. Deriving it only in config.Load would
+// leave exactly those callers indexing their own output.
+func TestNew_DerivesTheOutputDirIgnoreGlob(t *testing.T) {
+	cfg := config.Default()
+	cfg.Output.Dir = "artifacts/enola"
+	if _, err := New(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if !contains(cfg.Ignore, "artifacts/enola/**") {
+		t.Errorf("engine.New did not derive an ignore glob for output.dir; ignore = %v", cfg.Ignore)
+	}
+	// The default location stays ignored too: a repository that used .enola before
+	// switching still has artifacts there, and indexing its own history is the same
+	// defect wearing a different path.
+	if !contains(cfg.Ignore, ".enola/**") {
+		t.Errorf("the default .enola/** glob was dropped; ignore = %v", cfg.Ignore)
+	}
+}
+
+// An absolute output.dir was silently joined to the repository path, producing
+// /repo/private/tmp/…/out — a directory nested inside the repo rather than the
+// location asked for, and one no derived glob could describe.
+func TestNew_RejectsAnUnusableOutputDir(t *testing.T) {
+	for _, dir := range []string{filepath.Join(t.TempDir(), "out"), "..", "../elsewhere", "."} {
+		cfg := config.Default()
+		cfg.Output.Dir = dir
+		if _, err := New(cfg); err == nil {
+			t.Errorf("output.dir %q was accepted; it cannot be honoured as written", dir)
+		}
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func writeRepoFile(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	p := filepath.Join(repo, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -234,35 +234,46 @@ const defaultConfigName = "mcp-arch.yaml"
 //
 // Lookup order: the given path (or mcp-arch.yaml) relative to the working
 // directory, then — only for an unpacked bundle, see bundledConfigDir — a copy
-// beside the executable. Built-in defaults when neither resolves.
-func ResolveConfig(cfgPath string) (*config.Config, string) {
+// beside the executable. Built-in defaults when neither exists.
+//
+// A config that EXISTS but cannot be used is an error, not a fallback. The two
+// cases look similar and are not: a missing mcp-arch.yaml means "no preferences,
+// use the defaults", while an unparseable one — or one naming an output.dir that
+// cannot be honoured — means the user configured something and it is not in force.
+// Falling back there substitutes `repo: "."`, so a typo makes enola analyse the
+// working directory and present the result as an answer about the repository the
+// config named. The CLI already learned this once, for an explicitly-named path
+// that does not exist (see the default case in cmd/enola/main.go); this is the same
+// rule for a file that is present and wrong.
+func ResolveConfig(cfgPath string) (*config.Config, string, error) {
 	if cfgPath == "" {
 		cfgPath = defaultConfigName
 	}
 
 	cfg, err := config.Load(cfgPath)
 	if err == nil {
-		return cfg, "enola: using config " + cfg.SourcePath
+		return cfg, "enola: using config " + cfg.SourcePath, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, "", err
 	}
 
 	if !filepath.IsAbs(cfgPath) {
 		if exeDir, ok := bundledConfigDir(); ok {
-			if bundled, bErr := config.Load(filepath.Join(exeDir, cfgPath)); bErr == nil {
+			bundled, bErr := config.Load(filepath.Join(exeDir, cfgPath))
+			if bErr == nil {
 				wd, _ := os.Getwd()
 				return bundled, fmt.Sprintf("enola: using config %s (found next to the enola binary, not in %s)",
-					bundled.SourcePath, wd)
+					bundled.SourcePath, wd), nil
+			}
+			if !errors.Is(bErr, fs.ErrNotExist) {
+				return nil, "", bErr
 			}
 		}
 	}
 
-	if errors.Is(err, fs.ErrNotExist) {
-		wd, _ := os.Getwd()
-		return config.Default(), fmt.Sprintf("enola: no %s in %s, using built-in defaults", cfgPath, wd)
-	}
-	// A config that exists but cannot be read or parsed is a different situation
-	// from none at all: the user meant to configure something and it is not in
-	// force. Keep the underlying error rather than reporting only the fallback.
-	return config.Default(), fmt.Sprintf("warning: %v; using built-in defaults", err)
+	wd, _ := os.Getwd()
+	return config.Default(), fmt.Sprintf("enola: no %s in %s, using built-in defaults", cfgPath, wd), nil
 }
 
 // bundledConfigDir returns the executable's directory when a config sitting there
@@ -305,7 +316,10 @@ func bundledConfigDir() (string, bool) {
 // Use the returned Engine's methods to add additional (enterprise) plugins
 // before starting the server or generating snapshots.
 func NewEngine(opts Options) (*Engine, *config.Config, error) {
-	cfg, note := ResolveConfig(opts.ConfigPath)
+	cfg, note, err := ResolveConfig(opts.ConfigPath)
+	if err != nil {
+		return nil, nil, err
+	}
 	fmt.Fprintln(os.Stderr, note)
 
 	eng, err := engine.New(cfg)

--- a/pkg/bootstrap/config_resolution_test.go
+++ b/pkg/bootstrap/config_resolution_test.go
@@ -59,7 +59,10 @@ func TestResolveConfig_WorkingDirectoryConfigWins(t *testing.T) {
 	writeConfig(t, filepath.Join(dir, "mcp-arch.yaml"), "/from-cwd")
 	t.Chdir(dir)
 
-	cfg, note := bootstrap.ResolveConfig("")
+	cfg, note, err := bootstrap.ResolveConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Repo != "/from-cwd" {
 		t.Errorf("Repo = %q, want the cwd config's value", cfg.Repo)
 	}
@@ -74,7 +77,10 @@ func TestResolveConfig_WorkingDirectoryConfigWins(t *testing.T) {
 func TestResolveConfig_NoConfigSaysSo(t *testing.T) {
 	t.Chdir(t.TempDir())
 
-	cfg, note := bootstrap.ResolveConfig("")
+	cfg, note, err := bootstrap.ResolveConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Repo != "." {
 		t.Errorf("Repo = %q, want the built-in default", cfg.Repo)
 	}
@@ -83,23 +89,35 @@ func TestResolveConfig_NoConfigSaysSo(t *testing.T) {
 	}
 }
 
-// A config that exists but cannot be parsed is a different situation from none at
-// all — the user meant to configure something and it is not in force — so the
-// underlying error must survive into the note.
-func TestResolveConfig_UnparseableConfigReportsTheError(t *testing.T) {
-	dir := t.TempDir()
-	p := filepath.Join(dir, "mcp-arch.yaml")
-	if err := os.WriteFile(p, []byte("repo: [unterminated\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(dir)
+// A config that EXISTS but cannot be used must be an error, not a fallback.
+//
+// Falling back substitutes the built-in defaults, whose `repo: "."` is the WORKING
+// DIRECTORY — so a typo would make enola analyse whichever repository you happen to
+// be standing in and present the result as an answer about the one the config named.
+// A missing file means "no preferences"; a broken one means the opposite.
+func TestResolveConfig_UnusableConfigIsAnErrorNotAFallback(t *testing.T) {
+	for _, tc := range []struct{ name, yaml string }{
+		{"unparseable", "repo: [unterminated\n"},
+		// Reached through Normalize rather than the YAML parser, and must not be
+		// treated any more leniently: the file is present and says something enola
+		// cannot honour.
+		{"unusable output.dir", "repo: \".\"\noutput:\n  dir: \"/tmp/absolute\"\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "mcp-arch.yaml"), []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(dir)
 
-	cfg, note := bootstrap.ResolveConfig("")
-	if cfg.Repo != "." {
-		t.Errorf("Repo = %q, want the built-in default after a parse failure", cfg.Repo)
-	}
-	if !strings.Contains(note, "warning") || !strings.Contains(note, "built-in defaults") {
-		t.Errorf("note = %q, want it to carry both the parse error and the fallback", note)
+			cfg, note, err := bootstrap.ResolveConfig("")
+			if err == nil {
+				t.Fatalf("a broken config resolved to %#v with note %q, instead of erroring", cfg, note)
+			}
+			if cfg != nil {
+				t.Errorf("a config was returned alongside the error: %#v", cfg)
+			}
+		})
 	}
 }
 
@@ -110,7 +128,10 @@ func TestResolveConfig_BundledConfigUsedWhenBinaryIsNotOnPATH(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("PATH", filepath.Join(t.TempDir(), "elsewhere"))
 
-	cfg, note := bootstrap.ResolveConfig("")
+	cfg, note, err := bootstrap.ResolveConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Repo != "/from-bundle" {
 		t.Fatalf("Repo = %q, want the bundled config to apply to an unpacked binary", cfg.Repo)
 	}
@@ -130,7 +151,10 @@ func TestResolveConfig_BundledConfigRefusedWhenBinaryIsOnPATH(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("PATH", exeDir(t)+string(os.PathListSeparator)+"/usr/bin")
 
-	cfg, note := bootstrap.ResolveConfig("")
+	cfg, note, err := bootstrap.ResolveConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Repo == "/from-bundle" {
 		t.Errorf("a config beside a binary on PATH governed a repository elsewhere; note = %q", note)
 	}
@@ -145,7 +169,10 @@ func TestResolveConfig_ExplicitAbsolutePathNeverFallsBack(t *testing.T) {
 	bundleConfig(t, "/from-bundle")
 	missing := filepath.Join(t.TempDir(), "no-such-config.yaml")
 
-	cfg, _ := bootstrap.ResolveConfig(missing)
+	cfg, _, err := bootstrap.ResolveConfig(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Repo == "/from-bundle" {
 		t.Error("an explicit config path fell back to the config beside the binary")
 	}


### PR DESCRIPTION
…oding .enola

`.enola/**` was a literal in the default ignore list, sitting between `.next/**` and `dist/**` as though it were another build-artifact glob, and agreeing with cfg.Output.Dir only by coincidence. Point output.dir anywhere else and each snapshot walked the previous one's artifacts — facts.jsonl, insights.json, llm_context.md, plus the previous/ rotation from run 2 on — so an unchanged tree produced a different snapshot every run. Reproducibility is the property the baseline diff rests on, and this broke it for a reason having nothing to do with determinism, on a setting users are invited to change, with a symptom pointing nowhere near the cause. Comparability checking cannot catch it either: the config is identical on both sides.

config.Normalize() now fills in the defaults, validates them, and derives `<output.dir>/**`. It runs from config.Load AND engine.New, because a config assembled in code never passes through Load and has the same problem; it is idempotent. The literal .enola/** stays in the defaults so a repository that used the default before changing it does not start indexing its own history.

output.dir must name a subdirectory of the repository. It is joined to the repo path in half a dozen places, so an absolute value silently produced /repo/private/tmp/.../out rather than the location asked for, and no derived glob could describe it. Absolute paths, `..` escapes and `.` are now rejected by name, and the value is cleaned so the glob and the joined directory describe the same place.

Rejecting a bad output.dir exposed a worse behaviour above it: a config that EXISTED but could not be used was a warning, replaced by the built-in defaults — whose `repo: "."` is the working directory. A typo therefore made enola analyse whichever repo you were standing in and present it as an answer about the one the config named. ResolveConfig now errors for a config that is present and wrong; a missing config still falls back, which is the intended leniency. Same rule the CLI already applies to an explicitly-named path that does not exist.

Migration: the ignore list feeds ignore_glob_hash and config_hash, so a custom output.dir yields one incomparable diff and needs a re-pin. The default location is unaffected — the derivation dedupes against the literal already there.

TestSnapshot_CustomOutputDirIsNotIndexedAsSource takes three snapshots of an unchanged tree, writing artifacts each round, and asserts files_seen is constant. It fails on the code it replaces, reporting [2 7 11].