### PR TITLE
- examples/multi-repo.yaml: stop pinning five extractors. The file pr…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,18 @@ Thank you for your interest in contributing to enola. Every contribution — cod
    git checkout -b my-feature
    ```
 
+5. **Enable the pre-push hook** — once per clone:
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+   It runs the guards that are cheap locally and awkward in CI: the `cacheVersion`
+   coverage check, and the golden + determinism suite. Skip in an emergency with
+   `git push --no-verify`; CI enforces both anyway.
+
+   It also runs one check **CI cannot run at all**. See below.
+
 ## What to work on
 
 - **Bug reports and fixes** — if something doesn't work, open an issue or submit a fix.
@@ -40,6 +52,30 @@ If you're considering a larger change, please open an issue first so we can disc
    ```
 
 5. Open a pull request against `main`. Describe what the change does and why.
+
+### If you touch the agent hooks
+
+`pkg/install/`, `cmd/enola/hook.go`, `cmd/enola/doctor.go` and `internal/hookstate/`
+are covered by one test CI will never run for you:
+
+```bash
+ENOLA_E2E=1 go test -run TestStopHook_FiresInARealSession ./pkg/install/
+```
+
+It installs the hooks the way a user does, ends a **real agent session** with a known
+regression present, and asserts the verdict came out. CI runners do not run agent
+sessions by design, so this only ever executes on a developer's machine — the pre-push
+hook runs it automatically when your push touches one of those paths, and skips with a
+loud message if `claude` is not on your `PATH`.
+
+Please do not treat it as optional. The failure mode it guards against is a hook
+configuration that parses, reports success, and does nothing: every cheaper check
+passed while the `Stop` hook was silently never firing, because a unit test can only
+compare the output against the same belief that produced it. The full account is in
+[`DEFECTS_FOUND.md`](DEFECTS_FOUND.md).
+
+If you cannot run it, say so in the PR so a reviewer can. `enola doctor` is the
+same question asked after the fact, on a real repository.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ claude mcp add enola enola
 
 `enola install` writes a short instruction into the files your agents already read — Claude Code, Cursor, Copilot, Codex, Pi — and `--hooks` adds the two hooks that run the loop for you. It previews every change and asks before writing, never creates files you didn't have, and `enola uninstall` puts everything back byte-for-byte.
 
+After your next session, `enola doctor` reports whether those hooks actually fired. Worth running once: a hook configuration is a contract with your agent, and one it quietly ignores looks exactly like one it honours.
+
 Prefer to drive it yourself? Skip step 2 and run the loop by hand:
 
 ```bash

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,404 @@
+# Benchmarks
+
+Everything here was measured on 2026-07-31, on 38 public open-source repositories,
+with one binary, by scripts you can re-run. Where a number is unflattering it is
+still here.
+
+## What is measured, and why these five things
+
+A code graph for agents is usually benchmarked on retrieval: how few tool calls,
+how few tokens, how fast the agent finds the right file. Those are real questions,
+and enola is not benchmarked on them here. They measure how quickly an agent
+reaches code it was going to read anyway.
+
+The questions below are the ones that decide whether a *structural verdict* about
+your change can be believed:
+
+| | The question | Why it cannot be skipped |
+|---|---|---|
+| **1** | Does the same commit produce the same graph? | A diff between two snapshots is meaningless if the snapshots are not reproducible |
+| **2** | When something regresses, is exactly that reported? | A gate that also reports pre-existing problems gets switched off in a week |
+| **3** | Of the cross-repo edges that exist, how many are found — and are the misses shown? | A resolved-only count is advertising |
+| **4** | Does it finish on a real repository? | A graph you cannot build is not a graph |
+| **5** | Does an agent, given the tool, actually avoid shipping the regression? | The honest test of the whole idea |
+
+Axes 1–3 have no counterpart in a retrieval benchmark, because you cannot report a
+delta without a baseline, and you cannot report a miss without knowing what a hit
+would have been.
+
+## The corpus
+
+38 repositories, 239,349 source files parsed, 4,211,113 facts carrying 13 distinct
+language tags (C, C++, Go, Java, Kotlin, PHP, Python, Ruby, Rust, Swift, TypeScript,
+gRPC, OpenAPI). Public open-source only — every row is a repository you can clone and
+re-run.
+
+| Repository | Language | Files parsed | Facts | Modules | Routes | Cold | Warm |
+|---|---|---|---|---|---|---|---|
+| linux | C | 55,399 | 1,892,343 | 4,293 | 0 | 157.6s | 33.9s |
+| gitlab | Ruby | 47,711 | 435,020 | 10,484 | 1,848 | 29.1s | 19.4s |
+| rust | Rust | 36,090 | 394,970 | 3,759 | 0 | 20.4s | 9.1s |
+| shopware | PHP | 13,731 | 218,814 | 4,188 | 724 | 11.1s | 4.9s |
+| grafana | Go | 10,310 | 163,620 | 2,295 | 1,714 | 7.5s | 5.0s |
+| thingsboard | Java | 6,371 | 158,987 | 1,164 | 1,403 | 4.8s | 3.1s |
+| nextcloud-server | PHP | 6,037 | 101,462 | 1,538 | 12 | 5.9s | 2.0s |
+| discourse | Ruby | 10,353 | 93,295 | 1,483 | 1,217 | 6.9s | 4.1s |
+| dubbo | Java | 4,351 | 82,550 | 954 | 19 | 4.7s | 1.9s |
+| supabase | TypeScript | 6,918 | 70,203 | 1,679 | 83 | 5.6s | 2.4s |
+| airflow | Python | 4,061 | 67,992 | 1,261 | 463 | 8.7s | 5.3s |
+| deno | Rust | 4,353 | 62,118 | 2,056 | 4 | 7.8s | 2.0s |
+| superset | Python | 3,834 | 51,645 | 984 | 302 | 4.8s | 2.7s |
+| cal.com | TypeScript | 4,596 | 48,637 | 1,453 | 270 | 3.0s | 1.5s |
+| dbt-core | Rust | 1,371 | 46,935 | 321 | 202 | 2.9s | 1.0s |
+| wordpress | PHP | 2,840 | 45,681 | 441 | 6,671 | 5.5s | 1.2s |
+| gmsh | C++ | 1,679 | 41,348 | 86 | 0 | 2.9s | 0.8s |
+| chatwoot | Ruby | 3,643 | 36,046 | 863 | 744 | 2.1s | 1.3s |
+| gitea | Go | 2,210 | 34,088 | 395 | 758 | 1.5s | 1.1s |
+| saleor | Python | 2,473 | 30,052 | 202 | 4 | 3.1s | 2.1s |
+| flarum | PHP | 2,702 | 28,300 | 764 | 11 | 1.3s | 0.7s |
+| cognee | Python | 1,489 | 16,909 | 394 | 214 | 1.7s | 0.8s |
+| cognee-rs | Rust | 846 | 15,827 | 124 | 77 | 1.1s | 0.4s |
+| tokio | Rust | 780 | 14,450 | 99 | 0 | 0.8s | 0.3s |
+| crates-io | Rust | 878 | 12,451 | 214 | 96 | 0.8s | 0.4s |
+| solidus | Ruby | 1,766 | 10,009 | 383 | 171 | 0.9s | 0.7s |
+| excalidraw | TypeScript | 526 | 8,738 | 85 | 3 | 0.9s | 0.4s |
+| isowords | Swift | 382 | 5,615 | 160 | 2 | 0.4s | 0.2s |
+| nowinandroid | Kotlin | 312 | 5,110 | 123 | 4 | 0.4s | 0.3s |
+| nextcloud-collectives | PHP | 383 | 4,966 | 70 | 1 | 0.5s | 0.2s |
+| getdp | C++ | 169 | 4,562 | 9 | 0 | 0.8s | 0.2s |
+| enola | Go | 158 | 3,506 | 56 | 6 | 0.8s | 0.3s |
+| elk | Vue | 380 | 2,556 | 79 | 56 | 0.2s | 0.1s |
+| nextcloud-contacts | PHP | 170 | 1,706 | 51 | 1 | 0.3s | 0.2s |
+| grpc-web-example | Go + gRPC + TS | 12 | 293 | 8 | 5 | 0.1s | 0.1s |
+| sveltekit-realworld | Svelte | 42 | 195 | 14 | 13 | 0.1s | 0.1s |
+| cachet | PHP | 21 | 101 | 11 | 0 | 0.1s | 0.1s |
+| orocrm | PHP | 2 | 13 | 3 | 0 | 0.1s | 0.1s |
+
+**Parse errors across all 38 repositories: 0.**
+
+Cold is a first run with no extractor cache; warm is the best of two subsequent runs
+on an unchanged tree. Measured on an Apple-silicon laptop; treat the ratios as the
+signal, not the absolute seconds.
+
+## 1. Reproducibility
+
+Each repository was indexed **three times** — once cold, twice warm — and the
+receipt's `snapshot_id` and the SHA-256 of `facts.jsonl` were compared across all
+three. Running cold then warm is the point: it tests that a cached run and a
+from-scratch run agree, not merely that the same code path repeats itself.
+
+> **38 of 38 repositories produced a byte-identical `snapshot_id` and a
+> byte-identical `facts.jsonl` across all three runs — 114 runs, 4,211,113 facts,
+> zero drift.** `insights.json` is byte-stable on all 38 as well.
+
+This is the property everything else rests on. `snapshot_id` is
+`sha256(facts ‖ enola version ‖ config hash)`, not a UUID, so two runs on the same
+commit are provably the same graph — which is what lets `compare_receipts` refuse to
+diff snapshots that are not comparable instead of reporting churn as your change.
+
+## 2. Delta precision — the ratchet
+
+The claim is that enola reports **what your change did** and stays silent about
+everything that was already wrong. That is testable directly: pin a baseline, put
+the repository through four states, and see what each one is graded as.
+
+For each repository below, files were **added, never edited**, so every revert is a
+delete. The cycle case adds two new modules that import each other.
+
+| Repository | Language | Pre-existing findings | No change | Benign addition | Injected cycle | Reverted |
+|---|---|---|---|---|---|---|
+| superset | Python | 347 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| gitea | Go | 159 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| enola | Go | 144 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| cognee | Python | 123 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| excalidraw | TypeScript | 111 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| chatwoot | Ruby | 104 | PASS · +0 facts | PASS · +3 facts | **FAIL · 1 regression** | PASS · +0 |
+| solidus | Ruby | 72 | PASS · +0 facts | PASS · +3 facts | **FAIL · 1 regression** | PASS · +0 |
+| crates-io | Rust | 65 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| nowinandroid | Kotlin | 40 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| elk | TypeScript | 26 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| sveltekit-realworld | TypeScript | 1 | PASS · +0 facts | PASS · +2 facts | **FAIL · 1 regression** | PASS · +0 |
+| cachet | PHP | 0 | PASS · +0 facts | PASS · +3 facts | **FAIL · 1 regression** | PASS · +0 |
+
+Read the columns as four separate claims, all of which hold on all twelve:
+
+- **No change → +0 facts, +0 edges, PASS.** A genuine zero. Not "small", not
+  "noise below a threshold" — nothing at all. This is what makes the other three
+  columns mean something.
+- **Benign addition → PASS**, with the delta naming exactly the 2–3 facts added.
+  A new leaf module is not a regression, and reporting it as one is how gates die.
+- **Injected cycle → FAIL, exactly 1 regression** — out of **1,192 pre-existing
+  findings across these repositories**, up to 347 in a single one. None of them was
+  repeated. The ratchet holds.
+- **Reverted → PASS again**, +0 facts. The verdict is a function of the tree, not
+  of history.
+
+Eight languages, one behaviour. A regression is not detected by pattern-matching a
+language; it is a cycle in the module graph, computed by Tarjan's SCC over the
+resolved import edges, at confidence `1.0`.
+
+**Swift is deliberately absent**, and the reason is a property of the language rather
+than a limit of enola. A Swift module is a *declared* SPM target, so two added
+directories that import each other form no edge and no cycle — verified: the modules
+and the symbols appear, the cycle does not. Injecting one would mean editing
+`Package.swift`, and then "reverted" would be a file restore rather than a delete,
+which is exactly the property that makes the no-change column worth reading.
+
+### Why only cycles fail
+
+Across the corpus enola produced **24,648 findings**. Broken down:
+
+| Explainer | Findings | Class |
+|---|---|---|
+| hotspots | 20,891 | statistical outlier |
+| layers | 953 | heuristic |
+| **cycles** | **887** | **structural fact — the only one that fails a build** |
+| god-class | 714 | statistical outlier |
+| complexity-outliers | 491 | statistical outlier |
+| exported-surface | 442 | candidate |
+| dependency-depth | 270 | statistical outlier |
+
+3.6% of findings are eligible to fail a build. The other 96.4% are reported and let
+you through. That ratio is the design, not an accident: a gate that fails on one
+thing, and says which, is a gate people leave switched on.
+
+## 3. Cross-repo resolution, misses included
+
+The number that matters is not how many edges resolved. It is whether the ones that
+did **not** resolve are shown to you — because a service with no dependents and a
+service whose dependents enola failed to follow look identical in a graph.
+
+### On the committed multi-repo fixtures
+
+Ten cross-language fixtures, each with a golden fact file the test suite asserts on:
+
+| Fixture | Languages | Detected | Resolved | Unresolved | External | Edge confidence |
+|---|---|---|---|---|---|---|
+| ts_nest_multirepo | TypeScript ↔ TypeScript | 4 | 4 | 0 | 0 | verified |
+| go_grpc_multirepo | Go ↔ Protobuf | 3 | 3 | 0 | 0 | verified |
+| php_multirepo | PHP ↔ PHP | 2 | 2 | 0 | 0 | verified |
+| py_fastapi_multirepo | Python ↔ TypeScript ↔ Go | 2 | 2 | 0 | 0 | — |
+| py_grpc_multirepo | Python ↔ Protobuf | 1 | 1 | 0 | 0 | verified |
+| multirepo | OpenAPI ↔ OpenAPI | 1 | 1 | 0 | 0 | verified |
+| ts_express_multirepo | TypeScript ↔ JavaScript | 4 | 2 | **2** | 0 | verified |
+| go_httpclient_multirepo | Go ↔ Go | 4 | 1 | **1** | 2 | probable |
+| go_kafka_multirepo | Go ↔ Go (Kafka) | — | — | — | — | topic-matched |
+| kotlin_swift_multirepo | Kotlin ↔ Swift | — | — | — | — | — |
+| **Total** | | **21** | **16** | **3** | **2** | |
+
+The three unresolved edges are all deliberate, and each is a documented limit rather
+than a bug: a path too generic to attribute (`/healthcheck`), a path no loaded server
+serves, and a base URL injected from config with no literal binding.
+
+`verified` versus `probable` is a real distinction the fact carries: an edge matched
+through a declared contract (a `.proto` service, an OpenAPI `operationId`) is an
+identity; an edge matched by comparing URL strings is a resemblance. See
+[gRPC and OpenAPI](extraction/grpc-openapi.md).
+
+### On a real public cluster
+
+Nextcloud server plus two first-party apps, indexed into one graph
+(101,462 + 1,706 + 4,966 facts):
+
+```
+  service      classification  detected  resolved  unresolved
+  collectives  isolated              0         0           0
+  contacts     isolated              0         0           0
+  server       coverage_gap         11         0          11
+```
+
+Zero of eleven resolved. That is the honest number, and the report is built so it
+cannot be mistaken for success: `server` is classified **`coverage_gap`**, not
+`isolated`, and the output says so in words —
+
+> 1 service is classified `coverage_gap`: no resolved outbound edges, but enola DID
+> detect outbound call sites. Do not read these as isolated — they are the case where
+> "depends on nothing" and "enola could not tell" look identical from the graph alone.
+
+Nextcloud apps reach the server through in-process PHP APIs rather than cross-repo
+HTTP, so there is little here for the linker to match. The point of including it is
+that a report which only showed clusters where enola does well would not be evidence
+of anything.
+
+### On the example a reader can run
+
+[`examples/cross-repo/`](../examples/cross-repo/) — one command, two Go services:
+
+```
+==> Routes the api service actually serves
+    (registered as "/orders/{id}" — stored at the composed runtime path)
+    "/api/v2/orders"
+    "/api/v2/orders/{id}"
+
+  service  classification  detected  resolved  unresolved
+  api      isolated              0         0           0
+  web      connected             3         2           1
+```
+
+`api/server.go` registers the bare `/orders/{id}` inside a function that receives a
+subrouter mounted at `/api/v2` in `main`. Neither function contains the served path;
+the fact does. The web service's call resolves *because* that prefix was composed
+across the call boundary — and the one unresolved call is a deliberately dynamic URL,
+so the demonstration proves its own limit in the same run.
+
+## 4. Scale
+
+| | |
+|---|---|
+| Largest repository indexed | **Linux kernel** — 55,399 files, **1,892,343 facts**, 157.6s cold / 33.9s warm |
+| Largest Ruby | GitLab — 47,711 files, 435,020 facts, 29.1s / 19.4s |
+| Largest Rust | rust-lang/rust — 36,090 files, 394,970 facts, 20.4s / 9.1s |
+| Largest Go | Grafana — 10,310 files, 163,620 facts, 7.5s / 5.0s |
+| Throughput | 7,500–35,000 facts/sec depending on language |
+| Parse errors, all 38 repositories | **0** |
+| Memory, Linux kernel | heap peaked well inside a laptop's budget; no repository required tuning |
+
+Warm runs are 1.33×–5.22× faster than cold (over the 21 repositories whose cold run
+exceeds 0.5s; below that the timing is noise), from the per-file content-hash cache
+in `snapshot.meta.json`. Speed is not a claim enola competes on; these numbers are here
+to establish that the graph the other four sections rely on can actually be built on
+real code.
+
+## 5. What the extractors see
+
+Across the corpus enola extracted **17,098 routes** (14,620 server, 2,478 client) and
+recognised **32 distinct frameworks** without configuration:
+
+```
+wordpress 6668 · rails 3612 · openapi 1124 · axios 871 · request-options 761 · chi 751
+spring 578 · symfony 574 · resttemplate 418 · fastapi 354 · flask 297 · fetch 216
+nestjs 175 · axum 132 · grpc 107 · vue 103 · net/http 63 · nuxt 55 · openapi-fetch 46
+guzzle 44 · nextjs 39 · http-client 36 · faraday 16 · sveltekit 13 · net-http 12
+file-get-contents 9 · hono 7 · gorilla/mux 5 · retrofit 4 · django 4 · express 2
+urlsession 2
+```
+
+Fact kinds: 3,065,486 symbols · 979,468 dependencies · 61,328 file refs ·
+42,546 modules · 41,753 test refs · 17,098 routes · 3,434 storage.
+
+Two rows are worth reading carefully rather than as a score. **django 4** counts
+routes, not coverage: Saleor is GraphQL-first, so its REST surface really is that
+small, while 123 of its facts carry the Django framework tag (models, mostly). And
+**axum 132** is depressed by the same repository that supplied it: crates.io declares
+most of its API through `utoipa`'s `routes!()` macro, which enola deliberately does
+not expand — the documented limit in [rust.md](extraction/rust.md), observed on
+production code for the first time here.
+
+**What specific code produces which of these facts is documented per language, from
+committed fixtures, in [docs/extraction/](extraction/README.md)** — including what
+each extractor deliberately does *not* resolve.
+
+## 6. Agent A/B — does the agent ship the regression?
+
+The one A/B worth running is against **no tool**, on a task where the obvious
+implementation is structurally wrong.
+
+**Setup.** A small TypeScript service with three modules: `src/domain`, `src/store`
+(imports domain), `src/api`. The task: *add `recentOrders(customerId)` to the domain
+package and expose it from the API handler.* The natural implementation makes
+`domain` import `store`, closing a module cycle. TypeScript compiles it without
+complaint and every test still passes.
+
+Three arms, three trials each, Claude Code headless (`claude -p`, Claude Code 2.1.205).
+Each arm adds one thing to the one before it:
+
+- **bare** — no MCP servers, no instruction, no hooks.
+- **instruction** — enola's MCP server plus the exact instruction `enola install`
+  writes into the project's agent rules, which tells the agent to pin a baseline
+  before editing and diff afterwards.
+- **loop** — the same, plus the session hooks `enola install --hooks` configures, so
+  the change is graded when the agent stops whether or not it remembered to ask.
+
+Ground truth is identical for all three and does not trust the agent: the tree each
+run leaves behind is graded against a baseline pinned before it started.
+
+| Arm | Shipped the regression | Median turns | Median cost | Median wall |
+|---|---|---|---|---|
+| bare | **3 / 3** | 12 | $0.31 | 53s |
+| instruction | **1 / 3** | 14 | $0.66 | 125s |
+| loop | **0 / 3** | 24 | $1.12 | 252s |
+
+The bare agent shipped a dependency cycle every time. With the hooks installed, none
+of the three did — and the transcripts say why. From one of them, unprompted:
+
+> The regression was `src/domain ↔ src/store`: my first attempt made the domain
+> `import { listOrders }` from the store, which closed a loop with the store's
+> pre-existing `import type { Order }` from the domain. I removed the offending edge.
+
+That is the loop working as designed: the agent introduced the cycle, the Stop hook
+graded the session and handed back the verdict, and the agent corrected itself before
+reporting done. It cost roughly double the turns and 3.6× the money of the bare run.
+
+**Read this before quoting the table.**
+
+- **Nine runs is not a statistic.** 3/3 versus 0/3 is a real gap and the ordering is
+  monotonic, but the difference between the instruction arm's 1/3 and the loop arm's
+  0/3 is one run. Treat this as a demonstration that the mechanism works end to end,
+  not as a measured effect size.
+- **No arm ever called `diff_snapshot`.** Every enola-equipped run used exactly one
+  tool, `generate_snapshot`. The loop arm did not succeed because the agent asked
+  enola the right question — it succeeded because something asked on its behalf when
+  it stopped. That is the whole argument for the hook over the instruction.
+- **The instruction arm improved on bare anyway** (1/3 vs 3/3), which is worth being
+  honest about: having a structural map in context appears to help even when the
+  agent never queries the delta. With three trials, that could equally be noise.
+- **One trap, one language, one model.** A deliberately subtle module-level cycle in
+  TypeScript.
+
+## What this does not measure
+
+Stated so the numbers above are not read as more than they are.
+
+- **Retrieval speed, token counts and cost per query.** Deliberately absent. It is
+  the axis where every tool in this space competes and the one where enola's evidence
+  would be weakest — the A/B above shows the enola-equipped arms costing 2–3.6× *more*.
+- **The session hooks in interactive use.** Section 6 exercises them headlessly, under
+  `claude -p`. The configuration is the same either way, but interactive sessions were
+  not measured.
+- **Swift in the ratchet.** Measured in every other section; excluded from section 2
+  only, because a Swift module is a declared SPM target and no additive cycle
+  injection exists. Stated above rather than silently omitted.
+- **Kotlin and Swift at *large* scale.** Both now have a real public repository
+  (Google's reference Android app; a SwiftUI application), but at 312 and 382 parsed
+  files they are the small end of the corpus. The framework constructs are exercised
+  on production code; the scale claims are not.
+- **Vue and Svelte route surfaces are small.** Nuxt and SvelteKit are measured on real
+  applications, but 56 and 13 routes respectively — enough to show file-based routing
+  works, not enough to characterise it.
+- **Recall of cross-repo edges.** Section 3 reports what enola detected and what it
+  resolved. It does not report edges enola never detected at all — that would need a
+  hand-labelled ground truth for each cluster, which does not exist here.
+- **Comparisons with other tools.** Not measured, not estimated, not implied.
+
+## Reproducing
+
+```bash
+# one repository, three times — the reproducibility check in miniature
+enola --generate /path/to/repo && cp .enola/receipt.json /tmp/r1.json
+enola --generate /path/to/repo && cp .enola/receipt.json /tmp/r2.json
+diff <(jq -r .snapshot_id /tmp/r1.json) <(jq -r .snapshot_id /tmp/r2.json) && echo reproducible
+
+# the ratchet, on your own repository
+enola baseline pin .          # freeze the architecture
+#   …make a change…
+enola check .                 # exit 1 on a structural regression
+
+# cross-repo coverage, misses included
+enola coverage cluster.yaml
+```
+
+> **Read the `enola: using config …` line each command prints, and check it is the
+> config you meant.** A config's `extractors:` list *replaces* the built-in default
+> rather than merging with it, so the wrong one does not fail — it quietly analyses
+> something other than what you asked for. enola looks in the working directory first
+> and falls back to the directory holding the binary.
+
+---
+
+Building this benchmark also turned up seven defects in enola itself, all since fixed;
+[DEFECTS_FOUND.md](../DEFECTS_FOUND.md) is the record, and the only place their status
+is tracked.
+
+Per-language extraction detail: **[docs/extraction/](extraction/README.md)** ·
+Commands and flags: **[docs/CLI.md](CLI.md)** ·
+How the engine works: **[ARCHITECTURE.md](../ARCHITECTURE.md)**

--- a/docs/extraction/README.md
+++ b/docs/extraction/README.md
@@ -1,0 +1,52 @@
+# What enola extracts, per language
+
+These pages answer one question: **given this code, what ends up in the graph?**
+
+Every example is a file that ships in this repository, and every fact shown is copied
+from the golden file the test suite asserts against. So none of it is a description of
+intended behaviour — it is the behaviour, and if an extractor changes without these
+pages changing, the golden tests fail first.
+
+| | |
+|---|---|
+| Fixture sources | [`internal/engine/testdata/repos/`](../../internal/engine/testdata/repos/) |
+| Expected facts | [`internal/engine/testdata/golden/`](../../internal/engine/testdata/golden/) |
+| Measured on real repositories | [BENCHMARKS.md](../BENCHMARKS.md) |
+
+## The pages
+
+| Language | Routes and clients it understands | |
+|---|---|---|
+| [Go](go.md) | gorilla/mux, chi, Gin, Echo, `net/http` clients, gRPC, Kafka | prefix composition across function boundaries |
+| [TypeScript / JavaScript](typescript.md) | Express, NestJS, Next.js, `fetch`, axios, Prisma, TypeORM, Drizzle | Vue, Svelte, and file-based routing |
+| [Python](python.md) | FastAPI, Flask, Django, SQLAlchemy, gRPC | `include_router` prefixes folded repo-wide |
+| [Ruby](ruby.md) | Rails `routes.rb`, ActiveRecord, Packwerk | nested `resource`/`resources` path shapes |
+| [Java](java.md) | Spring MVC, RestTemplate, Feign, JPA, Dubbo SPI | |
+| [Kotlin](kotlin.md) | Retrofit, Room, Compose, Hilt | |
+| [Swift](swift.md) | URLSession, SwiftUI, UIKit | endpoint enums, protocol-extension prefixes |
+| [PHP](php.md) | Laravel, Symfony, WordPress, Guzzle | `apiResource` expansion, YAML route config |
+| [Rust](rust.md) | Axum route DSL | `.nest()` mounts composed crate-wide |
+| [C / C++](cpp.md) | — | header/source method merging, namespaces, templates |
+| [gRPC and OpenAPI](grpc-openapi.md) | `.proto` services, OpenAPI specs | the contract as the server side of an edge |
+
+## How to read a page
+
+Each one is organized the same way:
+
+1. **At a glance** — a table from source construct to fact kind.
+2. **What each construct produces** — the code, then the facts, then the query it unlocks.
+3. **What is deliberately not extracted** — the limits, stated next to the capability.
+
+That last section is not an apology. A missing edge shows up in `enola coverage` as an
+unresolved count you can go and look at; a *wrong* edge is invisible and gets acted on.
+Every extractor here reports the gap rather than inventing the edge, and the section
+says where those gaps are.
+
+## The fact model in one paragraph
+
+Everything below is one of six kinds — `module`, `symbol`, `route`, `storage`,
+`dependency`, `service` — plus two reference-only kinds (`file_ref`, `test_ref`) that
+carry edges without being architecture themselves. Facts are name-keyed, carry a
+`file:line`, and hold typed relations (`imports`, `calls`, `declares`, `handled_by`,
+`depends_on`, …). [ARCHITECTURE.md](../../ARCHITECTURE.md#the-fact-model) has the full
+model; these pages assume it only loosely.

--- a/docs/extraction/cpp.md
+++ b/docs/extraction/cpp.md
@@ -1,0 +1,128 @@
+# C / C++ — what enola extracts
+
+Parsed with tree-sitter-c and tree-sitter-cpp. Detected by a C source (`.c`), a C++
+source (`.cpp`/`.cc`/`.cxx`/`.hpp`/…), or a build file (`CMakeLists.txt`, `Makefile`,
+`meson.build`, `*.vcxproj`) plus any header. Language is recorded **per fact**, so a mixed
+tree reports `c` and `cpp` separately rather than collapsing to one.
+
+Fixture: [`cpp_sample`](../../internal/engine/testdata/repos/cpp_sample/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a source directory | one module per directory | `module` |
+| `int foo(void) { … }` | a symbol with `has_body=true` | `symbol` |
+| `static int foo(void)` | the same, with `static=true`, `exported=false` | `symbol` |
+| a declaration in a header + definition in a `.c` | **one** merged symbol, not two | `symbol` |
+| `#define X`, `const int` | a `constant` symbol | `symbol` |
+| `gc->set = xlp_gpio_set;` | a call edge to the assigned function | relation |
+| `.lock = fn` in a compound literal | a call edge to `fn` | relation |
+| a function name inside a `#define` body | a call edge recovered by a macro pre-pass | relation |
+| a token-pasted callback (`_pfx##_name##_show`) | a call edge to the pasted name | relation |
+| a call inside a `for`/`while` | `calls_in_loop` / `calls_in_scaling_loop` | props |
+
+## Symbols, and why `has_body` matters
+
+```c
+static int omap_reserve(void) { … }
+```
+
+```
+symbol drivers.omap_reserve   drivers/board.c:12
+       props: symbol_kind=function, language=c, static=true, exported=false,
+              has_body=true, cyclomatic=1
+```
+
+A header declaration and its definition are the same entity. Merging them means the
+symbol has one location — the definition — and one set of callers, instead of a phantom
+zero-caller declaration sitting next to the real thing.
+
+## The three ways a C callback gets its only caller
+
+C code wires behaviour through function pointers, and none of it looks like a call. All
+three forms are recovered, because otherwise most of a driver reads as dead code.
+
+**1. Function-pointer field assignment**
+
+```c
+static int probe(struct gpio_chip *gc)
+{
+	gc->set = xlp_gpio_set;          /* plain */
+	gc->get = &xlp_gpio_get;         /* address-of */
+	ct->chip.irq_mask = mvebu_mask;  /* nested field */
+	gc->ngpio = 32;                  /* plain data — must NOT create an edge */
+}
+```
+
+The first three create a `calls` edge from `probe` to the assigned function. The fourth
+assigns an integer and creates nothing — the discriminator is whether the right-hand side
+names a known function, not whether the statement is an assignment.
+
+**2. Compound-literal designated initializers**
+
+```c
+cfg = (struct regmap_config) {
+	.reg_bits = 8,
+	.lock     = dio48e_regmap_lock,
+	.unlock   = dio48e_regmap_unlock,
+};
+```
+
+`dio48e_regmap_lock` and `dio48e_regmap_unlock` get inbound edges from the enclosing
+function. `.reg_bits = 8` does not.
+
+**3. References that exist only inside macro bodies**
+
+A function named only in a `#define` replacement list is invisible to the AST — the
+preprocessor would have to run first. A project-wide macro pre-pass recovers both the call
+position and the value position:
+
+```c
+#define ATTR_PERM(_pfx, _name, _perm)                        \
+	static struct configfs_attribute _pfx##attr_##_name = {  \
+		.show  = _pfx##_name##_show,                         \
+		.store = _pfx##_name##_store,                        \
+	}
+```
+
+The pre-pass is **project-wide, not include-scoped**, so the pasted `cfg_label_show` /
+`cfg_label_store` callbacks are recovered even though the invoking file does not literally
+`#include` the header that defines the macro. Following `#include` graphs exactly would
+lose these, and the kernel's sysfs and configfs attribute surfaces are built almost
+entirely this way.
+
+## Loops
+
+```
+symbol drivers.constant_loop   drivers/loops.cpp:12
+       props: loop_count=1, loop_depth=1, scaling_loop_depth=0,
+              calls_in_loop=[drivers.step], calls_in_scaling_loop=[]
+```
+
+Same model as [Go](go.md#loops-for-n1-hunting) and [Ruby](ruby.md): a constant-bounded
+loop records the call but keeps the scaling set empty rather than absent.
+
+## C++ specifics
+
+Namespaces, templates and class methods are extracted, with header and source methods
+merged into one symbol as above.
+
+> **A note on `override`.** The C++ corpus used to validate this extractor
+> (getdp, gmsh, the Linux kernel) is pre-C++11 and never uses the `override`
+> specifier, so the code path that consumes it has zero exercise on real code.
+> `virtual` is the specifier that is actually in play there.
+
+## What is deliberately not extracted
+
+- **Preprocessor evaluation.** `#if`/`#ifdef` branches are all parsed; enola does not pick
+  a configuration, so facts from mutually exclusive branches can coexist.
+- **Template instantiation.** A template is one symbol, not one per instantiation.
+- **Virtual dispatch.** A call through a base-class pointer resolves to the declared
+  method, not to every override.
+- **Linker-level symbol resolution.** Two static functions with the same name in different
+  translation units are distinguished by module, not by object file.
+
+---
+
+Measured on real C/C++ repositories — including the Linux kernel: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/go.md
+++ b/docs/extraction/go.md
@@ -1,0 +1,219 @@
+# Go — what enola extracts
+
+Parsed with `go/ast` (not tree-sitter), so the Go graph is built from the same syntax
+tree the compiler uses. Detected by a `go.mod` at the repository root.
+
+Fixtures: [`go_sample`](../../internal/engine/testdata/repos/go_sample/) ·
+[`go_httpclient_multirepo`](../../internal/engine/testdata/repos/go_httpclient_multirepo/) ·
+[`go_grpc_multirepo`](../../internal/engine/testdata/repos/go_grpc_multirepo/) ·
+[`go_kafka_multirepo`](../../internal/engine/testdata/repos/go_kafka_multirepo/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a package directory | one module, keyed by its path | `module` |
+| `func`, `type`, `method` | one symbol with `symbol_kind`, `exported`, `cyclomatic` | `symbol` |
+| `import "..."` | a dependency tagged `internal` / `external` / `stdlib` | `dependency` |
+| a call inside a function | a `calls` relation on the calling symbol | relation |
+| a call inside a `for` | the callee also in `calls_in_loop` / `calls_in_scaling_loop` | props |
+| `r.HandleFunc("/x", h)` | a server route, **at its composed runtime path** | `route` |
+| `http.Get(base + "/x")` | a client route with `role: client` and a resolved `host` | `route` |
+| a `.proto` service + generated client | both sides of a gRPC edge | `route` |
+| a Kafka topic constant | a topic, attributed to the service that owns it | `storage` |
+| `*_test.go` | a reference-only `test_ref`, so test-only callees are not dead | `test_ref` |
+
+## Modules, symbols and imports
+
+```go
+// pkg/a/a.go
+package a
+
+import "example.com/gosample/pkg/b"
+
+func Alpha() {
+	b.Beta()
+}
+```
+
+```
+module      pkg/a                          props: package=a, language=go
+symbol      pkg/a.Alpha    pkg/a/a.go:7    props: symbol_kind=function, exported=true, cyclomatic=1
+                                           --calls--> pkg/b.Beta
+                                           --declares--> pkg/a
+dependency  pkg/a -> example.com/gosample/pkg/b   pkg/a/a.go:3   props: source=internal
+                                           --imports--> pkg/b
+```
+
+`source` separates `internal` (your own module path), `external` (a third-party module)
+and `stdlib`. Only `internal` edges take part in cycle detection — a package that
+imports `net/http` is not coupled to anything you own.
+
+### Cycles
+
+`go_sample` closes an `a` → `b` → `a` import loop on purpose. Tarjan's SCC over the
+`internal` dependency edges reports it at confidence `1.0`, which is the one finding
+[`enola check`](../CLI.md) fails a build on.
+
+### Loops, for N+1 hunting
+
+```go
+func GetPath(id int) {
+	for {
+		getByID(id)
+	}
+}
+
+func Seed() {
+	for _, c := range []string{"a", "b"} {
+		setup(c)
+	}
+}
+```
+
+```
+symbol pkg/a.GetPath   props: loop_count=1, loop_depth=1, scaling_loop_depth=0,
+                              calls_in_loop=[pkg/a.getByID],
+                              calls_in_scaling_loop=[pkg/a.getByID]
+symbol pkg/a.Seed      props: loop_count=1, loop_depth=1, scaling_loop_depth=0,
+                              calls_in_loop=[pkg/a.setup],
+                              calls_in_scaling_loop=[]        ← empty, not absent
+```
+
+A bare `for {}` walking a parent chain repeats without adding a factor of *n*, so
+`getByID` stays in the N+1 candidate set. `Seed`'s loop is bounded by a literal slice,
+so its `calls_in_scaling_loop` is emitted **empty rather than omitted** — an omitted key
+would make a consumer fall back to the unfiltered list and re-report the bounded call.
+
+### Test references
+
+`*_test.go` is ignored for indexing, so a function called only from a test would look
+dead. Both Go test idioms are recovered as `test_ref` facts that carry the call edge
+without being architecture:
+
+```
+test_ref  pkg/a/a_test.go       --calls--> pkg/a.helper     (in-package test)
+test_ref  pkg/a/a_ext_test.go   --calls--> pkg/a.Gamma      (package a_test, via import alias)
+```
+
+## Routes — prefix composition across function boundaries
+
+This is the part that decides whether a client call resolves at all.
+
+```go
+// api/server.go
+func main() {
+	r := mux.NewRouter()
+	v1 := r.PathPrefix("/v1").Subrouter()   // line 16
+	registerThings(v1)                      // line 17 — the subrouter crosses a call boundary
+	http.ListenAndServe(":8080", r)
+}
+
+func registerThings(r *mux.Router) {
+	r.HandleFunc("/things/{id}", getThing).Methods("GET")   // line 24 — bare leaf path
+}
+```
+
+Neither function contains the served path. The fact does:
+
+```
+route  /v1/things/{id}   api/server.go:24
+       props: framework=gorilla/mux, method=GET, handler=getThing
+       --handled_by--> ..getThing
+```
+
+The route is **stored at `/v1/things/{id}`**, not at the `/things/{id}` that appears on
+line 24. Composition runs as a module-wide fixpoint, so a mount can be declared in one
+function, one file, or one package and consumed in another. The same machinery covers
+chi's `r.Mount` / `r.Route`.
+
+Why it matters: a client calling `/v1/things/{id}` matches the composed path and nothing
+else. Store the bare path and the edge silently does not exist — and a missing cross-repo
+edge looks exactly like a service with no dependents.
+
+## Outbound HTTP calls
+
+```go
+const extBase = "https://api.example.com"       // third-party, no loaded server
+const internalBase = "http://api:8080"          // an internal host that IS a loaded repo
+
+func (c *Client) run(ctx context.Context) {
+	http.Get(extBase + "/v1/widgets")
+	http.NewRequestWithContext(ctx, "GET", internalBase+"/v1/things/{id}", nil)
+	http.NewRequest("POST", c.zepto.baseURL+"/v3/messages", nil)   // region switch: several hosts
+	http.Get(c.options.BaseURL + "/v1/internal")                   // host injected from config
+}
+```
+
+Four call sites, four different outcomes — and enola distinguishes them:
+
+| Call | Stored as | Why |
+|---|---|---|
+| `/v1/widgets` | `role=client, external=true, host=api.example.com` | literal host, no loaded server |
+| `/v1/things/{id}` | `role=client, external=true, host=api:8080` **and resolved to `api`** | internal host that matches a loaded repo — the server match is attempted before the external bucket |
+| `/v3/messages` | `role=client, external=true`, **no `host`** | the base URL is bound to several literals that disagree on host (a region switch) |
+| `/v1/internal` | `unmatched_by_server=true, unmatched_reason=path_unknown` | the base URL comes from injected config with no string-literal binding |
+
+The service fact carries the tally, which is what `enola coverage` reports:
+
+```
+service consumer  props: edge_coverage=[{edge_type: http_client,
+                                         detected: 4, resolved: 1, external: 2, unresolved: 1}]
+                  --depends_on--> api
+```
+
+One unresolved out of four, stated rather than hidden. A report that only showed the
+resolved count would be advertising.
+
+## gRPC
+
+A `.proto` service and a generated Go client become the two ends of one edge:
+
+```
+route  /users.v1.UserService/GetUser   server/proto/users/v1/users.proto:11
+       props: role=server, source=grpc-proto, rpc_service=users.v1.UserService,
+              rpc_method=GetUser, streaming=none
+route  /users.v1.UserService/GetUser   client/repo.go:16
+       props: role=client, source=go-grpc-client
+
+dependency client -> server
+       props: type=cross_repo, via=[grpc], confidence=verified, endpoint_count=2
+```
+
+`confidence=verified` — not `probable`. A gRPC edge is matched against a declared
+contract, so it is not a heuristic the way a URL-string match is.
+
+## Kafka
+
+```
+storage  svc-orders.order_placed        svc-billing/consumer.go:10
+         props: storage_kind=topic, messaging=kafka, source=config_default
+storage  analytics-sink.rows_exported   svc-billing/consumer.go:22
+         props: storage_kind=topic, messaging=kafka, source=env_default
+```
+
+Topics are namespaced by the service that **owns** them, not the one that mentions
+them, so a consumer reading `svc-orders.order_placed` produces a `depends_on` edge to
+`svc-orders` even though the two share no import. `source` records where the topic name
+came from (a config default, an env default), because a topic assembled at runtime is a
+weaker claim than a constant.
+
+## What is deliberately not extracted
+
+- **Dynamically built paths.** `r.HandleFunc(pathVar, h)` where `pathVar` is not a
+  literal is skipped rather than guessed. Same for a client URL with no literal binding.
+- **Mounts resolved across files by variable aliasing** beyond the fixpoint's reach —
+  the leaf keeps its bare path rather than being dropped, so it is still visible and
+  still shows up as an unresolved client edge.
+- **Absolute URLs to hosts you have not loaded.** These are tagged `external` with the
+  host recorded, never invented as an internal edge.
+- **Reflection and `interface{}` dispatch.** A call through an interface resolves to the
+  interface method, not to every implementation.
+
+Every one of these shows up as an unresolved count in
+[`enola coverage`](../CLI.md), never as a confident wrong edge.
+
+---
+
+Measured on real Go repositories: [BENCHMARKS.md](../BENCHMARKS.md).
+The full detection rules: [ARCHITECTURE.md → Supported languages](../../ARCHITECTURE.md#supported-languages).

--- a/docs/extraction/grpc-openapi.md
+++ b/docs/extraction/grpc-openapi.md
@@ -1,0 +1,127 @@
+# gRPC and OpenAPI — the contract as one end of an edge
+
+These two are not languages. They are *declared contracts*, and enola treats them as the
+authoritative server side of a cross-repository edge — which is why an edge matched
+through them carries `confidence: verified` rather than `probable`.
+
+Fixtures: [`openapi_sample`](../../internal/engine/testdata/repos/openapi_sample/) ·
+[`multirepo`](../../internal/engine/testdata/repos/multirepo/) ·
+[`go_grpc_multirepo`](../../internal/engine/testdata/repos/go_grpc_multirepo/) ·
+[`py_grpc_multirepo`](../../internal/engine/testdata/repos/py_grpc_multirepo/)
+
+## Why a contract is different from a URL string
+
+Most cross-repo linking compares a client's URL literal against a server's route literal.
+That is a *heuristic*: two services can serve `/users`, and a string match cannot tell you
+which one the client meant. A `.proto` service name or an OpenAPI `operationId` is a
+declared identifier, so the match is an identity, not a resemblance:
+
+```
+dependency client -> server   props: type=cross_repo, via=[grpc], confidence=verified,
+                                     endpoint_count=2,
+                                     endpoints=["POST /users.v1.UserService/CreateUser",
+                                                "POST /users.v1.UserService/GetUser"]
+dependency consumer -> api    props: type=cross_repo, via=[http-client], confidence=probable
+```
+
+`verified` and `probable` are different claims, and the fact says which one you are
+looking at.
+
+## gRPC
+
+Detected by any `.proto` file. The service definition becomes server routes; generated
+client stubs, and calls through them, become client routes.
+
+```protobuf
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc CreateUser(CreateUserRequest) returns (User);
+}
+```
+
+```
+route  /users.v1.UserService/GetUser      server/proto/users/v1/users.proto:11
+       props: role=server, source=grpc-proto, framework=grpc, method=POST,
+              rpc_service=users.v1.UserService, rpc_method=GetUser, streaming=none, type=grpc
+route  /users.v1.UserService/CreateUser   server/proto/users/v1/users.proto:12
+       props: role=server, source=grpc-proto, …, rpc_method=CreateUser
+```
+
+The path form is gRPC's own wire path (`/package.Service/Method`), so the client and
+server sides are directly comparable. `streaming` records `none` / client / server / bidi,
+because a streaming RPC has different failure and back-pressure characteristics from a
+unary one.
+
+Client call sites are found in the language extractors, not the proto extractor:
+
+```
+route  /users.v1.UserService/GetUser   client/repo.go:16     props: role=client, source=go-grpc-client
+route  /users.v1.UserService/GetUser   client/pkgvar.go:15   props: role=client, source=go-grpc-client
+```
+
+Two call sites for the same RPC, kept as two facts — `impact_analysis` on the RPC needs
+both, and collapsing them would understate the blast radius. Python (`py-grpc-client`) and
+TypeScript gRPC-web clients are recognised the same way.
+
+Generated code is tagged rather than hidden:
+
+```
+dependency gen/users/v1 -> google.golang.org/grpc   props: generated=true, source=external
+```
+
+so a query can exclude generated stubs without an ignore-glob guess.
+
+## OpenAPI
+
+Detected by any spec with an `openapi:` or `swagger:` key. Each operation becomes one
+route per method, carrying the metadata the spec already gives you:
+
+```
+route  /widgets       api/openapi/widgets.yaml   props: role=server, method=GET,
+                                                        operationId=listWidgets, tags=[widgets],
+                                                        summary="List all widgets",
+                                                        spec_file=api/openapi/widgets.yaml
+route  /widgets       api/openapi/widgets.yaml   props: role=server, method=POST, operationId=createWidget
+route  /widgets/{id}  api/openapi/widgets.yaml   props: role=server, method=GET, operationId=getWidget
+```
+
+There is no line number: a YAML operation is a configuration entry, and `spec_file` says
+which document it came from instead of inventing a position.
+
+### Client specs
+
+A spec that describes an API this repository *calls* rather than serves is recognised by
+its location (a `client/` directory) and stored with `role: client`:
+
+```
+route  /invoices   api/openapi/client/billing.yml   props: role=client, operationId=listInvoices, tags=[billing]
+```
+
+That is what makes a spec-only repository — one with no HTTP client code at all — still
+participate in the cross-repo graph:
+
+```
+route  /widgets    repoA/api/openapi/widgets.yaml         role=server, operationId=listWidgets
+route  /widgets    repoB/api/openapi/client/widgets.yml   role=client, operationId=fetchWidgets
+
+dependency repoB -> repoA   props: via=[http], confidence=verified, endpoints=["GET /widgets"]
+service    repoB            props: edge_coverage=[{detected: 1, resolved: 1, unresolved: 0}]
+                            --depends_on--> repoA
+```
+
+## What is deliberately not extracted
+
+- **Schema shapes.** enola records that an operation exists and who calls it, not the
+  request or response body. It is an architecture graph, not an API diff tool.
+- **`$ref` resolution across documents** for the purpose of route discovery — the paths
+  are read where they are declared.
+- **Runtime service discovery.** A gRPC channel whose target is resolved from a registry
+  at startup is not traced to a service; the RPC identity still matches, which is why the
+  edge resolves anyway.
+- **Proto options and custom annotations** (`google.api.http` gateway mappings) are not
+  yet expanded into REST routes, so a gRPC-gateway REST surface appears only if the
+  generated handlers are in a language extractor's reach.
+
+---
+
+Measured on real repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/java.md
+++ b/docs/extraction/java.md
@@ -1,0 +1,122 @@
+# Java — what enola extracts
+
+Parsed with tree-sitter. Detected by a `pom.xml` (Maven) or any `.java` source. A Gradle
+build file alone does **not** trigger it — Kotlin and Android use Gradle too, and guessing
+wrong there means running the wrong extractor over an entire repository.
+
+Fixture: [`java_sample`](../../internal/engine/testdata/repos/java_sample/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a package directory | one module | `module` |
+| `class` / `interface` / `enum` | a symbol with `fqn` and `abstract` | `symbol` |
+| a method | a symbol with `receiver`, `cyclomatic` | `symbol` |
+| a method that calls itself | `recursive_self=true` | props |
+| `import …` | a dependency tagged `internal` / `external` | `dependency` |
+| `@Repository`, `@Service`, `@Controller` | `framework=spring`, `component=repository` | props |
+| a JPA repository method | `performs_io=true`, `io_direct=true` | props |
+| `@Component` / `@Module` (Dagger, Hilt) | `di_component=true` / `di_module=true` | props |
+| a Dubbo SPI entry in `META-INF/` | a `file_ref` with a call edge to the implementation | `file_ref` |
+| `restTemplate.exchange(url, GET, …)` | a client route | `route` |
+| `@FeignClient` + `@GetMapping` | a client route with a `target_hint` | `route` |
+
+## Symbols
+
+```
+symbol …compute.Calculator       props: symbol_kind=class, abstract=true, fqn=com.example.compute.Calculator
+symbol …compute.Calculator.fib   props: symbol_kind=method, receiver=Calculator,
+                                        cyclomatic=2, recursive_self=true
+symbol …repo.WidgetRepository    props: symbol_kind=interface, framework=spring, component=repository
+symbol …repo.WidgetRepository.findByOwner
+                                 props: performs_io=true, io_direct=true, receiver=WidgetRepository
+```
+
+`fqn` is kept alongside the module-scoped name because Java identity is the fully
+qualified name — that is what an annotation, a config file or another repository refers
+to. `performs_io` is what makes an N+1 finding actionable: a call in a loop matters much
+more when the callee touches the database.
+
+## Dependency injection, which is where callers disappear
+
+A Dagger or Hilt graph wires implementations to interfaces with no direct call anywhere:
+
+```
+symbol …di.AppComponent   props: di_component=true, symbol_kind=interface
+symbol …di.NetworkModule  props: di_module=true,    symbol_kind=class
+```
+
+Marking these means a provider method is understood as a wiring point rather than an
+unreferenced function. Lombok-generated members are recognised for the same reason —
+otherwise every `@Builder` and `@RequiredArgsConstructor` class looks like it has no
+constructor.
+
+## Dubbo SPI — a caller that is not code
+
+```
+# src/main/resources/META-INF/dubbo/internal/com.example.spi.Strategy
+random=com.example.spi.RandomStrategy
+```
+
+```
+file_ref  src/main/resources/META-INF/dubbo/internal/com.example.spi.Strategy
+          --calls--> src/main/java/com/example/spi.RandomStrategy
+```
+
+`RandomStrategy` is loaded by name through the `ExtensionLoader` and has no Java caller
+at all. Reading the SPI resource file gives it one. This is the same class of problem as
+[WordPress hooks](php.md#routes--wordpress-hooks) and
+[C macro callbacks](cpp.md#the-three-ways-a-c-callback-gets-its-only-caller): the
+framework is the caller, and the framework's registry is a file.
+
+## Outbound HTTP
+
+```java
+restTemplate.exchange("/api/inventory/items/{id}", HttpMethod.GET, …);   // line 15
+restTemplate.postForObject("/api/inventory/items", …);                   // line 19
+```
+
+```
+route  /api/inventory/items/{id}   InventoryClient.java:15
+       props: role=client, framework=resttemplate, api=InventoryClient, method=GET
+route  /api/inventory/items        InventoryClient.java:19
+       props: role=client, framework=resttemplate, api=InventoryClient, method=POST
+```
+
+Declarative Feign clients carry a service name, which becomes a matching hint:
+
+```java
+@FeignClient(name = "shipping")
+interface ShippingClient {
+    @GetMapping("/api/shipping/{id}") Shipment get(@PathVariable String id);
+}
+```
+
+```
+route  /api/shipping/{id}   ShippingClient.java:12
+       props: role=client, framework=feign, source=feign, target_hint=shipping
+```
+
+`target_hint` is the service the annotation names. When that repository is loaded, the
+hint disambiguates between two services that happen to serve the same path.
+
+## Spring server routes
+
+`@RestController` and `@RequestMapping` / `@GetMapping` produce server routes with the
+class-level prefix composed onto each method, the same shape as
+[NestJS](typescript.md#routes--nestjs-controller-prefixes).
+
+## What is deliberately not extracted
+
+- **Runtime proxies and AOP.** A call intercepted by a Spring proxy resolves to the
+  declared method.
+- **Reflection.** `Class.forName(name)` resolves to nothing; the SPI file above is read
+  because it is a *declared* registry, not because reflection is traced.
+- **Non-literal paths.** A `@RequestMapping` built from a constant expression is not
+  evaluated.
+- **Interface dispatch** resolves to the interface method, not to every implementation.
+
+---
+
+Measured on real Java repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/kotlin.md
+++ b/docs/extraction/kotlin.md
@@ -1,0 +1,114 @@
+# Kotlin — what enola extracts
+
+Parsed with tree-sitter. Detected by `build.gradle.kts` / `build.gradle` with Kotlin or
+Android. Gradle alone is not enough to pick the Java extractor instead — the build file
+has to say which.
+
+Fixture: [`kotlin_sample`](../../internal/engine/testdata/repos/kotlin_sample/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a Gradle module / source directory | one module with `module_role` | `module` |
+| `class`, `interface`, `object` | a symbol with `symbol_kind` | `symbol` |
+| `data class` | `data_class=true` | props |
+| `override fun` | `override=true` | props |
+| a function that calls itself | `recursive_self=true` | props |
+| `@GET("…")` or `@GET(value = "…")` on a Retrofit interface | a client route | `route` |
+| `@Entity` / `@Dao` (Room) | a storage entity and a DAO | `storage` |
+| a `@Query`/`@Insert` DAO method | `io_direct=true`, `performs_io=true` | props |
+| `@Module` / `@Component` / `@Binds` (Dagger, Hilt) | `di_module`, `di_component`, `di_provider` | props |
+| `@HiltViewModel`, repositories, … | `android_component=…`, `framework=android` | props |
+
+## Retrofit — the client half of a mobile-to-backend edge
+
+Both argument forms are read. Kotlin lets any single-argument annotation be written
+with its argument named, and real Android codebases mix the two freely — matching only
+the positional form once yielded *zero* routes for an entire application, and a
+Retrofit interface with no routes contributes no mobile-to-backend edges at all.
+
+```kotlin
+interface ApiService {
+    @GET("/api/users/active")
+    suspend fun getActiveUsers(): Response<List<User>>      // line 19
+
+    @POST("auth/login")
+    suspend fun login(@Body body: LoginRequest): Response<Token>   // line 22
+
+    @GET(value = "topics")                                         // named argument
+    suspend fun topics(): Response<List<Topic>>
+}
+```
+
+```
+route  /api/users/active   ApiService.kt:19
+       props: role=client, framework=retrofit, source=retrofit, method=GET, api=ApiService
+route  auth/login          ApiService.kt:22
+       props: role=client, framework=retrofit, source=retrofit, method=POST, api=ApiService
+route  topics               ApiService.kt:25
+       props: role=client, framework=retrofit, source=retrofit, method=GET, api=ApiService
+
+symbol …ApiService.getActiveUsers   props: io_direct=true, performs_io=true, receiver=ApiService
+```
+
+Note that `auth/login` is stored **without** a leading slash, exactly as written. Retrofit
+resolves relative paths against the client's base URL, and enola does not invent the
+missing segment — the path is recorded as declared, and matching handles the difference.
+Inventing a leading `/` would produce a confident edge to the wrong route.
+
+## Room — storage with its DAO
+
+```
+storage  ….UserEntity   UserDao.kt:10   props: framework=room, storage_kind=entity
+storage  ….UserDao      UserDao.kt:16   props: framework=room, storage_kind=dao
+symbol   ….UserDao.getAll  props: io_direct=true, performs_io=true
+```
+
+The entity and the DAO are separate facts because they answer different questions: *what
+tables does this app have* and *what code touches them*. `io_direct` on the DAO method
+means an N+1 finding on a caller is about real database round-trips.
+
+## Dependency injection
+
+```
+symbol ….NetworkModule                 props: di_module=true, android_component=di_module, framework=android
+symbol ….NetworkModule.bindUserRepository  props: di_provider=true
+symbol ….AppComponent                  props: di_component=true, framework=android
+symbol ….UserRepository                props: android_component=repository
+```
+
+As in [Java](java.md#dependency-injection-which-is-where-callers-disappear), the point is
+that a `@Binds` provider has no direct caller. Marking it as wiring rather than dead code
+is the difference between a useful dead-code report and one nobody reads.
+
+## Loops and recursion
+
+```
+symbol ….HomeViewModel.updateItem  props: loop_count=1, loop_depth=1, scaling_loop_depth=0,
+                                          calls_in_loop=[….HomeViewModel.updateItem],
+                                          calls_in_scaling_loop=[]
+symbol ….fib                       props: recursive_self=true, cyclomatic=2
+```
+
+Same model as the other languages: a bounded loop records its calls but leaves the scaling
+set empty, and self-recursion is marked rather than reported as a cycle.
+
+## Compose and Android components
+
+Composable functions, ViewModels, repositories and Hilt entry points are tagged with
+`android_component` so a UI-layer question (*which screens read this repository?*) can be
+answered by filtering rather than by guessing from file paths.
+
+## What is deliberately not extracted
+
+- **KSP / kapt generated sources.** `**/generated/**` and `build/` are ignored by default;
+  a Room DAO implementation or a Hilt component generated at build time is not indexed.
+  The annotated declaration is what carries the meaning.
+- **Non-literal Retrofit paths.** `@GET(pathConstant)` is not resolved.
+- **Kotlin multiplatform expect/actual pairing** across source sets.
+- **Extension-function dispatch** resolves to the declared extension, not to receivers.
+
+---
+
+Measured on real Kotlin repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/php.md
+++ b/docs/extraction/php.md
@@ -1,0 +1,126 @@
+# PHP — what enola extracts
+
+Parsed with tree-sitter. Detected by `composer.json`, a WordPress bootstrap file
+(`wp-load.php` / `wp-settings.php` / `wp-config.php`), or any `.php` source within three
+directory levels — so a legacy tree with no package manager is still indexed.
+
+Fixtures: [`php_sample`](../../internal/engine/testdata/repos/php_sample/) (WordPress) ·
+[`php_laravel_sample`](../../internal/engine/testdata/repos/php_laravel_sample/) ·
+[`php_symfony_sample`](../../internal/engine/testdata/repos/php_symfony_sample/) ·
+[`php_multirepo`](../../internal/engine/testdata/repos/php_multirepo/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a source directory | one module, `framework=laravel` / `symfony` where detected | `module` |
+| `class`, `interface`, `trait`, `function` | a symbol with `symbol_kind` | `symbol` |
+| `use App\Other\Thing;` | a dependency | `dependency` |
+| `Route::get('/x', …)` (Laravel) | a server route | `route` |
+| `Route::apiResource('photos', …)` | **seven** routes, one per RESTful action | `route` |
+| `#[Route('/x')]` (Symfony attribute) | a server route with its route name | `route` |
+| `config/routes.yaml` | a server route per configured method | `route` |
+| `add_action` / `add_filter` (WordPress) | a pseudo-route on the hook name | `route` |
+| Guzzle / Laravel `Http::` / Symfony HttpClient | a client route with `role: client` | `route` |
+| Eloquent / Doctrine models | an entity | `storage` |
+
+## Routes — Laravel, including resource expansion
+
+```php
+Route::get('/api/users',  [UserController::class, 'index'])->name('users.index');
+Route::post('/api/users', [UserController::class, 'store']);
+Route::apiResource('photos', PhotoController::class);
+```
+
+Line 9 is one call. It becomes seven facts:
+
+```
+GET    /api/photos              action=index     handler=PhotoController::index
+POST   /api/photos              action=store     handler=PhotoController::store
+GET    /api/photos/create       action=create    handler=PhotoController::create
+GET    /api/photos/{id}         action=show      handler=PhotoController::show
+PUT    /api/photos/{id}         action=update    handler=PhotoController::update
+DELETE /api/photos/{id}         action=destroy   handler=PhotoController::destroy
+GET    /api/photos/{id}/edit    action=edit      handler=PhotoController::edit
+```
+
+All seven keep `routes/api.php:9` as their location, because that is the line you edit to
+change any of them. Route groups and prefixes compose onto these paths, and `->name()`
+is preserved as `name` so a `route('users.index')` reference resolves.
+
+## Routes — Symfony, from two sources
+
+Attributes on the controller and YAML in `config/` are both read, and the fact records
+which:
+
+```
+route  /products/{id}   src/Controller/ProductController.php:13
+       props: framework=symfony, name=product_show, handler=App\Controller\ProductController::show
+route  /health          config/routes.yaml
+       props: framework=symfony, name=health_check, source=symfony-config,
+              handler=App\Controller\HealthController::check
+route  /old/home        config/routes.yaml     method=GET   ┐ one fact per method,
+route  /old/home        config/routes.yaml     method=HEAD  ┘ as the config declares
+```
+
+A YAML-declared route has no line number — it is a configuration entry, not a statement —
+and `source=symfony-config` says so rather than inventing one.
+
+## Routes — WordPress hooks
+
+WordPress has no router; it has hooks. They are the actual entry points, so they are
+recorded as routes with the hook type as the method:
+
+```php
+add_action('init', 'acme_setup');
+add_filter('the_title', 'acme_format');
+```
+
+```
+route  ACTION init       inc/hooks.php:6   props: framework=wordpress, hook=add_action, callback=acme_setup
+route  FILTER the_title  inc/hooks.php:7   props: framework=wordpress, hook=add_filter, callback=acme_format
+```
+
+This is what stops a WordPress plugin's entire callback surface from reading as dead code:
+those functions have no PHP caller anywhere.
+
+## Outbound calls and cross-repo linking
+
+```
+route  /billing/invoices   consumer/src/BillingClient.php:16
+       props: role=client, framework=guzzle, api=BillingClient, source=php-http-client
+route  /billing/invoices   provider/routes/api.php:9
+       props: role=server, framework=laravel, handler=InvoiceController::index
+
+service consumer  props: edge_coverage=[{detected: 2, resolved: 2, unresolved: 0}]
+                  --depends_on--> provider
+```
+
+Guzzle, Laravel's `Http::` facade and Symfony's `HttpClient` are all recognised, each
+tagged with its own `framework` so you can tell which client library made the call.
+
+Note the third provider route in that fixture:
+
+```
+route  /billing/invoices/{id}   props: role=server, unmatched_by_clients=true
+```
+
+The provider serves it; no loaded client calls it. That is the `unused-routes` finding —
+a candidate at confidence `0.6`, because the caller may simply be a repository you have
+not loaded.
+
+## What is deliberately not extracted
+
+- **Routes registered in a loop** over a config array, or by a plugin discovery pass at
+  runtime.
+- **Non-literal paths and URLs.** `$client->get($endpoint)` with no literal binding is
+  not guessed.
+- **`__call` / `__callStatic` magic methods** — a call through them resolves to nothing
+  rather than to every candidate.
+- **Blade and Twig templates** are not yet parsed for helper calls, so a method used only
+  from a template can read as unreferenced. (The Ruby extractor does read ERB; PHP does
+  not yet.)
+
+---
+
+Measured on real PHP repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/python.md
+++ b/docs/extraction/python.md
@@ -1,0 +1,174 @@
+# Python — what enola extracts
+
+Parsed with tree-sitter. Detected by `pyproject.toml`, `setup.py`, `requirements.txt`,
+`Pipfile`, `pytest.ini`, `mypy.ini`, `tox.ini` or `setup.cfg`, at the root or up to three
+levels deep.
+
+Fixtures: [`python_sample`](../../internal/engine/testdata/repos/python_sample/) ·
+[`python_flask_sample`](../../internal/engine/testdata/repos/python_flask_sample/) ·
+[`py_fastapi_multirepo`](../../internal/engine/testdata/repos/py_fastapi_multirepo/) ·
+[`py_grpc_multirepo`](../../internal/engine/testdata/repos/py_grpc_multirepo/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a package directory | one module per directory | `module` |
+| `def`, `class`, `async def` | a symbol with `symbol_kind`, `exported`, `cyclomatic` | `symbol` |
+| `import` / `from … import` | a dependency tagged `internal` / `external` / `stdlib` | `dependency` |
+| a call inside a `for` / `while` | the callee in `calls_in_loop` / `calls_in_scaling_loop` | props |
+| `@app.get("/x")`, `@router.post("/y")` | a server route **at its composed runtime path** | `route` |
+| `app.include_router(r, prefix="/p")` | folds `/p` onto every route that router declares | — |
+| `@app.route` / `Blueprint` (Flask) | one route per HTTP method the decorator lists | `route` |
+| SQLAlchemy models | an entity with its table name | `storage` |
+| a `.proto` service + generated stub | both sides of a gRPC edge | `route` |
+| module-level statements | a `file_ref` carrying the call edges | `file_ref` |
+| `tests/`, `test_*.py`, `conftest.py` | a reference-only `test_ref` | `test_ref` |
+
+## Modules, symbols and calls
+
+Modules are directories, so `app/handlers/sqlalchemy` is its own module rather than part
+of `app`:
+
+```
+module  app
+module  app/handlers
+module  app/handlers/sqlalchemy
+module  app/handlers/tools
+
+symbol  app/api.handler        app/api.py:6
+        props: symbol_kind=function, exported=true, cyclomatic=1
+        --calls--> app/db.get_user
+        --declares--> app
+```
+
+Loop props work as they do in [Go](go.md#loops-for-n1-hunting) — `app/db.get_path` carries
+`loop_count=1, loop_depth=1, calls_in_scaling_loop=[app/db.get_user]`, which is the N+1
+candidate set.
+
+### Module-level code is not lost
+
+Python does real work at import time, and those calls belong to no function. They are
+recorded on a `file_ref` — an edge carrier that is not itself architecture:
+
+```
+file_ref  app/mcp_server.py   --calls--> app/mcp_server.health_check
+                              --calls--> app/mcp_server.list_users_tool
+                              --calls--> app/mcp_server.quickstart_prompt
+```
+
+Without this, an MCP tool registered by a decorator at module scope has no caller and
+reads as dead code.
+
+### Test references, and the one gap
+
+`tests/**`, `test_*.py` and `conftest.py` are ignored for indexing and recovered as
+`test_ref`:
+
+```
+test_ref  tests/test_app.py   --calls--> app/api.handler
+                              --calls--> app/tested_only.verify_checksum
+```
+
+> **Stated limit.** Python has no `TestRefExtractor` implementation yet — the globs are
+> configured and the recovery path exists, but until it is implemented a Python symbol
+> called *only* from a test reads as unreferenced. Expect dead-code false positives on
+> Python repositories to be higher than on Go, Ruby or TypeScript. This is written down
+> in [`internal/config/config.go`](../../internal/config/config.go) next to the globs
+> themselves rather than discovered later.
+
+## Routes — FastAPI router factories and `include_router`
+
+The dominant FastAPI idiom builds the router *inside* a function and nests the handlers
+as inner `def`s. Walking module-level statements never reaches those decorators, so this
+file used to emit no routes at all:
+
+```python
+# api/routers/search.py — the paths here are leaves
+def get_search_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/results")
+    async def results():
+        return []
+
+    @router.post("/")
+    async def search(payload: dict):
+        return {}
+
+    return router
+```
+
+```python
+# api/client.py — the mount is in a different file
+app = FastAPI()
+app.include_router(get_search_router(), prefix="/api/v1/search", tags=["search"])
+```
+
+The composed paths are what get stored:
+
+```
+route  /api/v1/search/results   api/routers/search.py:12   props: framework=fastapi, method=GET
+route  /api/v1/search           api/routers/search.py:16   props: framework=fastapi, method=POST
+```
+
+Note the second one: a router's `"/"` route under a `/api/v1/search` mount is
+`/api/v1/search`, not `/api/v1/search/`. Prefix folding runs repo-wide, so the factory
+and the mount can live anywhere.
+
+A TypeScript client in the same cluster then resolves against those paths:
+
+```
+route  /api/v1/search/results   web/src/api.ts:5    props: role=client, framework=fetch
+route  /api/v1/search           web/src/api.ts:17   props: role=client, framework=axios
+
+service acme  props: edge_coverage=[{edge_type: http_client, detected: 2, resolved: 2, unresolved: 0}]
+```
+
+## Routes — Flask
+
+```python
+@app.route("/users", methods=["GET", "POST"])
+def users(): ...
+
+@app.route("/health")
+def health(): ...
+```
+
+```
+route  /users    app.py:16   props: framework=flask, method=GET,  handler=app.users
+route  /users    app.py:16   props: framework=flask, method=POST, handler=app.users
+route  /health   app.py:22   props: framework=flask, method=GET,  handler=app.health
+```
+
+One fact per method, not one per decorator — because `GET /users` and `POST /users` are
+different endpoints with different clients, and an unused-route finding on one must not
+be masked by traffic on the other. Blueprints, `MethodView` classes and their registered
+prefixes are handled the same way (`views.HealthView.version`, `views.ping`).
+
+## gRPC
+
+```
+route  /users.v1.UserService/GetUser   proto/users/v1/users.proto   props: role=server, source=grpc-proto
+route  /users.v1.UserService/GetUser   client.py                    props: role=client, source=py-grpc-client
+dependency client -> server            props: type=cross_repo, via=[grpc], confidence=verified
+```
+
+`confidence=verified`, because both sides are matched through a declared contract rather
+than a string comparison.
+
+## What is deliberately not extracted
+
+- **Routes whose path is not a literal.** `@app.get(PREFIX + path_var)` is skipped rather
+  than guessed.
+- **Dynamic mounts.** `include_router` with a computed prefix leaves the sub-router's
+  routes at their bare paths rather than dropping them, so they stay visible and show up
+  as unresolved client edges.
+- **Runtime registration.** Routes added by a plugin loader or a metaclass at import time
+  are not traced.
+- **Duck typing and `getattr` dispatch.** A call through `getattr(obj, name)` resolves to
+  nothing rather than to every candidate.
+
+---
+
+Measured on real Python repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/ruby.md
+++ b/docs/extraction/ruby.md
@@ -1,0 +1,185 @@
+# Ruby — what enola extracts
+
+Parsed with tree-sitter. Detected by a `Gemfile` at the repository root. Rails
+conventions are recognised, but a plain Ruby project still produces modules, symbols and
+call edges.
+
+Fixture: [`ruby_sample`](../../internal/engine/testdata/repos/ruby_sample/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| `app/services`, `app/models/concerns`, … | one module per directory, `framework=rails` | `module` |
+| `class Foo < Bar` | a symbol with `superclass` | `symbol` |
+| `module Foo` | a symbol with `symbol_kind=interface` and an `abstract` verdict | `symbol` |
+| `def x` / `def self.x` | `Foo#x` (instance) / `Foo.x` (class) | `symbol` |
+| `STOP_WORDS = …` | a `constant` symbol | `symbol` |
+| `resources :things` in `routes.rb` | one route per generated path **and** method | `route` |
+| a class-body DSL macro (`track_metrics :runs`) | a `calls` edge on the class fact | relation |
+| `delegate :a, :b, to: :x` | `calls` edges for each delegated name | relation |
+| `public_send(:"report_#{t}")` | a `dynamic_send_prefixes` hint on the file | `file_ref` |
+| an ERB template | a `file_ref` carrying its helper and presenter calls | `file_ref` |
+| `spec/**/*_spec.rb`, `test/**/*_test.rb` | a reference-only `test_ref` | `test_ref` |
+
+## Routes — nested resource path shapes
+
+23 lines of routing DSL:
+
+```ruby
+Rails.application.routes.draw do
+  namespace :admin do
+    resources :reports, only: [:index, :show] do
+      resource  :export,   only: [:show, :create]
+      resources :sections, only: [:index, :show]
+    end
+  end
+
+  resource :session, only: [:show, :create, :destroy]
+  root to: "home#index"
+end
+```
+
+Ten route facts, each with the method and the controller action:
+
+```
+GET    /admin/reports                              action=index
+GET    /admin/reports/:id                          action=show
+GET    /admin/reports/:report_id/export            action=show      ← singular: no :id of its own
+POST   /admin/reports/:report_id/export            action=create
+GET    /admin/reports/:report_id/sections          action=index
+GET    /admin/reports/:report_id/sections/:id      action=show      ← plural: keeps its own :id
+GET    /session                                    action=show
+POST   /session                                    action=create
+DELETE /session                                    action=destroy
+GET    /                                           handler=home#index
+```
+
+The distinction the extractor has to get right is the third line versus the sixth. A
+singular `resource` nested in a plural `resources` hangs off the parent **member**
+(`/:report_id`) and has no `:id`; a plural `resources` keeps one. Get that wrong and a
+client calling `/admin/reports/7/export` matches nothing. `scope` and `namespace`
+prefixes compose the same way.
+
+## Modules, classes and the `abstract` verdict
+
+Ruby modules do two unrelated jobs, and enola separates them:
+
+```ruby
+module Trackable                 # a mixin: defines instance methods
+  extend ActiveSupport::Concern
+  def track!; touch(:tracked_at); end
+end
+
+module Reporting                 # a namespace: only wraps a class
+  class ReportWorker < BaseWorker; end
+end
+```
+
+```
+symbol Trackable   props: symbol_kind=interface, concern=true, abstract=true
+symbol Reporting   props: symbol_kind=interface,               abstract=false
+symbol Reporting::ReportWorker  props: symbol_kind=class, superclass=BaseWorker
+```
+
+`abstract` feeds package-metrics abstractness. A Concern that defines instance methods is
+never instantiated on its own and *is* an abstraction; a Rails namespace module is not,
+and counting it as one skews every module's abstractness score.
+
+## DSL macros, delegation and dynamic dispatch
+
+Ruby's metaprogramming is where naive extraction produces false dead code. Three cases,
+all resolved into ordinary edges:
+
+```ruby
+class ReportWorker < BaseWorker
+  track_metrics :runs                              # class-body macro
+  delegate :formatted_name, :subtitle, to: :presenter
+
+  def self.build(type)
+    public_send(:"report_#{type}", type)           # dynamic dispatch
+  end
+
+  def report_daily(type); end
+  def report_weekly(type); end
+end
+```
+
+- The macro is recorded as a `calls` edge (`track_metrics`) **on the class fact**, so the
+  base method backing it is not reported as dead.
+- `delegate` folds each delegated name into `calls`, so `formatted_name` and `subtitle`
+  have callers.
+- The interpolated symbol contributes `dynamic_send_prefixes: ["report_"]` to the file,
+  and same-prefix methods are treated as dispatched rather than dead. The prefix is only
+  committed because this scope also calls `send`/`public_send` — proximity to a
+  dispatcher is what makes the guess safe enough to act on.
+
+### Loop counting that does not cry wolf
+
+```ruby
+def summarize(users)
+  users.each { |user| notify(user); user.recent_posts }  # scaling → loop_depth 1
+  6.times { |i| bucket(i) }                              # constant-bounded → no depth
+  STOP_WORDS.each { |w| index(w) }                       # ALL-CAPS constant → bounded
+  %w[csv pdf].map.each { |fmt| render_format(fmt) }      # bounded literal behind a chain
+end
+
+def reindex(model)
+  model.find_in_batches { |batch| batch.each { |r| persist(r) } }   # depth 1, not 2
+end
+```
+
+```
+symbol …#summarize  props: loop_count=4, loop_depth=1, calls_in_loop=[notify, recent_posts]
+symbol …#reindex    props: loop_count=1, loop_depth=1, calls_in_loop=[persist]
+```
+
+Four loops, one of them scaling. `find_in_batches` yields a *batch*, so the inner `.each`
+is the real per-element loop and the nesting is depth 1 — reporting depth 2 there would
+flag the standard Rails batching idiom as a performance problem in every Rails codebase.
+
+### `super` is not recursion
+
+```ruby
+def display_label
+  decorate(__method__)
+  super
+end
+```
+
+`super` records a call to the same-named ancestor method and is deliberately *not*
+flagged `recursive_self` — it climbs the ancestor chain and terminates.
+
+## Views and tests
+
+```
+file_ref app/views/reports/show.html.erb  --calls--> ReportPresenter.render_summary
+                                          --calls--> current_user
+                                          --calls--> can_view_reports?
+test_ref spec/services/report_worker_spec.rb --calls--> Reporting::ReportWorker.build
+```
+
+ERB templates carry the only caller many presenters and helpers have. Specs are excluded
+from indexing but recovered as reference-only facts, so a method used only by a spec has
+an incoming edge without the spec becoming architecture.
+
+### One naming hazard, handled
+
+`app/jobs/cache_warmup_ab_test.rb` is production code whose basename ends in `test`. The
+test globs are **directory-scoped** (`**/test/**/*_test.rb`), not a bare `*_test.rb`
+suffix, so this file is indexed as source. A bare suffix glob both ignored it and routed
+it to reference-only extraction, and the class vanished from the graph entirely.
+
+## What is deliberately not extracted
+
+- **Routes drawn dynamically** — a `routes.rb` that loops over a config array is not
+  unrolled.
+- **`method_missing` and `define_method` with computed names**, beyond the
+  dispatcher-proximity prefix heuristic above.
+- **`ApplicationRecord`, `*BaseController` and `*::Base`** are excluded from god-class
+  candidacy: their fan-in comes from every subclass inheriting them, which is the
+  framework working, not a design problem.
+
+---
+
+Measured on real Ruby repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/rust.md
+++ b/docs/extraction/rust.md
@@ -1,0 +1,145 @@
+# Rust — what enola extracts
+
+Parsed with tree-sitter. Detected by a `Cargo.toml`, at the root or up to three levels
+deep, so a workspace with member crates in subdirectories is picked up.
+
+Fixture: [`rust_sample`](../../internal/engine/testdata/repos/rust_sample/) ·
+Axum route behaviour is covered by
+[`rustextractor/axum_test.go`](../../internal/extractors/rustextractor/axum_test.go)
+
+> **Check your `mcp-arch.yaml` before you conclude Rust is unsupported.** A config file's
+> `extractors:` list *replaces* the built-in default rather than merging with it, so a
+> config written before an extractor existed silently disables it. A repository indexed
+> with a stale list reports zero Rust facts and says nothing about why. Either add `rust`
+> to the list or delete the key to inherit the default.
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a crate or module directory | one module with its `crate` name | `module` |
+| `fn`, `struct`, `enum`, `trait`, `impl` block | a symbol with `symbol_kind` | `symbol` |
+| a method in an `impl` | a symbol with `receiver` and `static` | `symbol` |
+| `use crate::db::get_user;` | a dependency tagged `internal` / `external` | `dependency` |
+| a constructor call | an `instantiates` relation | relation |
+| `.route("/x", get(h))` (Axum) | a server route **at its composed mount path** | `route` |
+| `.nest("/p", other::router())` | folds `/p` onto every route the nested router declares | — |
+
+## Symbols
+
+```rust
+// src/db.rs
+pub struct User { … }
+
+impl User {
+    pub fn new(name: &str) -> Self { User { name: String::from(name) } }
+}
+
+pub fn get_user() -> User { User::new("x") }
+```
+
+```
+symbol  src.User        src/db.rs:3    props: symbol_kind=struct, exported=true
+symbol  src.User.new    src/db.rs:9    props: symbol_kind=method, receiver=User, static=true
+                                       --instantiates--> User
+                                       --instantiates--> String
+symbol  src.get_user    src/db.rs:17   props: symbol_kind=function, exported=true
+                                       --instantiates--> User
+dependency src -> crate::db::get_user  src/api.rs:3   props: source=internal
+```
+
+`static=true` distinguishes an associated function (`User::new`) from a method taking
+`self` — they have different call sites and different impact when changed.
+
+## Routes — Axum `.nest()` composed across files
+
+An Axum application assembles its router from sub-routers, and the mount prefix lives in
+a different file from the paths it applies to:
+
+```rust
+// src/router_builder.rs
+fn build() -> Router {
+    Router::new()
+        .route("/", get(root))
+        .nest("/api/v1/datasets", routers::datasets::router())
+        .nest("/api/v1/search",   routers::search::router())
+}
+```
+
+```rust
+// src/routers/datasets.rs
+pub fn router() -> Router {
+    Router::new()
+        .route("/",                  get(list).post(create))
+        .route("/status",            get(status))
+        .route("/{dataset_id}/data", get(data))
+}
+```
+
+The composed paths are what get stored:
+
+```
+/                                      ← the root builder's own route, still bare
+/api/v1/datasets                       ← the sub-router's "/" under its mount
+/api/v1/datasets/status
+/api/v1/datasets/{dataset_id}/data
+/api/v1/search
+```
+
+and the bare `/status` is **gone** — it is not stored alongside the composed path, because
+a route that is not served at `/status` must not match a client calling `/status`.
+
+Composition is a crate-wide fixpoint, so it accumulates through multiple levels:
+
+```rust
+// build() nests "/api/v1/activity" → activity::router()
+// activity::router() nests "/spans" → spans::router()
+// spans::router() declares "/{id}"
+→ /api/v1/activity/agents
+→ /api/v1/activity/spans/{id}
+```
+
+### Per-route middleware is transparent
+
+```rust
+.route("/plain",   get(handler))
+.route("/layered", get(handler).layer(Extension(state)))   // still a GET /layered
+.route("/both",    get(list).post(create).layer(mw))       // both verbs survive
+```
+
+A non-verb method in the chain — `.layer()`, `.route_layer()`, `.with_state()` — is a
+decorator, not a terminator. Treating one as a terminator dropped the route entirely
+rather than losing an annotation, with the verb sitting in plain sight.
+
+### Graceful degradation, on purpose
+
+```rust
+fn build(mount: &str, r: Router) -> Router {
+    Router::new().nest(mount, r)      // the mount is not a literal
+}
+```
+
+The nested router's routes keep their **bare** paths (`/thing`) rather than being dropped.
+A visible route at the wrong path is still findable and still shows up as an unresolved
+client edge; a dropped route is invisible. The same rule covers `.route(path, svc)` with
+a non-literal path — it emits nothing rather than guessing.
+
+## What is deliberately not extracted
+
+- **Macro-generated routes and items.** Anything produced by a proc macro is not
+  expanded. This is the largest real-world gap, not a corner case: a production service
+  that declares its API through a router macro exposes almost none of it to enola, and
+  the resulting route count looks like a bug rather than a boundary. Check how your
+  routes are declared before reading a low number as one.
+- **`.route(path, handler_value)`** — a handler passed as a value rather than through a
+  verb builder. There is no method to infer, and a guessed one could false-match
+  another repository's endpoint, so the route is skipped rather than invented.
+- **Non-literal paths and mounts**, per the degradation rule above.
+- **Trait dispatch.** A call through `dyn Trait` resolves to the trait method, not to
+  every `impl`.
+- **`cfg`-gated code** is parsed as written; enola does not evaluate feature flags, so all
+  branches contribute facts.
+
+---
+
+Measured on real Rust repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/swift.md
+++ b/docs/extraction/swift.md
@@ -1,0 +1,129 @@
+# Swift — what enola extracts
+
+Parsed with the [tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift)
+grammar, vendored under
+[`internal/extractors/swiftextractor/grammar/`](../../internal/extractors/swiftextractor/grammar/).
+Detected by `Package.swift`, `.xcodeproj` or `.xcworkspace`.
+
+Fixture: [`swift_sample`](../../internal/engine/testdata/repos/swift_sample/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| an SPM target | a module with `spm_package`, `spm_target`, `module_role` | `module` |
+| an Xcode app target | **several** modules, one per source directory | `module` |
+| `class`, `struct`, `enum`, `protocol` | a symbol with `symbol_kind`, `final`, `enum` | `symbol` |
+| a method | a symbol with `receiver`, `async`, `override` | `symbol` |
+| a method that calls itself | `recursive_self=true` | props |
+| `URLSession.shared.data(for:)` | `io_direct=true` **and** a client route | props + `route` |
+| a method that only *calls* one that does I/O | `performs_io=true`, transitively | props |
+| `#if DEBUG` around a declaration | `conditional=true` | props |
+| a `TargetType`-style endpoint enum | one client route per case, at the composed path | `route` |
+| `import OtherTarget` | a dependency with `spm=true` and the manifest that declares it | `dependency` |
+
+## Modules — SPM targets and the Xcode app-target problem
+
+```
+module ./Sources/CoreKit    props: spm_package=CoreKit, spm_target=CoreKit, module_role=production
+module Tests/CoreKitTests   props: spm_package=CoreKit, spm_target=CoreKitTests, module_role=test
+dependency Tests/CoreKitTests -> ./Sources/CoreKit
+           props: source=internal, spm=true, manifest=Package.swift
+```
+
+`module_role` separates production from test targets, so a test target's imports do not
+count as production coupling.
+
+An **Xcode app target** is the awkward case: a whole iOS app is often one target, which
+would collapse the entire application into a single module and make every architectural
+question about it unanswerable. App and app-extension targets declared in an XcodeGen
+project are therefore subdivided into **one module per source directory**, with
+intra-target type references contributing coupling between them. Frameworks and SPM
+packages stay whole, because there the target boundary is already the architecture.
+
+## Symbols
+
+```
+symbol …CoreKit.FeedService            props: symbol_kind=class, final=true,
+                                              signature="let baseURL: URL\nfunc fetchFeed() async throws -> Data\n…"
+symbol …CoreKit.FeedService.fetchFeed  props: async=true, io_direct=true, performs_io=true, receiver=FeedService
+symbol …CoreKit.FeedService.loadFeed   props: async=true, performs_io=true, receiver=FeedService
+symbol …CoreKit.TreeWalker.walk        props: recursive_self=true, cyclomatic=2
+symbol …CoreKit.SelectableCell.setSelected  props: override=true
+symbol …CoreKit.Gate                   props: conditional=true, final=true
+```
+
+### `io_direct` versus `performs_io`
+
+```swift
+func fetchFeed() async throws -> Data {
+    let (data, _) = try await URLSession.shared.data(for: request)   // io_direct
+}
+
+func loadFeed() async throws -> Data {
+    return try await fetchFeed()                                     // performs_io, transitively
+}
+```
+
+`io_direct` means this function itself invokes a network primitive. `performs_io` is
+propagated up the call graph, so a caller three hops from `URLSession` still reports that
+it reaches the network. That is the difference between "this function does I/O" and "this
+function is on an I/O path", and only the second answers *is it safe to call this in a
+loop?*
+
+## Routes — endpoint enums with a protocol-extension prefix
+
+The version prefix is not in the enum. It is a default implementation on the protocol, in
+a different declaration:
+
+```swift
+protocol APIEndpoint {
+    var urlPrefixComponent: String { get }
+    var urlPathComponent: String { get }
+    var method: HTTPMethod { get }
+}
+
+extension APIEndpoint {
+    var urlPrefixComponent: String { "v2" }      // repo-wide default
+}
+
+enum ReportsEndpoint: APIEndpoint {              // declares no prefix of its own
+    case list
+    case send([String: Any])
+}
+
+extension ReportsEndpoint {
+    var urlPathComponent: String {
+        switch self { case .list: return "reports.json"; case .send: return "reports.json" }
+    }
+    var method: HTTPMethod {
+        switch self { case .list: return .get; case .send: return .post }
+    }
+}
+```
+
+Every case inherits `"v2"`, so the client routes are `v2/reports.json` for `GET` and for
+`POST` — composed across a protocol extension that may be three files away. A direct
+`URLSession` call is picked up too:
+
+```
+route  feed/items   Sources/CoreKit/Networking.swift:17
+       props: role=client, framework=urlsession, source=urlsession, method=GET, api=Networking
+```
+
+This is the iOS half of *if I change this endpoint, which screens break?* — the mobile
+client's call has to reach the backend route, and it only does if the prefix was resolved.
+
+## What is deliberately not extracted
+
+- **Runtime-composed URLs.** A path assembled from a computed property with no literal
+  binding is not guessed.
+- **Objective-C interop.** `@objc` selectors and bridged call sites are not traced.
+- **Protocol witness dispatch.** A call through a protocol resolves to the protocol
+  requirement, not to every conforming type.
+- **`#if` branches** are all parsed; enola does not evaluate build configurations, but the
+  affected declarations carry `conditional=true` so you can tell.
+
+---
+
+Measured on real Swift repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/docs/extraction/typescript.md
+++ b/docs/extraction/typescript.md
@@ -1,0 +1,138 @@
+# TypeScript / JavaScript — what enola extracts
+
+Parsed with tree-sitter's TypeScript grammar, which handles JavaScript natively — there
+is no separate JS extractor. Detected by `tsconfig.json`, `tsconfig.base.json`, or a
+`package.json` with TypeScript, at the root or one level deep, so monorepos are picked up
+per package. Vue and Svelte are the same extractor with their own single-file-component
+handling.
+
+Fixtures: [`ts_sample`](../../internal/engine/testdata/repos/ts_sample/) ·
+[`ts_express_multirepo`](../../internal/engine/testdata/repos/ts_express_multirepo/) ·
+[`ts_nest_multirepo`](../../internal/engine/testdata/repos/ts_nest_multirepo/) ·
+[`ts_orm_sample`](../../internal/engine/testdata/repos/ts_orm_sample/)
+
+## At a glance
+
+| You write | enola stores | Kind |
+|---|---|---|
+| a source directory | one module per directory | `module` |
+| `function`, `class`, `interface`, `const fn = …` | a symbol with `symbol_kind` | `symbol` |
+| `import … from` | a dependency, `internal` / `external` | `dependency` |
+| `app.get("/x", h)` (Express) | a server route | `route` |
+| `@Get()` on a `@Controller("v2/slots")` | a server route at the **composed** path | `route` |
+| `@controller(…)` (InversifyJS) | a server route | `route` |
+| `fetch("/x")`, `axios.post("/y")` | a client route with `role: client` | `route` |
+| `pages/about.vue` (Nuxt) | a route derived from the file path | `route` |
+| `src/routes/blog/[slug]/+page.svelte` | a route derived from the file path | `route` |
+| a Prisma / TypeORM / Drizzle model | an entity with its table name | `storage` |
+| top-level statements | a `file_ref` carrying the call edges | `file_ref` |
+| `*.test.ts`, `*.spec.tsx` | a reference-only `test_ref` | `test_ref` |
+
+## Routes — NestJS controller prefixes
+
+```ts
+// api/src/slots/slots.controller.ts
+@Controller('v2/slots')
+export class SlotsController {
+  @Get('available')  getAvailableSlots() {}   // line 10
+  @Post('reserve')   reserveSlot() {}         // line 15
+}
+```
+
+```
+route  /v2/slots/available   api/src/slots/slots.controller.ts:10
+       props: framework=nestjs, method=GET, handler=getAvailableSlots, role=server
+route  /v2/slots/reserve     api/src/slots/slots.controller.ts:15
+       props: framework=nestjs, method=POST, handler=reserveSlot, role=server
+```
+
+The class-level prefix is folded onto each method decorator, so the stored path is the
+one a client actually calls. InversifyJS `@controller` prefixes are handled the same way
+(`/api/orders`, `/api/orders/:id/cancel` in the same fixture).
+
+## Routes — Express
+
+```
+route  /healthcheck        server/index.js:8    props: framework=express, method=GET
+route  /healthcheck        server/index.js:9    props: framework=express, method=OPTIONS
+route  /go/:name           server/index.js:10   props: framework=express, method=GET,
+                                                       unmatched_by_clients=true
+route  /admin/users/:id/ban server/index.js:20  props: framework=express, method=POST
+```
+
+`unmatched_by_clients=true` is what the `unused-routes` explainer reports: an endpoint
+this repository serves that no loaded client calls. It is a *candidate* at confidence
+`0.6`, not a verdict — the client may simply not be in the graph.
+
+## Client calls, and how a near-miss is reported
+
+```ts
+await axios.get('/healthcheck');
+await axios.get('/admin/users');
+await axios.post(`/admin/users/${id}/ban`);
+await axios.get('/not/served/anywhere');
+```
+
+```
+route  /healthcheck           props: role=client, framework=axios,
+                                     unmatched_by_server=true, unmatched_reason=generic_path
+route  /admin/users           props: role=client, framework=axios          → resolves
+route  /admin/users/{}/ban    props: role=client, framework=axios          → resolves
+route  /not/served/anywhere   props: role=client, framework=axios,
+                                     unmatched_by_server=true, unmatched_reason=path_unknown
+```
+
+Two things worth noticing. A template literal becomes `{}`, which matches the server's
+`:id` — that is how `/admin/users/${id}/ban` links to `/admin/users/:id/ban`. And the two
+misses carry **different reasons**: `/healthcheck` is too generic to attribute to one
+server with confidence, while `/not/served/anywhere` has no candidate at all. The service
+tally is `detected: 4, resolved: 2, unresolved: 2` — reported, not rounded up.
+
+## File-based routing
+
+Nuxt pages and SvelteKit routes have no decorator to read; the path *is* the route.
+
+```
+pages/about.vue                          → route /about          framework=nuxt
+src/routes/+page.svelte                  → route /               type=page
+src/routes/about/+page.svelte            → route /about          type=page
+src/routes/blog/[slug]/+page.svelte      → route /blog/[slug]    type=page
+src/routes/api/users/+server.ts          → route /api/users      type=server, method=ALL
+src/routes/(app)/dashboard/+page.svelte  → route /dashboard      route group stripped
+src/routes/+layout.svelte                → route /               type=layout
+```
+
+Two deliberate non-routes, both covered by tests: `+page.server.ts` is a load function
+rather than an endpoint and emits nothing, and a `.svelte` file outside `src/routes/`
+(a component in `src/lib/`) is not a route.
+
+## Storage — three ORMs, one shape
+
+```
+storage  prisma.Post   prisma/schema.prisma:5   props: framework=prisma,  table=Post
+storage  src.User      src/entity.ts:5          props: framework=typeorm, table=users
+storage  src.Session   src/entity.ts:15         props: framework=typeorm, table=Session
+storage  src.orders    src/schema.ts:4          props: framework=drizzle, table=orders
+```
+
+`table` is the *physical* name — `@Entity('users')` gives `users`, while an undecorated
+`Session` class keeps its class name. That distinction matters when the same database is
+reached from another repository in another language.
+
+## What is deliberately not extracted
+
+- **Non-literal paths.** `axios.get(url)` where `url` is a variable with no literal
+  binding produces no route. A base URL resolved from a file-local literal *is* followed;
+  one injected from config is not.
+- **`openGraph` and metadata objects** that contain URL-shaped strings are not requests,
+  and are not recorded as client routes.
+- **Prefetch and refetch helpers** are separated from real request boundaries, so a
+  query-cache warm-up does not double-count as an outbound call.
+- **Paths without a leading `/`.** A bare `"users"` string is too ambiguous to treat as a
+  request path.
+- **Runtime-registered routes** — an Express router assembled in a loop over a config
+  array is not unrolled.
+
+---
+
+Measured on real TypeScript repositories: [BENCHMARKS.md](../BENCHMARKS.md).

--- a/examples/multi-repo.yaml
+++ b/examples/multi-repo.yaml
@@ -94,19 +94,24 @@ ignore:
   - "Dockerfile"
   - "**/Dockerfile*"
   - "**/.env*"
-extractors:
-  - go
-  - kotlin
-  - typescript
-  - swift
-  - ruby
-# explainers: / renderers: are deliberately absent.
+# extractors: / explainers: / renderers: are all deliberately absent.
 #
 # A list-valued key REPLACES the built-in list rather than extending it, so naming
 # a subset here silently disables everything that ships beyond it — this file used
 # to pin four explainers, turning off the other six (god-class, hotspots,
 # unused-routes, dependency-depth, exported-surface, complexity-outliers) for anyone
 # who adopted it. Omitting the keys means new plugins arrive automatically.
+#
+# `extractors:` was the same mistake, and worse here than anywhere else. This file
+# pinned five languages while its own header promised it "enables all extractors so
+# it works regardless of which languages each repository uses" — so a cluster
+# containing a PHP, Rust, Python, Java or C++ repository indexed it as though the
+# language were unsupported. A cluster config is the one place you cannot know in
+# advance which languages will turn up, which is exactly why it must not guess.
+#
+# The per-language examples (go.yaml, ruby.yaml, …) DO pin one extractor, and that
+# is correct: naming the language is the entire point of those files. The rule is
+# "pin a plugin list only when the list is the reason the file exists".
 output:
   dir: ".enola"
   max_context_tokens: 16000


### PR DESCRIPTION
…omised

  in its own header that it "enables all extractors so it works regardless of
  which languages each repository uses", then named five of twelve — so a
  cluster containing PHP, Rust, Python, Java or C++ indexed those repos as
  though the language were unsupported. A cluster config is the one place you
  cannot know which languages will turn up. The per-language examples keep
  their single extractor: pin a plugin list only when the list is the reason
  the file exists.
- CONTRIBUTING: enable the pre-push hook, and run the agent-hook end-to-end test if you touch the installer. CI cannot run it — runners do not run agent sessions — so a developer's machine is the only place it executes.
- docs/BENCHMARKS.md: 38 repositories, 4,211,113 facts, 239,349 files, zero parse errors, 38/38 byte-identical across 114 runs. Ratchet widened to 12 repositories and 8 languages against 1,192 pre-existing findings. Swift is excluded from that section only, with the reason stated.