### PR TITLE
fix(explainers): make MeanStdDev depend on the multiset, not the call…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -184,6 +184,10 @@ Explainers turn raw facts into architectural observations. Each insight carries 
 
 The shared module-graph construction and statistical-outlier helpers used by several of these live in [`internal/explainers/common`](internal/explainers/common/common.go).
 
+**Determinism has two halves, and both are load-bearing.** `StronglyConnectedComponents` documents the first: visit nodes in sorted order with sorted neighbour lists, so Go's randomized map iteration cannot reach the output. `MeanStdDev` is the second: it sorts a copy of its values before reducing, so `mean + kσ` is a function of the *multiset* and not of the order the caller iterated.
+
+The second was learned the hard way. Callers build that slice by walking the fact store, whose order reflects concurrent extraction and varies between runs; float addition is not associative; and god-class is the only explainer that puts a threshold into its **output** (`confidence`) rather than using it solely to select. So across 90 runs of 30 repositories, `facts.jsonl` was byte-identical every time — it is sorted before it is written — while `insights.json` moved in the last two digits of a `float64` on one repository. Nothing a human reads changed, and `snapshot_id` does not cover `insights.json`, but `output_hashes["insights.json"]` stopped being reproducible. Any new statistic belongs behind a reduction with this property.
+
 ---
 
 ## The explain package (`pkg/explain`)
@@ -767,7 +771,7 @@ This is the candidate set for dead-endpoint cleanup, computed deterministically 
 
 The flag means "unused by the clients in **this snapshot**" — not "dead." A consumer you didn't load (an admin script, a cron job, a webhook, a third-party caller, a mobile deep link) won't appear, so treat the list as candidates to verify, not delete on sight. The `unmatched_by_clients` flag is computed by the engine during linking and is **always** present on the facts; the `unused-routes` explainer (above) additionally rolls it up into one insight per service, with that caveat attached, and only that rolled-up insight depends on the explainer being enabled.
 
-> **Config note:** the `crossrepo` explainer (which adds a cross-repo entry to `insights.json`) must be listed under `explainers:` in your config — the bundled configs already include it. The `service` nodes, graph edges, traversal, and the `llm_context.md` section work regardless of explainer config; only the `insights.json` entry depends on it.
+> **Config note:** the `crossrepo` explainer (which adds a cross-repo entry to `insights.json`) is enabled by default, and stays enabled as long as your config does not declare an `explainers:` list — the shipped configs deliberately declare none, since such a list replaces the defaults rather than extending them. If you do narrow it, `crossrepo` has to be in it. The `service` nodes, graph edges, traversal, and the `llm_context.md` section work regardless of explainer config; only the `insights.json` entry depends on it.
 
 ---
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -977,8 +977,15 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	outputHashes["facts.jsonl"] = hashBytes(factsBuf.Bytes())
 	log.Printf("[engine] wrote %s", factsPath)
 
-	// Write insights.json
-	insightsJSON, err := json.MarshalIndent(b.snapshot.Insights, "", "  ")
+	// Write insights.json. A nil slice marshals to `null`, not `[]`, so a repository
+	// with no findings produced a document that breaks any consumer iterating the
+	// parsed value without a nil check — on exactly the repositories least likely to
+	// be used while testing a consumer.
+	insights := b.snapshot.Insights
+	if insights == nil {
+		insights = []facts.Insight{}
+	}
+	insightsJSON, err := json.MarshalIndent(insights, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling insights: %w", err)
 	}

--- a/internal/engine/insights_artifact_test.go
+++ b/internal/engine/insights_artifact_test.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/config"
+)
+
+// insightsAfterSnapshot generates a snapshot of repo, writes the artifacts, and
+// returns the exact bytes of insights.json plus the hash the receipt recorded for it.
+func insightsAfterSnapshot(t *testing.T, e *Engine, repo, outDir string) (string, string) {
+	t.Helper()
+	if _, err := e.GenerateSnapshot(context.Background(), repo, false); err != nil {
+		t.Fatalf("GenerateSnapshot: %v", err)
+	}
+	if err := e.WriteArtifacts(repo); err != nil {
+		t.Fatalf("WriteArtifacts: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(repo, outDir, "insights.json"))
+	if err != nil {
+		t.Fatalf("reading insights.json: %v", err)
+	}
+
+	metaRaw, err := os.ReadFile(filepath.Join(repo, outDir, "snapshot.meta.json"))
+	if err != nil {
+		t.Fatalf("reading snapshot.meta.json: %v", err)
+	}
+	var meta struct {
+		OutputHashes map[string]string `json:"output_hashes"`
+	}
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		t.Fatal(err)
+	}
+	return string(raw), meta.OutputHashes["insights.json"]
+}
+
+// The receipt records output_hashes["insights.json"], so the file has to be
+// byte-reproducible or comparing two runs — on one machine or across two — fails for
+// a reason that has nothing to do with the code being analysed.
+//
+// The unit-level guarantee lives in explainers/common (MeanStdDev is a function of
+// the multiset) and in godclass. This asserts the property a consumer actually sees:
+// the same tree, twice, produces the same file.
+func TestWriteArtifacts_InsightsAreByteReproducible(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "go.mod", "module example.com/rep\n\ngo 1.25\n")
+	writeRepoFile(t, repo, "core/hub.go", "package core\n\nfunc Hub() string { return \"hub\" }\n")
+	for i := range 12 {
+		writeRepoFile(t, repo, filepath.Join("callers", "c"+string(rune('a'+i))+".go"),
+			"package callers\n\nimport \"example.com/rep/core\"\n\nfunc C"+string(rune('A'+i))+
+				"() string { return core.Hub() }\n")
+	}
+
+	cfg := config.Default()
+	cfg.Repo = repo
+	e, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, firstHash := insightsAfterSnapshot(t, e, repo, cfg.Output.Dir)
+	second, secondHash := insightsAfterSnapshot(t, e, repo, cfg.Output.Dir)
+
+	if first != second {
+		t.Errorf("insights.json differs between two runs of an unchanged tree:\n--- first\n%s\n--- second\n%s",
+			first, second)
+	}
+	if firstHash != secondHash {
+		t.Errorf("output_hashes[insights.json] = %q then %q — the receipt is not reproducible",
+			firstHash, secondHash)
+	}
+}
+
+// A repository with no findings must still write a JSON array. A nil slice marshals
+// to `null`, which breaks any consumer that iterates the parsed value without a nil
+// check — on exactly the repositories nobody thinks to test against.
+func TestWriteArtifacts_EmptyInsightsAreAnArrayNotNull(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "go.mod", "module example.com/quiet\n\ngo 1.25\n")
+	writeRepoFile(t, repo, "a/a.go", "package a\n\nfunc A() string { return \"a\" }\n")
+
+	cfg := config.Default()
+	cfg.Repo = repo
+	e, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, _ := insightsAfterSnapshot(t, e, repo, cfg.Output.Dir)
+	if raw == "null" {
+		t.Fatal("insights.json is `null` for a repository with no findings, not `[]`")
+	}
+	var parsed []any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("insights.json does not parse as an array: %v\n%s", err, raw)
+	}
+}

--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -275,20 +275,45 @@ func SymbolModule(name string) string {
 
 // MeanStdDev returns the arithmetic mean and population standard deviation of
 // the given values. Both are 0 for an empty slice.
+//
+// The result depends only on the MULTISET of values, never on the order the caller
+// supplied them in. That is a guarantee, not an accident: floating-point addition is
+// not associative, so a sequential reduction over the same numbers in a different
+// order differs in the last bits. Callers build these slices by iterating the fact
+// store, whose order reflects concurrent extraction and varies between runs — which
+// made insights.json non-reproducible across runs of an unchanged tree, on the one
+// explainer (god-class) that puts a threshold into its output rather than only using
+// it to select. facts.jsonl hid this because it is sorted before it is written.
+//
+// Sorting here rather than at each call site fixes every caller at once, including
+// the two where the same wobble is currently latent: hotspots and
+// complexity-outliers emit a constant confidence, so their thresholds affect only
+// WHICH items are selected — robust to 1e-15 until a value sits exactly on the
+// cutoff. The codebase already holds this discipline elsewhere; see
+// StronglyConnectedComponents, which documents the same determinism requirement for
+// map iteration.
 func MeanStdDev(values []float64) (mean, std float64) {
 	n := len(values)
 	if n == 0 {
 		return 0, 0
 	}
+
+	// Copied before sorting: callers pass slices they keep using, and reordering
+	// one under them would be a silent action at a distance.
+	v := append([]float64(nil), values...)
+	sort.Float64s(v)
+
 	var sum float64
-	for _, v := range values {
-		sum += v
+	for _, x := range v {
+		sum += x
 	}
 	mean = sum / float64(n)
 
+	// The second pass must read the sorted copy too. Sorting only the mean's
+	// reduction would leave the variance order-dependent, and the threshold with it.
 	var variance float64
-	for _, v := range values {
-		d := v - mean
+	for _, x := range v {
+		d := x - mean
 		variance += d * d
 	}
 	variance /= float64(n)

--- a/internal/explainers/common/determinism_test.go
+++ b/internal/explainers/common/determinism_test.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// MeanStdDev must be a function of the MULTISET, bit for bit — not of the order the
+// caller happened to iterate in.
+//
+// Float addition is not associative, so a sequential reduction over the same numbers
+// in a different order differs in the last bits. Callers build these slices by
+// walking the fact store, whose order reflects concurrent extraction and changes
+// between runs, and god-class puts the resulting threshold straight into its output:
+// across 90 runs of 30 repositories, facts.jsonl was byte-identical every time while
+// insights.json moved on one repository, 11 of 25 findings, spread ~1.9e-15.
+//
+// Bitwise equality is the right assertion. An epsilon comparison would pass on the
+// broken code, since the whole defect is a difference far below any tolerance
+// anybody would choose — and far above zero, which is what byte-comparing an
+// artifact requires.
+func TestMeanStdDev_DependsOnlyOnTheMultiset(t *testing.T) {
+	// Values that actually exercise the associativity problem: mixing magnitudes is
+	// what makes the summation order visible. A uniform slice would pass either way.
+	base := []float64{1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 1e6, 1e-6, 7, 7, 7, 0.1, 0.2, 0.3}
+	wantMean, wantStd := MeanStdDev(base)
+
+	r := rand.New(rand.NewSource(1))
+	for i := range 200 {
+		shuffled := append([]float64(nil), base...)
+		r.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+
+		mean, std := MeanStdDev(shuffled)
+		if mean != wantMean || std != wantStd {
+			t.Fatalf("shuffle %d changed the result:\n mean %v -> %v\n  std %v -> %v\n order %v",
+				i, wantMean, mean, wantStd, std, shuffled)
+		}
+	}
+}
+
+// The same guarantee, stated where the callers actually consume it.
+func TestOutlierThreshold_DependsOnlyOnTheMultiset(t *testing.T) {
+	base := []float64{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 1e5, 1e-5}
+	want := OutlierThreshold(base, 2)
+
+	r := rand.New(rand.NewSource(2))
+	for i := range 200 {
+		shuffled := append([]float64(nil), base...)
+		r.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+		if got := OutlierThreshold(shuffled, 2); got != want {
+			t.Fatalf("shuffle %d: threshold %v -> %v", i, want, got)
+		}
+	}
+}
+
+// Sorting a copy rather than in place. Callers pass slices they keep using —
+// god-class builds `values` alongside a fanIn map it indexes afterwards — so
+// reordering one under them would be a silent action at a distance.
+func TestMeanStdDev_DoesNotReorderTheCallersSlice(t *testing.T) {
+	values := []float64{5, 3, 9, 1}
+	before := append([]float64(nil), values...)
+
+	MeanStdDev(values)
+
+	for i := range values {
+		if values[i] != before[i] {
+			t.Fatalf("the caller's slice was reordered: %v -> %v", before, values)
+		}
+	}
+}

--- a/internal/explainers/godclass/determinism_test.go
+++ b/internal/explainers/godclass/determinism_test.go
@@ -1,0 +1,121 @@
+package godclass
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// ringGraph builds a symbol graph with a realistic fan-in distribution: n symbols
+// arranged in a ring so every one has at least one caller, plus extra callers drawn
+// from the same pool so fan-in spreads across 1..mod, and one hub well above the rest.
+//
+// Drawing the extra callers from the pool rather than inventing new ones is what
+// makes the fixture faithful. A generator that adds a fresh caller symbol per edge
+// floods the distribution with zero-fan-in symbols, which drags mean+kσ far below
+// the hub — the confidence then saturates at exactly 1.0 and the test asserts
+// nothing at all, however carefully it compares. (Ask me how I know.)
+func ringGraph(n, mod, hubExtra int) []facts.Fact {
+	name := func(i int) string { return fmt.Sprintf("pkg/s%d.Fn", i%n) }
+
+	targets := make([][]string, n)
+	for i := range n {
+		targets[i] = append(targets[i], name(i+1))
+	}
+	for j := range n {
+		extra := j % mod
+		if j == 0 {
+			extra = hubExtra
+		}
+		for k := range extra {
+			c := (j + 2 + k) % n
+			targets[c] = append(targets[c], name(j))
+		}
+	}
+
+	out := make([]facts.Fact, 0, n)
+	for i := range n {
+		var rels []facts.Relation
+		for _, t := range targets[i] {
+			rels = append(rels, facts.Relation{Kind: facts.RelCalls, Target: t})
+		}
+		out = append(out, facts.Fact{
+			Kind:      facts.KindSymbol,
+			Name:      name(i),
+			File:      fmt.Sprintf("pkg/s%d.go", i),
+			Relations: rels,
+		})
+	}
+	return out
+}
+
+func storeInOrder(symbols []facts.Fact) *facts.Store {
+	s := facts.NewStore()
+	s.Add(symbols...)
+	s.BuildGraph()
+	return s
+}
+
+// God-class is the only explainer that puts a computed threshold into its OUTPUT
+// rather than using it solely to select, so it must produce identical output for
+// identical inputs whatever order the fact store happens to hold them in.
+//
+// That order is not stable: it reflects concurrent extraction and varies between
+// runs of an unchanged tree. Across 90 runs of 30 repositories, facts.jsonl was
+// byte-identical every time — it is sorted before it is written — while
+// insights.json differed on one repository, 11 of 25 findings, spread ~1.9e-15,
+// because `mean + kσ` was reduced with sequential `+=` over a slice in store order
+// and float addition is not associative. Nothing a human reads changed; the
+// receipt's output_hashes["insights.json"] stopped being reproducible.
+//
+// Bitwise comparison is the point. An epsilon would pass on the broken code: the
+// whole defect lives below any tolerance anyone would pick, and above the zero that
+// byte-comparing an artifact demands.
+func TestExplain_ConfidenceDoesNotDependOnFactStoreOrder(t *testing.T) {
+	base := ringGraph(100, 10, 20)
+
+	want, err := New().Explain(context.Background(), storeInOrder(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(want) == 0 {
+		t.Fatal("fixture produced no god-class findings, so this test would assert nothing")
+	}
+	// The guard that this test needs most. `confidence` clamps to [0.5, 1], so a hub
+	// far enough above the threshold reports exactly 1.0 no matter how the threshold
+	// wobbles — and the comparison below then passes on broken and fixed code alike.
+	// The real finding sat at 0.869; this fixture sits at 0.864.
+	for _, in := range want {
+		if in.Confidence <= 0.5 || in.Confidence >= 1 {
+			t.Fatalf("confidence %v is clamped, so the threshold cannot influence it and "+
+				"this test proves nothing — retune the fixture", in.Confidence)
+		}
+	}
+
+	r := rand.New(rand.NewSource(7))
+	for i := range 50 {
+		shuffled := append([]facts.Fact(nil), base...)
+		r.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+
+		got, err := New().Explain(context.Background(), storeInOrder(shuffled))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("shuffle %d produced %d findings, want %d", i, len(got), len(want))
+		}
+		for j := range got {
+			if got[j].Title != want[j].Title {
+				t.Fatalf("shuffle %d: finding %d is %q, want %q — the finding ORDER depends on "+
+					"store order too", i, j, got[j].Title, want[j].Title)
+			}
+			if got[j].Confidence != want[j].Confidence {
+				t.Fatalf("shuffle %d: confidence for %q is %.17g, want %.17g — insights.json is "+
+					"not byte-reproducible", i, got[j].Title, got[j].Confidence, want[j].Confidence)
+			}
+		}
+	}
+}

--- a/internal/explainers/godclass/godclass.go
+++ b/internal/explainers/godclass/godclass.go
@@ -74,6 +74,12 @@ func (e *GodClassExplainer) Explain(ctx context.Context, store *facts.Store) ([]
 		seen[s.Name] = true
 		distinct = append(distinct, s)
 	}
+	// Sorted by name, so this explainer's inputs do not inherit the fact store's
+	// insertion order — which reflects concurrent extraction and varies run to run.
+	// MeanStdDev is order-independent on its own, so this is belt and braces; it is
+	// worth having because it removes the non-determinism at the source instead of
+	// relying on every downstream consumer to neutralise it.
+	sort.Slice(distinct, func(i, j int) bool { return distinct[i].Name < distinct[j].Name })
 
 	// Fan-in per symbol and the distribution used for outlier detection.
 	fanIn := make(map[string]int, len(distinct))


### PR DESCRIPTION
…er's order

Float addition is not associative, so a sequential reduction over the same values in a different order differs in the last bits. Callers build that slice by walking the fact store, whose order reflects concurrent extraction and varies between runs of an unchanged tree — and god-class is the only explainer that puts a threshold into its OUTPUT (confidence) rather than using it solely to select. Across 90 runs of 30 repositories, facts.jsonl was byte-identical every time (it is sorted before it is written) while insights.json moved on one repository: 11 of 25 findings, spread ~1.9e-15. Invisible at the two decimals anyone reads, and snapshot_id does not cover insights.json, but output_hashes["insights.json"] stopped being reproducible.

MeanStdDev now sorts a copy and reduces over it. Both loops read the sorted copy — sorting only the mean's reduction would leave the variance, and the threshold with it, order-dependent — and it copies rather than sorting in place because callers pass slices they keep using. Fixing it here rather than at the three call sites also closes the latent case in hotspots and complexity-outliers, whose constant confidences make them robust to 1e-15 only until a value sits exactly on the cutoff.

godclass additionally sorts its distinct symbols by name. Belt and braces, and verified as such: with MeanStdDev fixed the regression test passes either way. Kept because it removes the store's insertion order from the explainer's inputs instead of relying on downstream code to neutralise it.

Also fixes the minor observation filed alongside the defect: insights.json serialized as `null` rather than `[]` for a repository with no findings, breaking any consumer that iterates the parsed value without a nil check.

TestExplain_ConfidenceDoesNotDependOnFactStoreOrder runs the explainer over 50 shuffles of fact insertion order and compares confidences bitwise; on the code it replaces it reports 0.86399086126634428 against 0.86399086126634406. Its fixture draws callers from the symbols already in the graph rather than inventing one per edge: the naive shape floods the distribution with zero-fan-in symbols, the confidence saturates at the [0.5, 1] clamp, and the test then passes on broken and fixed code alike. It asserts no confidence is clamped, so it cannot decay into that. An epsilon comparison would fail the same way — the defect lives below any tolerance and above the zero a byte-comparison requires.