### PR TITLE
Warn when the explainer set differs between snapshots

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -101,6 +101,11 @@ const (
 	// WarnExtractorSet — the extractor sets differ, so one language's facts appear
 	// wholesale as added or removed.
 	WarnExtractorSet WarningKind = "extractor_set"
+	// WarnExplainerSet — the explainer sets differ, so one explainer's findings appear
+	// wholesale as new or resolved. Advisory rather than blocking: the fact delta is
+	// unaffected, so the change is still gradeable — only the finding attribution for
+	// the explainers that differ is wrong.
+	WarnExplainerSet WarningKind = "explainer_set"
 	// WarnIgnoreGlobs — the ignore globs differ, so the set of files parsed changed.
 	WarnIgnoreGlobs WarningKind = "ignore_globs"
 	// WarnInvertedPair — the baseline is NEWER than the current snapshot, so the
@@ -360,6 +365,33 @@ func compareMeta(base, cur facts.SnapshotMeta) Comparability {
 	if only := missingFrom(cur.Extractors, base.Extractors); len(only) > 0 {
 		c.add(WarnExtractorSet,
 			"current run added extractor(s) not in the baseline: %s — their facts will all appear as ADDED",
+			strings.Join(only, ", "))
+	}
+
+	// The same two arms for EXPLAINERS. Findings are keyed by their source, so an
+	// explainer present on one side only contributes its entire output as a delta:
+	// every one of its findings reads as introduced or cleared by the change.
+	//
+	// Explainers were recorded in the receipt from the start and never compared, so
+	// this was silent. `explainers:` is an ordinary config knob, and enabling or
+	// disabling one between pinning and checking presented that explainer's whole
+	// finding set as the work of the change. The same happens without anyone editing
+	// anything where the enabled set is decided at runtime rather than by the config.
+	//
+	// ADVISORY, unlike the extractor arms: an extractor set mismatch invalidates the
+	// FACT delta, which is the substrate everything else is computed from, so there is
+	// nothing left worth grading. A differing explainer set leaves facts, edges and
+	// coupling exact and misattributes only the findings from the explainers that
+	// differ. That is a misleading report rather than a wrong verdict, so it is worth
+	// saying loudly and not worth declining to grade over.
+	if only := missingFrom(base.Explainers, cur.Explainers); len(only) > 0 {
+		c.add(WarnExplainerSet,
+			"baseline had explainer(s) not in the current run: %s — their findings will all appear as RESOLVED",
+			strings.Join(only, ", "))
+	}
+	if only := missingFrom(cur.Explainers, base.Explainers); len(only) > 0 {
+		c.add(WarnExplainerSet,
+			"current run added explainer(s) not in the baseline: %s — their findings will all appear as NEW",
 			strings.Join(only, ", "))
 	}
 

--- a/internal/diff/explainerset_test.go
+++ b/internal/diff/explainerset_test.go
@@ -1,0 +1,120 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// base returns two metas that are comparable in every respect, so a test can vary one
+// field and attribute the resulting warning to that field alone.
+func comparablePair() (facts.SnapshotMeta, facts.SnapshotMeta) {
+	m := facts.SnapshotMeta{
+		RepoPath:     "/repo",
+		GeneratedAt:  "2026-08-01T10:00:00Z",
+		EnolaVersion: "v1",
+		Extractors:   []string{"go"},
+		Explainers:   []string{"cycles", "layers"},
+	}
+	cur := m
+	cur.GeneratedAt = "2026-08-01T10:00:01Z"
+	return m, cur
+}
+
+func hasKind(c Comparability, k WarningKind) bool {
+	for _, got := range c.Kinds {
+		if got == k {
+			return true
+		}
+	}
+	return false
+}
+
+// An explainer present on one side only contributes its entire finding set as a delta.
+// That was recorded in the receipt from the start and never compared, so it was silent.
+func TestCompareMeta_ExplainerSetDiffers(t *testing.T) {
+	tests := []struct {
+		name           string
+		baseExplainers []string
+		curExplainers  []string
+		wantWarn       bool
+		wantSubstring  string
+	}{
+		{
+			name:           "identical sets do not warn",
+			baseExplainers: []string{"cycles", "layers"},
+			curExplainers:  []string{"cycles", "layers"},
+			wantWarn:       false,
+		},
+		{
+			name:           "order alone does not warn",
+			baseExplainers: []string{"cycles", "layers"},
+			curExplainers:  []string{"layers", "cycles"},
+			wantWarn:       false,
+		},
+		{
+			name:           "current gained one: its findings all read as NEW",
+			baseExplainers: []string{"cycles"},
+			curExplainers:  []string{"cycles", "dead-code"},
+			wantWarn:       true,
+			wantSubstring:  "dead-code",
+		},
+		{
+			name:           "baseline had one the current lost: its findings all read as RESOLVED",
+			baseExplainers: []string{"cycles", "dead-code"},
+			curExplainers:  []string{"cycles"},
+			wantWarn:       true,
+			wantSubstring:  "RESOLVED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, c := comparablePair()
+			b.Explainers, c.Explainers = tt.baseExplainers, tt.curExplainers
+
+			got := CompareMeta(b, c)
+
+			if hasKind(got, WarnExplainerSet) != tt.wantWarn {
+				t.Fatalf("WarnExplainerSet present = %v, want %v (warnings: %v)",
+					!tt.wantWarn, tt.wantWarn, got.Warnings)
+			}
+			if !tt.wantWarn {
+				if !got.Comparable {
+					t.Errorf("Comparable = false, want true; warnings: %v", got.Warnings)
+				}
+				return
+			}
+			if tt.wantSubstring != "" {
+				var found bool
+				for _, w := range got.Warnings {
+					if strings.Contains(w, tt.wantSubstring) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("no warning contains %q; got %v", tt.wantSubstring, got.Warnings)
+				}
+			}
+		})
+	}
+}
+
+// The explainer arm must not be reported as an extractor mismatch. They have different
+// consequences — a differing extractor set invalidates the fact delta everything else is
+// computed from, while a differing explainer set leaves it exact — and pkg/check keys
+// blocking-vs-advisory off the kind.
+func TestCompareMeta_ExplainerSetIsNotExtractorSet(t *testing.T) {
+	b, c := comparablePair()
+	b.Explainers, c.Explainers = []string{"cycles"}, []string{"cycles", "hotspots"}
+
+	got := CompareMeta(b, c)
+
+	if hasKind(got, WarnExtractorSet) {
+		t.Errorf("explainer difference reported as WarnExtractorSet; kinds = %v", got.Kinds)
+	}
+	if !hasKind(got, WarnExplainerSet) {
+		t.Errorf("WarnExplainerSet missing; kinds = %v", got.Kinds)
+	}
+}

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -166,6 +166,13 @@ var blockingKinds = map[diff.WarningKind]bool{
 var advisoryKinds = map[diff.WarningKind]bool{
 	diff.WarnStaleBaseline: true,
 	diff.WarnPreReceipt:    true,
+	// The explainer set differed. Deliberately advisory rather than blocking: unlike a
+	// differing EXTRACTOR set, the fact delta is untouched, so the change is still
+	// gradeable and only the findings from the explainers that differ are misattributed.
+	// Registering it here is what makes "advisory" mean reported-and-graded rather than
+	// silent — a kind in neither map is carried in ComparabilityWarnings but named in
+	// no summary line.
+	diff.WarnExplainerSet: true,
 }
 
 // Verdict is the graded delta.

--- a/pkg/check/explainerset_test.go
+++ b/pkg/check/explainerset_test.go
@@ -1,0 +1,90 @@
+package check
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/diff"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// A differing explainer set must NOT decline the grade. The fact delta is untouched by
+// it, so the change is still gradeable; only the findings from the explainers that
+// differ are misattributed. Declining here would cost a red build for a config edit.
+func TestEvaluate_ExplainerSetIsAdvisoryNotBlocking(t *testing.T) {
+	d := &diff.SnapshotDiff{
+		Comparability: diff.Comparability{
+			Comparable: false,
+			Kinds:      []diff.WarningKind{diff.WarnExplainerSet},
+			Warnings:   []string{"current run added explainer(s) not in the baseline: dead-code"},
+		},
+	}
+
+	v := Evaluate(d, Policy{})
+
+	if v.Status == StatusIncomparable {
+		t.Errorf("Status = %q, want a graded status — an explainer mismatch must not decline", v.Status)
+	}
+	if len(v.BlockingKinds) != 0 {
+		t.Errorf("BlockingKinds = %v, want none", v.BlockingKinds)
+	}
+	if len(v.AdvisoryKinds) != 1 || v.AdvisoryKinds[0] != diff.WarnExplainerSet {
+		t.Errorf("AdvisoryKinds = %v, want [%v]", v.AdvisoryKinds, diff.WarnExplainerSet)
+	}
+}
+
+// Advisory must not mean silent. The warning text renders from ComparabilityWarnings
+// whatever the kind is, so asserting only on that would pass without the kind being
+// registered at all. What registration buys is the categorised summary — the line that
+// tells a reader this was graded anyway, and why that is safe here.
+func TestRender_ExplainerSetIsCategorisedAsAdvisory(t *testing.T) {
+	const warning = "current run added explainer(s) not in the baseline: dead-code — their findings will all appear as NEW"
+	d := &diff.SnapshotDiff{
+		Comparability: diff.Comparability{
+			Comparable: false,
+			Kinds:      []diff.WarningKind{diff.WarnExplainerSet},
+			Warnings:   []string{warning},
+		},
+	}
+
+	out := Evaluate(d, Policy{}).Render()
+
+	if !strings.Contains(out, "dead-code") {
+		t.Errorf("rendered verdict does not mention the differing explainer:\n%s", out)
+	}
+	if !strings.Contains(out, "Advisory (graded anyway)") {
+		t.Errorf("explainer mismatch not categorised as advisory:\n%s", out)
+	}
+	if !strings.Contains(out, string(diff.WarnExplainerSet)) {
+		t.Errorf("advisory summary does not name the %s kind:\n%s", diff.WarnExplainerSet, out)
+	}
+	// The kind must carry a meaning; writeKinds falls back to printing the bare kind
+	// name, which tells a reader nothing about why the grade was still trustworthy.
+	if !strings.Contains(out, "the facts and coupling in this delta are unaffected") {
+		t.Errorf("advisory summary has no meaning text for %s:\n%s", diff.WarnExplainerSet, out)
+	}
+}
+
+// The gate still fails on a real regression while the advisory is in force — the
+// advisory softens the comparability caveat, not the policy.
+func TestEvaluate_ExplainerSetStillGradesRegressions(t *testing.T) {
+	d := &diff.SnapshotDiff{
+		Comparability: diff.Comparability{
+			Comparable: false,
+			Kinds:      []diff.WarningKind{diff.WarnExplainerSet},
+			Warnings:   []string{"explainer sets differ"},
+		},
+		FindingsNew: []facts.Insight{{
+			Source: "cycles", Title: "Cyclic dependency detected (2 modules)", Confidence: 1.0,
+		}},
+	}
+
+	v := Evaluate(d, Policy{})
+
+	if v.Status != StatusRegression {
+		t.Errorf("Status = %q, want %q", v.Status, StatusRegression)
+	}
+	if v.ExitCode() != 1 {
+		t.Errorf("ExitCode = %d, want 1", v.ExitCode())
+	}
+}

--- a/pkg/check/render.go
+++ b/pkg/check/render.go
@@ -16,6 +16,7 @@ var kindMeaning = map[diff.WarningKind]string{
 	diff.WarnDifferentRepo:   "the two snapshots are of different repositories, so the delta is not about your change",
 	diff.WarnVersionMismatch: "different enola versions extract differently, so unchanged code can appear as churn",
 	diff.WarnExtractorSet:    "a language present on one side only makes all of its facts appear added or removed",
+	diff.WarnExplainerSet:    "an explainer present on one side only makes all of its findings appear new or resolved; the facts and coupling in this delta are unaffected",
 	diff.WarnIgnoreGlobs:     "the set of files parsed changed, so some of this delta is exclusion changes, not code changes",
 	diff.WarnUnclassified:    "an uncategorized caveat was raised; the gate fails closed rather than grade what it cannot judge",
 	diff.WarnStaleBaseline:   "the delta is real, but it also contains whatever the repository itself changed since the baseline was pinned",


### PR DESCRIPTION
compareMeta compared extractors and never explainers, so an explainer present on one side only made its whole finding set read as new or resolved, with no warning and Comparable: true.

Add WarnExplainerSet with the same two symmetric arms as the extractor check. Advisory, not blocking: the fact delta is unaffected, so the change stays gradeable and only the differing explainers' findings are misattributed. Registered in advisoryKinds and kindMeaning so it is named in the verdict's advisory summary, not only in the raw warning list.