### PR TITLE
Record when agent hooks fire, and add `doctor` to report it

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,15 +4,26 @@
 #
 #     git config core.hooksPath .githooks
 #
-# It runs two checks:
+# It runs three checks:
 #   1. cacheVersion coverage guard (fast, no CGO): fails if a `// vN:` changelog
 #      entry in internal/engine/cache.go has no registered test in
 #      internal/cachecov/coverage_test.go — i.e. an extractor behavior was bumped
 #      without a covering test.
 #   2. golden + determinism: the extractor fact graph for the fixture repos is
 #      byte-identical to the committed goldens and reproducible across runs.
+#   3. the agent-hook end-to-end test — ONLY when the push touches the installer.
 #
-# To skip in an emergency: `git push --no-verify` (CI still enforces both).
+# Why 3 lives here and not in CI: it needs a real Claude Code session, and CI runners
+# do not run agent sessions by design. That is not a gap that can be closed by moving
+# it — the hook config is a contract owned by another product, so the check has to run
+# somewhere an agent exists. A developer's machine is the only such place, which makes
+# this hook the last line before a release. `enola doctor` is the line after it.
+#
+# It is scoped to installer changes because it costs ~90s and a few cents of API spend.
+# An unconditional gate that expensive is one people turn off, and a guard nobody runs
+# protects nothing.
+#
+# To skip in an emergency: `git push --no-verify` (CI still enforces 1 and 2).
 set -e
 
 echo "pre-push: cacheVersion coverage guard…"
@@ -20,5 +31,36 @@ go test -count=1 -run TestCacheVersionCoverage ./internal/cachecov/
 
 echo "pre-push: golden + determinism…"
 go test -count=1 -run 'TestGolden|TestDeterminism' ./internal/engine/...
+
+# ── 3. agent hooks, only when the installer moved ─────────────────────────────
+# git feeds pre-push one line per ref: <local ref> <local sha> <remote ref> <remote sha>
+zero=$(git hash-object --stdin </dev/null | tr '0-9a-f' '0')
+changed=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+	[ -z "$local_sha" ] && continue
+	[ "$local_sha" = "$zero" ] && continue # branch deletion: nothing to check
+	if [ "$remote_sha" = "$zero" ]; then
+		# New branch: compare against whatever it forked from, falling back to the
+		# previous commit rather than diffing the entire history.
+		base=$(git merge-base "$local_sha" origin/HEAD 2>/dev/null || echo "$local_sha^")
+	else
+		base="$remote_sha"
+	fi
+	changed="$changed$(git diff --name-only "$base" "$local_sha" 2>/dev/null || true)
+"
+done
+
+if printf '%s' "$changed" | grep -qE '^(pkg/install/|cmd/enola/hook\.go|cmd/enola/doctor\.go|internal/hookstate/)'; then
+	if ! command -v claude >/dev/null 2>&1; then
+		echo "pre-push: installer changed, but 'claude' is not on PATH — SKIPPING the hook"
+		echo "          end-to-end test. Nothing else can catch a hook that never fires;"
+		echo "          run it manually before releasing:"
+		echo "              ENOLA_E2E=1 go test -run TestStopHook_FiresInARealSession ./pkg/install/"
+	else
+		echo "pre-push: installer changed — agent hook end-to-end test (~90s, real session)…"
+		ENOLA_E2E=1 go test -count=1 -timeout 15m \
+			-run TestStopHook_FiresInARealSession ./pkg/install/
+	fi
+fi
 
 echo "pre-push: OK"

--- a/cmd/enola/doctor.go
+++ b/cmd/enola/doctor.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/enola-labs/enola/internal/hookstate"
+)
+
+// runDoctor is `enola doctor`: does the loop actually run in this repository?
+//
+// It exists because of a failure mode a test cannot cover. `enola install --hooks`
+// wrote a configuration the agent silently ignored, so the hooks never fired — and
+// nothing anywhere said so. The installer reported success, the hook binary worked when
+// invoked by hand, and the agent simply never called it. See DEFECTS_FOUND.md.
+//
+// The shape of that configuration is a contract owned by the agent, which ships on its
+// own schedule and can change after enola is released. So the durable check is not a
+// test in this repository — it is asking, on the machine where it matters, whether the
+// hooks have fired lately. That is all this command does.
+//
+// Exit codes follow `enola coverage`, not `enola check`: this is a report, so it exits
+// 0 whenever it ran, and 2 only for a usage error. A non-zero code from enola means
+// "your change did something", and a diagnostic must not borrow that meaning.
+func runDoctor(args []string) {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "machine-readable output")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr,
+			"Usage: enola doctor [flags] [repo_path]\n\n"+
+				"Report whether enola's agent hooks are actually firing in this repository.\n\n"+
+				"`install --hooks` can write a configuration the agent ignores — it reports\n"+
+				"success either way. This asks the only question that settles it: when did the\n"+
+				"hooks last run?\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	repoDir, err := os.Getwd()
+	if err != nil {
+		cmdFatal("doctor", "cannot determine the working directory: %v", err)
+	}
+	if rest := fs.Args(); len(rest) > 0 {
+		if !isDirectory(rest[0]) {
+			cmdFatal("doctor", "%q is not a directory", rest[0])
+		}
+		repoDir = rest[0]
+	}
+	abs, err := filepath.Abs(repoDir)
+	if err == nil {
+		repoDir = abs
+	}
+
+	outDir := hookOutputDir(repoDir)
+	state := hookstate.Load(outDir)
+	installed := hooksConfigured(repoDir)
+
+	if *asJSON {
+		out := map[string]any{
+			"repo":             repoDir,
+			"hooks_configured": installed,
+			"state":            state,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return
+	}
+
+	fmt.Printf("enola doctor: %s\n\n", repoDir)
+	fmt.Println("Session hooks")
+
+	if !installed {
+		fmt.Println("  not configured for this repository.")
+		fmt.Println("  Run `enola install --hooks` to have the loop run itself: a baseline pinned")
+		fmt.Println("  at session start, and the change graded when the session ends.")
+		return
+	}
+	fmt.Println("  configured in .claude/settings.json")
+	if !state.InstalledAt.IsZero() {
+		fmt.Printf("  installed        %s (%s ago)\n",
+			state.InstalledAt.Format(time.RFC3339), humanSince(state.InstalledAt))
+	}
+	if state.HookCommand != "" {
+		fmt.Printf("  hook command     %s\n", state.HookCommand)
+	}
+	fmt.Println()
+
+	for _, e := range []struct {
+		event hookstate.Event
+		label string
+		does  string
+	}{
+		{hookstate.EventSessionStart, "session-start", "pins the baseline your change is graded against"},
+		{hookstate.EventStop, "stop", "grades the change when the session ends"},
+	} {
+		r := state.Get(e.event)
+		fmt.Printf("  %-15s %s\n", e.label, e.does)
+		if r == nil || r.Count == 0 {
+			fmt.Printf("  %-15s NEVER FIRED\n", "")
+			continue
+		}
+		fmt.Printf("  %-15s last ran %s ago · %d run(s) · last outcome: %s\n",
+			"", humanSince(r.LastFired), r.Count, r.LastOutcome)
+	}
+
+	// The verdict, stated rather than left for the reader to assemble.
+	fmt.Println()
+	switch {
+	case !state.Fired(hookstate.EventStop) && !state.Fired(hookstate.EventSessionStart):
+		fmt.Println("  NEITHER HOOK HAS EVER RUN.")
+		fmt.Println("  The configuration exists but nothing is invoking it. Start a session in this")
+		fmt.Println("  repository and re-run; if it still says this, the agent is not reading the")
+		fmt.Println("  hooks — a shape enola writes that your agent version ignores would look")
+		fmt.Println("  exactly like this. Please report it.")
+	case !state.Fired(hookstate.EventStop):
+		fmt.Println("  THE STOP HOOK HAS NEVER RUN — the half that reports regressions.")
+		fmt.Println("  A baseline is being pinned and nothing is grading against it.")
+	case state.Get(hookstate.EventStop).LastOutcome == hookstate.OutcomeDeclined:
+		fmt.Println("  The stop hook is running, but last declined to grade: the baseline was not")
+		fmt.Println("  comparable to the current snapshot. It stays silent in-session when this")
+		fmt.Println("  happens, so it looks identical to a clean run. Re-pin with")
+		fmt.Println("  `enola baseline pin` and check `enola check` for the reason.")
+	case state.Get(hookstate.EventStop).LastOutcome == hookstate.OutcomeUnavailable:
+		fmt.Println("  The stop hook is running but has nothing to grade against — usually no")
+		fmt.Println("  baseline yet. `enola baseline pin` fixes it; the session-start hook will")
+		fmt.Println("  also do it on the next session.")
+	default:
+		fmt.Println("  Both hooks are firing. The loop is closed.")
+	}
+}
+
+// hooksConfigured reports whether .claude/settings.json carries an entry enola owns.
+//
+// Deliberately a shallow scan for the marker rather than a shape check: whether the
+// shape is one the agent honours is exactly the question this command cannot answer
+// from the file, and pretending otherwise is how the original defect survived. The
+// heartbeat answers it; this only establishes that something was written.
+func hooksConfigured(repoDir string) bool {
+	data, err := os.ReadFile(filepath.Join(repoDir, ".claude", "settings.json"))
+	if err != nil {
+		return false
+	}
+	var doc struct {
+		Hooks map[string]json.RawMessage `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return false
+	}
+	for _, raw := range doc.Hooks {
+		if containsEnolaMarker(raw) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsEnolaMarker walks arbitrary JSON looking for enola's ownership marker, so it
+// keeps working if the surrounding structure changes shape again.
+func containsEnolaMarker(raw json.RawMessage) bool {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return false
+	}
+	var walk func(any) bool
+	walk = func(n any) bool {
+		switch t := n.(type) {
+		case map[string]any:
+			if s, ok := t["source"].(string); ok && s == "enola" {
+				return true
+			}
+			for _, child := range t {
+				if walk(child) {
+					return true
+				}
+			}
+		case []any:
+			for _, child := range t {
+				if walk(child) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return walk(v)
+}
+
+// humanSince renders an age at the resolution a human cares about here — the question
+// is "recently, or never", not "how many milliseconds".
+func humanSince(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "less than a minute"
+	case d < time.Hour:
+		return fmt.Sprintf("%d minute(s)", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%d hour(s)", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%d day(s)", int(d.Hours()/24))
+	}
+}

--- a/cmd/enola/doctor_test.go
+++ b/cmd/enola/doctor_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSettings(t *testing.T, repo, body string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHooksConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			// The shape enola writes today.
+			name: "matcher-grouped with marker",
+			body: `{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"enola hook stop","source":"enola"}]}]}}`,
+			want: true,
+		},
+		{
+			// The broken shape older installs left behind. It must still be RECOGNISED —
+			// `doctor` reporting "not configured" for a repo that is configured, badly,
+			// would hide exactly the case it exists to surface.
+			name: "legacy flat entry with marker",
+			body: `{"hooks":{"Stop":[{"type":"command","command":"enola hook stop","source":"enola"}]}}`,
+			want: true,
+		},
+		{
+			name: "someone else's hooks only",
+			body: `{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"mine.sh"}]}]}}`,
+			want: false,
+		},
+		{name: "no hooks key", body: `{"permissions":{"allow":[]}}`, want: false},
+		{name: "not json", body: `{`, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeSettings(t, repo, tt.body)
+			if got := hooksConfigured(repo); got != tt.want {
+				t.Errorf("hooksConfigured = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHooksConfigured_NoSettingsFile(t *testing.T) {
+	if hooksConfigured(t.TempDir()) {
+		t.Error("a repository with no .claude/settings.json is not configured")
+	}
+}
+
+// hookOutputDir is what tells doctor and install where the heartbeat lives; if it
+// disagreed with the engine the report would read a file nothing writes.
+func TestHookOutputDir(t *testing.T) {
+	repo := t.TempDir()
+	if got, want := hookOutputDir(repo), filepath.Join(repo, ".enola"); got != want {
+		t.Errorf("default output dir = %q, want %q", got, want)
+	}
+
+	cfg := "repo: \".\"\noutput:\n  dir: \"custom-out\"\n"
+	if err := os.WriteFile(filepath.Join(repo, "mcp-arch.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := hookOutputDir(repo), filepath.Join(repo, "custom-out"); got != want {
+		t.Errorf("configured output dir = %q, want %q", got, want)
+	}
+}
+
+func TestHookOutputDir_UnreadableConfigFallsBackToDefault(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "mcp-arch.yaml"), []byte("::: not yaml :::"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A diagnostic must never be the reason something breaks.
+	if got, want := hookOutputDir(repo), filepath.Join(repo, ".enola"); got != want {
+		t.Errorf("got %q, want the default %q", got, want)
+	}
+}

--- a/cmd/enola/hook.go
+++ b/cmd/enola/hook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/enola-labs/enola/internal/engine"
 	"github.com/enola-labs/enola/internal/facts"
 	"github.com/enola-labs/enola/internal/filelock"
+	"github.com/enola-labs/enola/internal/hookstate"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/check"
 )
@@ -70,7 +71,14 @@ func runStopHook(ctx context.Context) {
 	// Silence is the norm. The gate only has something to say when a baseline was pinned
 	// during this session AND the change regressed the architecture; every other path
 	// ends here, having printed nothing.
-	verdict, ok := gradeQuietly(ctx, in.CWD)
+	verdict, outDir, ok := gradeQuietly(ctx, in.CWD)
+
+	// Record the run BEFORE deciding whether to speak, and on every path. The silent
+	// paths are the ones worth recording: a hook that never fires and a hook that fires
+	// and finds nothing are indistinguishable in a session, and only one of them is
+	// broken. See internal/hookstate and DEFECTS_FOUND.md.
+	hookstate.RecordFired(outDir, hookstate.EventStop, stopOutcome(verdict, ok))
+
 	if !ok || verdict.Status != check.StatusRegression {
 		return
 	}
@@ -164,6 +172,13 @@ func pinBaselineSingleFlight(ctx context.Context, repoDir string) {
 		return
 	}
 
+	// Recorded in the detached child rather than in the hook the agent calls, because
+	// the parent returns before knowing anything and resolving the output dir there
+	// would reintroduce the very work detaching exists to avoid. Doing nothing is still
+	// a run: "skipped" and "never fired" are different states, and only one is a fault.
+	outcome := hookstate.OutcomeSkipped
+	defer func() { hookstate.RecordFired(outDir, hookstate.EventSessionStart, outcome) }()
+
 	// Non-blocking: several agent terminals open on one repository is the documented
 	// normal case, and queueing them would turn one redundant snapshot into a series of
 	// them running back to back. Whoever gets the lock does the work; the rest do nothing.
@@ -194,6 +209,7 @@ func pinBaselineSingleFlight(ctx context.Context, repoDir string) {
 	// Stamp it as ours, so a later session may replace it and a deliberate pin may not be
 	// replaced by us. Written after SetBaseline, which republishes the directory.
 	_ = os.WriteFile(filepath.Join(baselineDir, autoPinMarker), nil, 0o644)
+	outcome = hookstate.OutcomePinned
 }
 
 // shouldAutoPin decides whether to replace the existing baseline.
@@ -227,30 +243,54 @@ func shouldAutoPin(baselineDir, repoDir, outputDir string) bool {
 	return now.Commit != base.Meta.Git.Commit
 }
 
+// stopOutcome classifies a Stop-hook run for the heartbeat.
+//
+// The distinction that earns its keep is OutcomeDeclined: the hook is silent for an
+// incomparable baseline exactly as it is silent for a clean change, and only a
+// heartbeat can tell an operator which of the two has been happening all week.
+func stopOutcome(v check.Verdict, ok bool) hookstate.Outcome {
+	if !ok {
+		return hookstate.OutcomeUnavailable
+	}
+	switch v.Status {
+	case check.StatusRegression:
+		return hookstate.OutcomeReported
+	case check.StatusIncomparable:
+		return hookstate.OutcomeDeclined
+	default:
+		return hookstate.OutcomeClean
+	}
+}
+
 // gradeQuietly runs the gate, returning ok=false for every reason a hook should stay
 // silent rather than report a problem.
-func gradeQuietly(ctx context.Context, repoDir string) (check.Verdict, bool) {
+//
+// It also returns the engine's output directory, which the caller needs to record the
+// heartbeat. That is returned even on the failure paths wherever it is known, because
+// "the hook ran and could not grade" is precisely the state worth having on record.
+func gradeQuietly(ctx context.Context, repoDir string) (check.Verdict, string, bool) {
 	if !isDirectory(repoDir) {
-		return check.Verdict{}, false
+		return check.Verdict{}, "", false
 	}
 
 	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
 	if err != nil {
-		return check.Verdict{}, false
+		return check.Verdict{}, "", false
 	}
 	cfg.Repo, cfg.Repos = repoDir, nil
 	repoPaths, err := cfg.RepoPaths()
 	if err != nil || len(repoPaths) == 0 {
-		return check.Verdict{}, false
+		return check.Verdict{}, "", false
 	}
 	anchor := repoPaths[0]
+	outDir := eng.OutputDir(anchor)
 
 	// Load the baseline BEFORE snapshotting. Without one there is nothing to grade, and
 	// checking first means the common case costs nothing rather than paying for a full
 	// snapshot to discover it was pointless.
-	base, err := bootstrap.LoadSnapshotDir(engine.ResolveBaselineDir(eng.OutputDir(anchor), "pinned"))
+	base, err := bootstrap.LoadSnapshotDir(engine.ResolveBaselineDir(outDir, "pinned"))
 	if err != nil {
-		return check.Verdict{}, false
+		return check.Verdict{}, outDir, false
 	}
 
 	// Read-only, exactly like `enola check`: the hook must not mutate the repository's
@@ -258,16 +298,16 @@ func gradeQuietly(ctx context.Context, repoDir string) (check.Verdict, bool) {
 	eng.SetPersistCache(false)
 	for i, p := range repoPaths {
 		if _, err := eng.GenerateSnapshot(ctx, p, i > 0); err != nil {
-			return check.Verdict{}, false
+			return check.Verdict{}, outDir, false
 		}
 	}
 	snap := eng.Snapshot()
 	if snap == nil || eng.Store().Count() == 0 {
-		return check.Verdict{}, false
+		return check.Verdict{}, outDir, false
 	}
 	current := &facts.Snapshot{Meta: snap.Meta, Facts: eng.Store().All(), Insights: snap.Insights}
 
-	return check.Evaluate(diff.Compute(base, current), check.Policy{}), true
+	return check.Evaluate(diff.Compute(base, current), check.Policy{}), outDir, true
 }
 
 // configForRepo prefers a config inside the repository, matching how `enola check`

--- a/cmd/enola/install.go
+++ b/cmd/enola/install.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/hookstate"
 	"github.com/enola-labs/enola/pkg/install"
 )
 
@@ -148,9 +150,48 @@ func runInstall(args []string, remove bool) {
 	fmt.Println()
 	printPlan(applied)
 
+	// Stamp the heartbeat so `enola doctor` can later say "installed on X, never fired
+	// since" — the one report that distinguishes hooks that are wired up from hooks that
+	// merely look wired up. Local scope only: a global install has no repository whose
+	// output directory could hold the record.
+	if opts.Scope == install.ScopeLocal {
+		if outDir := hookOutputDir(repoDir); outDir != "" {
+			switch {
+			case remove:
+				// A stale "never fired since <date>" after the hooks were deliberately
+				// removed would be a false alarm, so the record goes with them.
+				hookstate.Clear(outDir)
+			case opts.Hooks:
+				hookstate.RecordInstalled(outDir, opts.HookCommand)
+			}
+		}
+	}
+
 	if !remove && opts.Hooks {
 		fmt.Println("\nRestart your agent session for the hooks to take effect.")
+		fmt.Println("Then `enola doctor` will tell you whether they are actually firing.")
 	}
+}
+
+// hookOutputDir resolves a repository's enola output directory without building an
+// engine, so `install` neither pays for plugin registration nor emits the engine's
+// config line in the middle of its own report.
+//
+// It mirrors what the hooks themselves do: a repo-local mcp-arch.yaml when there is
+// one, built-in defaults otherwise. A config that cannot be read falls back to the
+// defaults rather than failing the install — the heartbeat is a diagnostic, and a
+// diagnostic must never be the reason an install breaks.
+func hookOutputDir(repoDir string) string {
+	cfg := config.Default()
+	if p := filepath.Join(repoDir, "mcp-arch.yaml"); fileExists(p) {
+		if loaded, err := config.Load(p); err == nil {
+			cfg = loaded
+		}
+	}
+	if err := cfg.Normalize(); err != nil {
+		return ""
+	}
+	return filepath.Join(repoDir, cfg.Output.Dir)
 }
 
 func act(o install.Options, remove bool) ([]install.Result, error) {

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -47,6 +47,9 @@ func main() {
 		case "coverage":
 			runCoverage(ctx, os.Args[2:])
 			os.Exit(0)
+		case "doctor":
+			runDoctor(os.Args[2:])
+			os.Exit(0)
 		case "baseline":
 			runBaseline(os.Args[2:])
 			os.Exit(0)
@@ -314,7 +317,7 @@ func runExplain(ctx context.Context, eng *bootstrap.Engine, cfg *config.Config, 
 
 // knownSubcommands are dispatched before the flag loop. Listed here so an argument that
 // was MEANT to be one gets a targeted message instead of a generic path error.
-var knownSubcommands = []string{"check", "coverage", "baseline", "install", "uninstall", "upgrade"}
+var knownSubcommands = []string{"check", "coverage", "doctor", "baseline", "install", "uninstall", "upgrade"}
 
 // unknownArgHelp explains a rejected argument in terms of what the caller probably meant.
 //

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -60,7 +60,7 @@ The install script installs **only the binary**, by design - it does not place a
 curl -fsSL https://raw.githubusercontent.com/enola-labs/enola/main/mcp-arch.yaml -o mcp-arch.yaml
 ```
 
-The [`examples/`](../examples/) directory has ready-made per-language and multi-repo starting points, and [`examples/full.yaml`](../examples/full.yaml) documents every option. For the full field reference and defaults, see **[ARCHITECTURE.md → Configuration](ARCHITECTURE.md#configuration)**.
+The [`examples/`](../examples/) directory has ready-made per-language and multi-repo starting points, and [`examples/full.yaml`](../examples/full.yaml) documents every option. For the full field reference and defaults, see **[ARCHITECTURE.md → Configuration](../ARCHITECTURE.md#configuration)**.
 
 ### Connect it to your agent
 
@@ -183,7 +183,7 @@ Some questions don't need an agent at all. The MCP server also serves a **read-o
 - *What did the analysis find?* - every insight grouped by explainer and filterable by confidence, so you can see the cycles and hotspots without asking a model to list them.
 - *Is this snapshot trustworthy?* - the receipt: snapshot ID, enola version, git ref and dirty flag, extractors used.
 - *Why does this snapshot look thin?* - extraction quality: files seen vs. parsed vs. skipped, parse errors with samples, unresolved cross-repo edges, coverage gaps.
-- *What has this actually saved me?* - the same value estimate `--status` prints, per tool and lifetime ([how it's calculated](ARCHITECTURE.md#the-value-model)).
+- *What has this actually saved me?* - the same value estimate `--status` prints, per tool and lifetime ([how it's calculated](../ARCHITECTURE.md#the-value-model)).
 
 Reading it costs nothing and burns no context. It's also the fastest way to sanity-check a snapshot before you trust an answer built on it.
 
@@ -357,7 +357,7 @@ Code health
 
 No artifacts are written; `.enola/` is not touched. For a persistent snapshot with agent-readable output, use `--generate` or the MCP server.
 
-For interactive per-module blast-radius queries with configurable depth, see the `impact_analysis` tool reference in **[ARCHITECTURE.md → The tools](ARCHITECTURE.md#the-tools)**.
+For interactive per-module blast-radius queries with configurable depth, see the `impact_analysis` tool reference in **[ARCHITECTURE.md → The tools](../ARCHITECTURE.md#the-tools)**.
 
 ---
 
@@ -373,6 +373,7 @@ Every path argument follows the same rule: **a directory is a repository, a file
 |------|--------------|
 | `install [--hooks] [--global]` | **Tell your coding agents enola is here.** Writes its instructions into the files they actually read - `.claude/rules/enola.md`, `.cursor/rules/enola.mdc`, and a marked block in `AGENTS.md` if you have one. Previews every change and asks before writing. See [Wiring it into your agents](#wiring-it-into-your-agents---enola-install). |
 | `coverage [--repo=<svc>] [--unresolved] [--json]` | **Which cross-repo edges enola resolved, and which it did not** — per service, so you can tell a genuinely isolated service from one whose outbound edges enola could not follow. The unresolved list is always shown: it is what makes the resolved count worth believing, and each entry is either a repository you have not loaded, a third-party endpoint, or a blind spot in enola. Needs two or more repositories in one graph. A report, not a gate — it always exits `0`. |
+| `doctor [repo]` | **Are the session hooks actually firing?** `install --hooks` writes a hook configuration and reports success — but whether your agent honours that configuration is a contract owned by the agent, not by enola, and a config it ignores looks identical to one it runs. So the hooks record every time they fire, *including* the runs where they deliberately say nothing, and this reports when each last ran and what it concluded. `NEVER FIRED` after a real session means the wiring is not working. A report, not a gate — it always exits `0`. |
 | `uninstall [--global]` | Remove everything `install` wrote, leaving the rest of each file byte-for-byte as it was. |
 | `baseline pin\|show\|clear [repo\|config]` | Manage the diff baseline - the "before" a change is graded against. `pin` snapshots the repository and freezes it (no separate `--generate` needed); `show` reports what the current baseline describes; `clear` removes it. Stored per repository, in that repo's `.enola/baseline`, so several repos each keep their own. |
 | `check [flags] [repo\|config]` | **Grade what a change did to the architecture**, and exit with a code CI can act on. Read-only: writes nothing and leaves the baseline in place, so it can be run repeatedly. See [The gate](#the-gate---enola-check). |
@@ -548,7 +549,7 @@ Run the same session again over an unchanged repo and it collapses to a few thou
 
 Be clear about what these numbers are. They answer one question: **what would an agent have had to ingest to reach the same answer with ordinary tools - grep, glob, open a file, read it, infer?** So a snapshot is priced from the *corpus it indexed*, measured, not from the fact that a call happened; a 17.9K-token service and the 218M-token Linux kernel are not the same act of work, and no flat per-call price is right for both. Reading time converts to your time waiting on the agent, including the rework a non-deterministic reconstruction implies. Failed calls are counted but earn nothing, and the tokens you spend reading enola's own response are subtracted - so `output_mode='summary'` genuinely scores better than `'full'`.
 
-They're an estimate, labelled as one - but the inputs are real: corpus sizes measured at snapshot time, call counts recorded per repository under `~/.enola/usage/`. They survive server restarts and deleting a repo's `.enola/` directory, and `--status` works from any directory, not just a snapshotted one. The full model, its constants and what it deliberately leaves out are in [ARCHITECTURE.md](ARCHITECTURE.md#the-value-model).
+They're an estimate, labelled as one - but the inputs are real: corpus sizes measured at snapshot time, call counts recorded per repository under `~/.enola/usage/`. They survive server restarts and deleting a repo's `.enola/` directory, and `--status` works from any directory, not just a snapshotted one. The full model, its constants and what it deliberately leaves out are in [ARCHITECTURE.md](../ARCHITECTURE.md#the-value-model).
 
 **The dagger matters more than the number.** When the corpus exceeds what an agent can hold at once - as an 8-repo ecosystem or a large monorepo does - the counterfactual isn't expensive, it's *impossible*: cross-repo edges can't be derived by re-reading files when both sides can't be in context together. Those rows are flagged, because "not reproducible by re-reading" is a stronger claim than any figure.
 
@@ -596,7 +597,7 @@ To run a one-shot snapshot without starting the MCP server:
 enola --generate [config_path]   # config_path is optional; defaults to mcp-arch.yaml, falling back to built-in defaults if absent
 ```
 
-Artifacts are written to the configured `output.dir` (default `.enola/`). The config file is optional - see **[ARCHITECTURE.md → Configuration](ARCHITECTURE.md#configuration)** for the full field reference and defaults.
+Artifacts are written to the configured `output.dir` (default `.enola/`). The config file is optional - see **[ARCHITECTURE.md → Configuration](../ARCHITECTURE.md#configuration)** for the full field reference and defaults.
 
 **Indexing a whole cluster in one command.** Cross-repo linking needs several repositories in one graph. Name them with `repos:` and a single run indexes them all - the first fresh, the rest appended - producing the service nodes, cross-repo edges, `coverage_report` and unused-route findings that a single-repo snapshot cannot have:
 

--- a/internal/hookstate/hookstate.go
+++ b/internal/hookstate/hookstate.go
@@ -1,0 +1,191 @@
+// Package hookstate records when enola's agent hooks last ran.
+//
+// It exists because of a defect that no test in this repository could have caught.
+// `enola install --hooks` wrote the Stop hook in a JSON shape the agent ignored, so
+// the hooks never fired — and every cheaper check passed while it was broken: the
+// installer wrote the file it meant to, the hook binary produced the right verdict
+// when invoked by hand, and a unit test asserted the shape against the same belief
+// that produced it. See DEFECTS_FOUND.md.
+//
+// The shape of that config is a contract owned by the agent, which ships on its own
+// schedule and can change after enola is released. So it is not testable here in any
+// durable way: the only defence that survives the contract moving is noticing, on the
+// machine where it matters, that the hooks have stopped firing.
+//
+// Hence a heartbeat. Every hook invocation records that it ran — INCLUDING the runs
+// where it deliberately says nothing, which is the overwhelming majority and the whole
+// point. Silence was the defect's entire signature; a hook that has never fired is now
+// distinguishable from one that fires and finds nothing to report.
+package hookstate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileName is the heartbeat file, written inside the engine's output directory.
+//
+// It is deliberately NOT one of engine.snapshotArtifactFiles, so `baseline pin` does
+// not copy it into baseline/ and a heartbeat can never be mistaken for snapshot state.
+// The output directory is excluded from indexing, so this file contributes no facts
+// and cannot affect a snapshot ID.
+const FileName = "hooks.json"
+
+// Outcome is what a hook run concluded. Recorded because "fired 40 times and always
+// declined to grade" and "fired 40 times and found nothing wrong" look identical from
+// a timestamp alone, and only one of them is a problem.
+type Outcome string
+
+const (
+	// OutcomeReported: a regression was found and handed back to the agent.
+	OutcomeReported Outcome = "reported"
+	// OutcomeClean: graded successfully, nothing to report. The normal case.
+	OutcomeClean Outcome = "clean"
+	// OutcomeDeclined: the baseline was not comparable, so no verdict was possible.
+	// The hook stays silent in-session; this is where that silence becomes visible.
+	OutcomeDeclined Outcome = "declined"
+	// OutcomeUnavailable: nothing to grade against — usually no baseline pinned yet.
+	OutcomeUnavailable Outcome = "unavailable"
+	// OutcomePinned: the session-start hook froze a baseline.
+	OutcomePinned Outcome = "pinned"
+	// OutcomeSkipped: the session-start hook deliberately did no work — a deliberate
+	// baseline it must not replace, an unchanged tree, or another session holding the lock.
+	OutcomeSkipped Outcome = "skipped"
+)
+
+// Event names a hook. These match the `enola hook <event>` subcommands.
+type Event string
+
+const (
+	EventStop         Event = "stop"
+	EventSessionStart Event = "session-start"
+)
+
+// Record is one event's history. Count is cumulative; the timestamps bound it.
+type Record struct {
+	FirstFired  time.Time `json:"first_fired"`
+	LastFired   time.Time `json:"last_fired"`
+	Count       int       `json:"count"`
+	LastOutcome Outcome   `json:"last_outcome,omitempty"`
+}
+
+// State is the whole file.
+type State struct {
+	// InstalledAt is when `install --hooks` last configured this repository. It is what
+	// makes "never fired" meaningful: without it, an empty file cannot be told apart
+	// from hooks that were never installed in the first place.
+	InstalledAt time.Time          `json:"installed_at,omitempty"`
+	Events      map[Event]*Record  `json:"events,omitempty"`
+	// HookCommand records which binary the installed hooks invoke, so a heartbeat that
+	// stopped can be attributed to a moved or replaced enola rather than to the agent.
+	HookCommand string `json:"hook_command,omitempty"`
+}
+
+// Fired reports whether the event has ever run.
+func (s State) Fired(e Event) bool {
+	r, ok := s.Events[e]
+	return ok && r.Count > 0
+}
+
+// Get returns the record for an event, or nil.
+func (s State) Get(e Event) *Record { return s.Events[e] }
+
+// Path returns the heartbeat file's location for an output directory.
+func Path(outDir string) string { return filepath.Join(outDir, FileName) }
+
+// Load reads the heartbeat. A missing or unreadable file is not an error: it means
+// "nothing recorded", which is a legitimate state and the one a fresh repository is in.
+func Load(outDir string) State {
+	var s State
+	data, err := os.ReadFile(Path(outDir))
+	if err != nil {
+		return s
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{} // a corrupt heartbeat is worth less than no heartbeat
+	}
+	return s
+}
+
+// RecordFired stamps an event. Best-effort and silent by contract: this is called from
+// a hook, and a hook that cannot fail loudly must not try. Every error path returns
+// without disturbing the caller.
+func RecordFired(outDir string, e Event, o Outcome) {
+	mutate(outDir, func(s *State) {
+		if s.Events == nil {
+			s.Events = map[Event]*Record{}
+		}
+		r := s.Events[e]
+		if r == nil {
+			r = &Record{FirstFired: now()}
+			s.Events[e] = r
+		}
+		r.LastFired = now()
+		r.Count++
+		r.LastOutcome = o
+	})
+}
+
+// RecordInstalled stamps the install time and the hook command, so a later report can
+// say "installed on X, never fired since".
+func RecordInstalled(outDir, hookCommand string) {
+	mutate(outDir, func(s *State) {
+		s.InstalledAt = now()
+		s.HookCommand = hookCommand
+	})
+}
+
+// Clear removes the heartbeat, for `uninstall`. A stale "never fired since <date>"
+// after the hooks were deliberately removed would be a false alarm.
+func Clear(outDir string) { _ = os.Remove(Path(outDir)) }
+
+// now is a variable so tests can pin it.
+var now = func() time.Time { return time.Now().UTC().Truncate(time.Second) }
+
+// mutate applies fn to the current state and writes it back atomically.
+//
+// Read-modify-write without locking is deliberate. Several agent sessions on one
+// repository is the documented normal case, so a concurrent update can lose a count —
+// which costs nothing, because the question this answers is "has it fired at all, and
+// when last", not "exactly how many times". What must NOT happen is a torn file, and
+// the temp-plus-rename below makes that impossible: a reader sees either the old file
+// or the new one. Taking a lock here would mean a hook waiting on another hook, which
+// is exactly what these hooks are built never to do.
+func mutate(outDir string, fn func(*State)) {
+	if outDir == "" {
+		return
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return
+	}
+	s := Load(outDir)
+	fn(&s)
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	// Staged in the same directory so the rename stays on one filesystem: across a
+	// mount boundary os.Rename fails with EXDEV and the atomicity is lost.
+	tmp, err := os.CreateTemp(outDir, "."+FileName+".tmp-")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, Path(outDir)); err != nil {
+		_ = os.Remove(tmpName)
+	}
+}

--- a/internal/hookstate/hookstate_test.go
+++ b/internal/hookstate/hookstate_test.go
@@ -1,0 +1,178 @@
+package hookstate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLoad_MissingFileIsNotAnError(t *testing.T) {
+	s := Load(t.TempDir())
+	if s.Fired(EventStop) || s.Fired(EventSessionStart) {
+		t.Error("a repository with no heartbeat must report nothing fired")
+	}
+	if !s.InstalledAt.IsZero() {
+		t.Error("InstalledAt should be zero when nothing was recorded")
+	}
+}
+
+// The distinction the whole package exists for: a hook that fired and found nothing is
+// not a hook that never fired, even though both are silent in the session.
+func TestRecordFired_SilentRunIsStillRecorded(t *testing.T) {
+	dir := t.TempDir()
+	RecordFired(dir, EventStop, OutcomeClean)
+
+	s := Load(dir)
+	if !s.Fired(EventStop) {
+		t.Fatal("a clean (silent) stop run must still be recorded as fired")
+	}
+	r := s.Get(EventStop)
+	if r.Count != 1 {
+		t.Errorf("Count = %d, want 1", r.Count)
+	}
+	if r.LastOutcome != OutcomeClean {
+		t.Errorf("LastOutcome = %q, want %q", r.LastOutcome, OutcomeClean)
+	}
+	if r.FirstFired.IsZero() || r.LastFired.IsZero() {
+		t.Error("both timestamps should be set on the first run")
+	}
+}
+
+func TestRecordFired_AccumulatesAndKeepsFirstFired(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC)
+	restore := now
+	defer func() { now = restore }()
+
+	now = func() time.Time { return base }
+	RecordFired(dir, EventStop, OutcomeClean)
+	now = func() time.Time { return base.Add(2 * time.Hour) }
+	RecordFired(dir, EventStop, OutcomeReported)
+
+	r := Load(dir).Get(EventStop)
+	if r.Count != 2 {
+		t.Errorf("Count = %d, want 2", r.Count)
+	}
+	if !r.FirstFired.Equal(base) {
+		t.Errorf("FirstFired moved: %v, want %v", r.FirstFired, base)
+	}
+	if !r.LastFired.Equal(base.Add(2 * time.Hour)) {
+		t.Errorf("LastFired = %v, want the later stamp", r.LastFired)
+	}
+	if r.LastOutcome != OutcomeReported {
+		t.Errorf("LastOutcome = %q, want the most recent one", r.LastOutcome)
+	}
+}
+
+func TestRecordFired_EventsAreIndependent(t *testing.T) {
+	dir := t.TempDir()
+	RecordFired(dir, EventSessionStart, OutcomePinned)
+
+	s := Load(dir)
+	if !s.Fired(EventSessionStart) {
+		t.Error("session-start should be recorded")
+	}
+	// The half-installed case this package is meant to surface.
+	if s.Fired(EventStop) {
+		t.Error("stop must NOT be reported as fired just because session-start did")
+	}
+}
+
+func TestRecordInstalled_MakesNeverFiredMeaningful(t *testing.T) {
+	dir := t.TempDir()
+	RecordInstalled(dir, "/usr/local/bin/enola")
+
+	s := Load(dir)
+	if s.InstalledAt.IsZero() {
+		t.Error("InstalledAt not recorded")
+	}
+	if s.HookCommand != "/usr/local/bin/enola" {
+		t.Errorf("HookCommand = %q", s.HookCommand)
+	}
+	if s.Fired(EventStop) {
+		t.Error("installing must not look like firing")
+	}
+}
+
+func TestRecordInstalled_PreservesExistingHistory(t *testing.T) {
+	dir := t.TempDir()
+	RecordFired(dir, EventStop, OutcomeClean)
+	RecordInstalled(dir, "enola")
+
+	if !Load(dir).Fired(EventStop) {
+		t.Error("re-installing must not erase the run history")
+	}
+}
+
+func TestClear_RemovesTheRecord(t *testing.T) {
+	dir := t.TempDir()
+	RecordFired(dir, EventStop, OutcomeClean)
+	Clear(dir)
+
+	if Load(dir).Fired(EventStop) {
+		t.Error("Clear should remove the heartbeat, so uninstall leaves no false alarm")
+	}
+	if _, err := os.Stat(Path(dir)); !os.IsNotExist(err) {
+		t.Error("the file itself should be gone")
+	}
+}
+
+// A hook must never fail loudly, so every error path has to be silent and harmless.
+func TestRecordFired_UnwritableDirIsSilent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nope")
+	if err := os.WriteFile(dir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	RecordFired(dir, EventStop, OutcomeClean) // must not panic
+	RecordFired("", EventStop, OutcomeClean)  // nor on an empty path
+}
+
+func TestLoad_CorruptFileDegradesToEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(Path(dir), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if Load(dir).Fired(EventStop) {
+		t.Error("a corrupt heartbeat must read as 'nothing recorded', not crash or lie")
+	}
+}
+
+// Concurrent sessions on one repository are the documented normal case. A lost count is
+// acceptable; a torn file that reads back as corrupt is not.
+func TestRecordFired_ConcurrentWritesLeaveValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			RecordFired(dir, EventStop, OutcomeClean)
+		}()
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatalf("heartbeat missing after concurrent writes: %v", err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("heartbeat is not valid JSON after concurrent writes: %v\n%s", err, data)
+	}
+	if !s.Fired(EventStop) {
+		t.Error("at least one of the concurrent writes should have landed")
+	}
+}
+
+// The heartbeat lives in the output directory but must never be mistaken for snapshot
+// state: engine.copyArtifacts copies a fixed list, and this file is not on it.
+func TestFileName_IsNotASnapshotArtifact(t *testing.T) {
+	for _, artifact := range []string{"facts.jsonl", "insights.json", "snapshot.meta.json", "receipt.json"} {
+		if FileName == artifact {
+			t.Fatalf("%s collides with a snapshot artifact name", FileName)
+		}
+	}
+}

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -79,6 +79,7 @@ func DefaultHelp(bin Binary) HelpSpec {
 			bin.Name + " baseline <pin|show|clear> [repo_path|config_path]",
 			bin.Name + " check [flags] [repo_path|config_path]",
 			bin.Name + " coverage [flags] [repo_path|config_path]",
+			bin.Name + " doctor [repo_path]",
 			bin.Name + " install [--hooks] [--global] [repo_path]",
 		},
 		Commands: []FlagDoc{
@@ -87,6 +88,7 @@ func DefaultHelp(bin Binary) HelpSpec {
 			{Flag: "baseline", Desc: "Manage the diff baseline — the \"before\" your changes are graded\nagainst. \"pin\" snapshots the repository and freezes it (no separate\n--generate needed), \"show\" reports what the current baseline\ndescribes, \"clear\" removes it. The baseline is stored per-repository,\nin that repo's output dir, so several repos each keep their own."},
 			{Flag: "check", Desc: "Grade what a change did to the architecture against the pinned\nbaseline, and exit with a code CI can act on:\n  0 clean · 1 regression · 2 error · 3 declined (not comparable)\nRead-only by default — nothing is written, and the baseline stays\nput, so it can be run as often as you like. Run\n\"" + bin.Name + " check --help\" for the flags."},
 			{Flag: "coverage", Desc: "Report which cross-repo edges were resolved and which were not,\nper service — telling a genuinely isolated service apart from one\nwhose outbound edges could not be followed. Needs two or more\nrepositories in one graph. A report, not a gate: always exits 0."},
+			{Flag: "doctor", Desc: "Report whether the session hooks are actually FIRING in this\nrepository, not merely configured. `install --hooks` can write a\nconfiguration your agent silently ignores — it reports success\neither way — so this asks the only question that settles it: when\ndid each hook last run, and what did it conclude? A report, not a\ngate: always exits 0."},
 		},
 		Flags: []FlagDoc{
 			{Flag: "--generate", Desc: "Generate a snapshot and exit (do not start MCP server)"},
@@ -117,6 +119,7 @@ func DefaultHelp(bin Binary) HelpSpec {
 			{Comment: "Report a regression without failing the build", Command: bin.Name + " check --warn-only"},
 			{Comment: "See which cross-repo edges resolved, and which did not", Command: bin.Name + " coverage cluster.yaml"},
 			{Comment: "Just the blind spots", Command: bin.Name + " coverage --unresolved cluster.yaml"},
+			{Comment: "Are the session hooks actually firing?", Command: bin.Name + " doctor"},
 			{Comment: "Compare against the preceding snapshot instead of the pin", Command: bin.Name + " check --baseline=previous"},
 			{Comment: "Also fail on new layer violations", Command: bin.Name + " check --fail-on=cycles,layers --min-confidence=0.8"},
 			{Comment: "Check MCP server status", Command: bin.Name + " --status"},


### PR DESCRIPTION
The session hooks were registered in a shape the agent ignored, so they never ran — and nothing said so. The installer reported success, the hook binary produced the right verdict when invoked by hand, and a unit test asserted the shape against the same belief that produced it. Silence was the entire signature.

That shape is a contract owned by another product, which ships on its own schedule and can change after a release. No test here would notice, and there is no schema to validate against offline, so this is not preventable by testing enola alone. The defence that survives the contract moving is noticing, on the machine where it matters, that the hooks stopped firing.

- internal/hookstate: every hook invocation stamps <output.dir>/hooks.json, INCLUDING the runs that deliberately say nothing. Those are the majority and the point: "fired and found nothing" and "never fired" are identical in a session and only one is a fault.
- install --hooks stamps the install time, so "never fired since" means something; uninstall clears it, so a removed hook raises no false alarm.
- enola doctor: when each hook last ran, what it concluded, and a verdict. Reports the marker only — whether the shape is honoured is exactly what the file cannot say, and pretending otherwise is how this survived. Exits 0 always: a non-zero code means "your change did something", and a diagnostic must not borrow that meaning.
- .githooks/pre-push runs the end-to-end test when the push touches the installer. Runners do not run agent sessions, so it cannot live in CI; scoping keeps a ~90s gate switched on rather than disabled.

The heartbeat is not a snapshot artifact, so `baseline pin` never copies it, and the output dir is excluded from indexing — three snapshots of a hooks-installed repo produce identical snapshot IDs. Writes are temp-plus-rename without a lock: a concurrent update may lose a count, which costs nothing; a torn file cannot happen.

Verified against the defect it exists to catch. With the Stop entry regressed to the old shape, one real session later doctor reports NEVER FIRED for both hooks; on the fixed one, both are firing.