### PR TITLE
Resolve module directory against both snapshot shapes

### DIFF
--- a/internal/explainers/common/common.go
+++ b/internal/explainers/common/common.go
@@ -53,15 +53,83 @@ func FileDir(file string) string {
 // a name no module has, in any repo. Anything resolving a file back to its module has
 // to cross that gap explicitly.
 //
-// Repo is populated in BOTH modes; only the File prefix is append-mode-specific. That
-// is what makes the strip safe rather than lossy: a single-repo fact is File "main.go"
-// with Repo "go_sample", the prefix does not match, and nothing is removed.
+// Repo is populated in BOTH modes; only the File prefix is append-mode-specific.
+//
+// The strip is NOT unconditionally safe, which is why callers that know the module
+// namespace should prefer ModuleDirCandidates. It assumes the repo label cannot also
+// be a real leading path segment — false for the dominant Python layout, where the
+// package inside the repo carries the repo's own name (cognee/cognee,
+// superset/superset). There "cognee/pkg/x.py" strips to "pkg", which names no module,
+// so every edge out of the tree hangs off a phantom node.
 func ModuleDir(f facts.Fact) string {
 	file := f.File
 	if f.Repo != "" {
 		file = strings.TrimPrefix(file, f.Repo+"/")
 	}
 	return FileDir(file)
+}
+
+// ModuleDirCandidates returns the directories a fact's file may name in MODULE-NAME
+// space. Both are legitimate; which one is correct depends on the snapshot's shape,
+// and that cannot be decided from the fact alone:
+//
+//   - the raw repo-relative directory — correct in a single-repo snapshot, including
+//     the case where the first path segment genuinely equals the repo name;
+//   - the same directory with the repo label stripped — correct in an append-mode
+//     (multi-repo) snapshot, where File is repo-prefixed and module names are not.
+//
+// Callers resolve against the module namespace they hold rather than guessing. A
+// caller that used ModuleDir alone silently lost every edge in a repo whose top-level
+// source directory shares the repo's name.
+func ModuleDirCandidates(f facts.Fact) []string {
+	raw := FileDir(f.File)
+	stripped := ModuleDir(f)
+	if raw == stripped {
+		return []string{raw}
+	}
+	return []string{raw, stripped}
+}
+
+// resolveModuleDir picks the module a fact's file belongs to, trying every candidate
+// directory against the known module names.
+//
+// EXACT matches on all candidates are tried before walking any of them up. The order
+// is load-bearing: walking a candidate up can reach a short ancestor that happens to
+// exist in the other snapshot shape (the bare repo label "consumer" in an append-mode
+// graph), so letting a walk-up beat an exact match would let the two shapes
+// cross-match and attribute an edge to the wrong module.
+func resolveModuleDir(f facts.Fact, prod, test map[string]bool) string {
+	candidates := ModuleDirCandidates(f)
+	for _, c := range candidates {
+		if prod[c] || test[c] {
+			return c
+		}
+	}
+	for _, c := range candidates {
+		if m := nearestModuleOrEmpty(c, prod, test); m != "" {
+			return m
+		}
+	}
+	// Unchanged fallback: the repo-stripped directory, so a fact that resolves to no
+	// module at all behaves exactly as it did before.
+	return candidates[len(candidates)-1]
+}
+
+// nearestModuleOrEmpty walks dir up its path until it reaches a known production or
+// test module, returning "" when nothing encloses it — the difference from
+// nearestModule, which reports the input unchanged and so cannot express a miss.
+func nearestModuleOrEmpty(dir string, prod, test map[string]bool) string {
+	cur := dir
+	for {
+		if prod[cur] || test[cur] {
+			return cur
+		}
+		i := strings.LastIndex(cur, "/")
+		if i < 0 {
+			return ""
+		}
+		cur = cur[:i]
+	}
 }
 
 // nearestModule walks dir up its path until it reaches a known production or test
@@ -71,17 +139,10 @@ func ModuleDir(f facts.Fact) string {
 // only differs for nested layouts (Swift/Xcode targets) where the module lives
 // above the file's leaf directory. Mirrors package_metrics' resolveToModule.
 func nearestModule(dir string, prod, test map[string]bool) string {
-	cur := dir
-	for {
-		if prod[cur] || test[cur] {
-			return cur
-		}
-		i := strings.LastIndex(cur, "/")
-		if i < 0 {
-			return dir
-		}
-		cur = cur[:i]
+	if m := nearestModuleOrEmpty(dir, prod, test); m != "" {
+		return m
 	}
+	return dir
 }
 
 // IsExternalImport reports whether an import target points outside the repo
@@ -217,13 +278,16 @@ func BuildModuleGraphExcluding(store *facts.Store, excludeKinds ...string) map[s
 		// edge could form (which silently zeroed cycle detection on such projects).
 		// Resolving up keeps this graph consistent with package_metrics.
 		//
-		// ModuleDir, not FileDir: in an append-mode snapshot the file is repo-prefixed
-		// ("consumer/src/client.ts") while module facts keep their bare name ("src").
-		// Walking up from the prefixed dir reaches no module and nearestModule returns
-		// the raw directory, so every multi-repo edge used to hang off a phantom node
-		// that nothing else referenced — silently costing cycle and depth detection the
-		// coupling that spans repositories.
-		sourceModule := nearestModule(ModuleDir(dep), moduleNames, testModules)
+		// Resolved against BOTH the raw and repo-stripped directories, because which
+		// one is right depends on the snapshot's shape. In an append-mode snapshot the
+		// file is repo-prefixed ("consumer/src/client.ts") while module facts keep
+		// their bare name ("src"), so the raw dir resolves to nothing. But stripping
+		// unconditionally breaks the opposite case — a single-repo Python layout whose
+		// package carries the repo's name ("cognee/benchcyca" -> "benchcyca") — where
+		// the stripped dir is the one that names no module. Either way the edge used
+		// to hang off a phantom node nothing else referenced, silently zeroing cycle
+		// and depth detection across the whole tree. See resolveModuleDir.
+		sourceModule := resolveModuleDir(dep, moduleNames, testModules)
 		if testModules[sourceModule] {
 			continue // edge out of a test bundle — not production architecture
 		}

--- a/internal/explainers/common/moduledir_test.go
+++ b/internal/explainers/common/moduledir_test.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// The two snapshot shapes a dependency fact can arrive in. Neither the raw file
+// directory nor the repo-stripped one is correct for both, which is the whole reason
+// ModuleDirCandidates exists.
+//
+// The single-repo case here is the one that regressed in the field: a Python package
+// carrying its repository's own name (cognee/cognee, superset/superset). Stripping the
+// repo label removed a REAL path segment, so the edge was attributed to a module name
+// that existed nowhere and every cycle through that tree went undetected.
+func TestResolveModuleDir_BothSnapshotShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		fact facts.Fact
+		prod []string
+		want string
+	}{
+		{
+			name: "single repo, package shares the repo name",
+			fact: facts.Fact{Repo: "cognee", File: "cognee/benchcyca/__init__.py"},
+			prod: []string{"cognee", "cognee/benchcyca", "cognee/benchcycb"},
+			want: "cognee/benchcyca",
+		},
+		{
+			name: "append mode, file is repo-prefixed",
+			fact: facts.Fact{Repo: "consumer", File: "consumer/src/client.ts"},
+			prod: []string{"src", "routes"},
+			want: "src",
+		},
+		{
+			name: "single repo, package differs from the repo name",
+			fact: facts.Fact{Repo: "proj", File: "pkg/a/__init__.py"},
+			prod: []string{"pkg", "pkg/a", "pkg/b"},
+			want: "pkg/a",
+		},
+		{
+			name: "nested layout resolves up to the module root",
+			fact: facts.Fact{Repo: "app", File: "Sources/Foo/Bar/X.swift"},
+			prod: []string{"Sources/Foo"},
+			want: "Sources/Foo",
+		},
+		{
+			name: "no enclosing module falls back to the repo-stripped dir",
+			fact: facts.Fact{Repo: "app", File: "app/unknown/x.go"},
+			prod: []string{"other"},
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prod := make(map[string]bool, len(tt.prod))
+			for _, m := range tt.prod {
+				prod[m] = true
+			}
+			if got := resolveModuleDir(tt.fact, prod, map[string]bool{}); got != tt.want {
+				t.Errorf("resolveModuleDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// An exact match on ANY candidate must beat a walk-up on any other. Without that
+// ordering the repo label itself ("consumer") can absorb an edge whose real module is
+// the stripped path, so the two snapshot shapes cross-match.
+func TestResolveModuleDir_ExactBeatsWalkUp(t *testing.T) {
+	f := facts.Fact{Repo: "consumer", File: "consumer/src/client.ts"}
+	prod := map[string]bool{"consumer": true, "src": true}
+
+	if got := resolveModuleDir(f, prod, map[string]bool{}); got != "src" {
+		t.Errorf("resolveModuleDir() = %q, want %q — a walk-up to the repo label beat an exact match", got, "src")
+	}
+}
+
+// A module cycle must close when the package carries the repo's name. This is the
+// end-to-end shape of the field regression, expressed on the graph the cycles
+// explainer actually reads.
+func TestBuildModuleGraph_CycleClosesWhenPackageSharesRepoName(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "cognee", Repo: "cognee", File: "cognee"},
+		facts.Fact{Kind: facts.KindModule, Name: "cognee/a", Repo: "cognee", File: "cognee/a"},
+		facts.Fact{Kind: facts.KindModule, Name: "cognee/b", Repo: "cognee", File: "cognee/b"},
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "cognee/a/__init__ -> cognee.b",
+			Repo: "cognee", File: "cognee/a/__init__.py",
+			Relations: []facts.Relation{{Kind: facts.RelImports, Target: "cognee/b"}},
+		},
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "cognee/b/__init__ -> cognee.a",
+			Repo: "cognee", File: "cognee/b/__init__.py",
+			Relations: []facts.Relation{{Kind: facts.RelImports, Target: "cognee/a"}},
+		},
+	)
+
+	graph := BuildModuleGraph(store)
+
+	for _, edge := range [][2]string{{"cognee/a", "cognee/b"}, {"cognee/b", "cognee/a"}} {
+		found := false
+		for _, to := range graph[edge[0]] {
+			if to == edge[1] {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing edge %s -> %s; graph = %v", edge[0], edge[1], graph)
+		}
+	}
+	// The phantom node the bug produced: the repo-stripped source dir, which names no
+	// module and therefore anchors edges nothing else can reach.
+	if len(graph["a"]) > 0 {
+		t.Errorf("edge attributed to phantom node %q (repo prefix wrongly stripped): %v", "a", graph["a"])
+	}
+}

--- a/internal/explainers/layers/layers.go
+++ b/internal/explainers/layers/layers.go
@@ -462,11 +462,14 @@ func (e *LayerExplainer) detectViolations(store *facts.Store, pattern *archPatte
 		}
 		// Resolve the importing file's directory up to its nearest classified module,
 		// so a file nested below the module root (Swift/Xcode) still attributes to a
-		// layer instead of being dropped. ModuleDir rather than FileDir: in an
-		// append-mode snapshot the file is repo-prefixed and module names are not, so
-		// FileDir yields the repo label and nothing resolves — which silenced this
-		// explainer entirely for multi-repo graphs.
-		sourceModule, sourceOK := resolveLayerModule(common.ModuleDir(dep), pattern.Modules)
+		// layer instead of being dropped. Both the raw and repo-stripped directories
+		// are tried: the stripped one is required in an append-mode snapshot (the file
+		// is repo-prefixed and module names are not, so the raw dir yields the repo
+		// label and nothing resolves), while the raw one is required in a single-repo
+		// layout whose top-level package carries the repo's own name, where stripping
+		// removes a real path segment. Using either alone silences this explainer for
+		// one of the two shapes.
+		sourceModule, sourceOK := resolveLayerModuleFor(dep, pattern.Modules)
 		if !sourceOK {
 			continue
 		}
@@ -584,6 +587,28 @@ func resolveLayerModule(path string, modules map[string]string) (string, bool) {
 		}
 		cur = cur[:i]
 	}
+}
+
+// resolveLayerModuleFor resolves a dependency fact's own file to a classified module,
+// trying every directory the file may name (see common.ModuleDirCandidates).
+//
+// Exact matches are tried across all candidates before any is walked up, for the same
+// reason as common.resolveModuleDir: a walk-up can reach a short ancestor that exists
+// only because of the OTHER snapshot shape, and letting it beat an exact match would
+// attribute the import to the wrong module.
+func resolveLayerModuleFor(dep facts.Fact, modules map[string]string) (string, bool) {
+	candidates := common.ModuleDirCandidates(dep)
+	for _, c := range candidates {
+		if _, ok := modules[c]; ok {
+			return c, true
+		}
+	}
+	for _, c := range candidates {
+		if m, ok := resolveLayerModule(c, modules); ok {
+			return m, true
+		}
+	}
+	return "", false
 }
 
 // matchesLayer checks if a module path contains any of the given patterns.


### PR DESCRIPTION
ModuleDir strips the repo label unconditionally, so a top-level source directory sharing the repository's name resolves to a name no module has. Edges out of that tree hang off a phantom node and leave the coupling graph entirely, taking cycle and layer detection with them.

Add ModuleDirCandidates, returning both the raw and repo-stripped directories. Callers resolve against the module names they hold, trying exact matches on every candidate before any walk-up, so the two snapshot shapes cannot cross-match. Applied in BuildModuleGraphExcluding and in the layers explainer, which had the same defect.