### PR TITLE
Extract the shared subcommands into pkg/command

### DIFF
--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/cli"
+	"github.com/enola-labs/enola/pkg/command"
 	"github.com/enola-labs/enola/pkg/dashboard"
 	"github.com/enola-labs/enola/pkg/explain"
 	"github.com/enola-labs/enola/pkg/status"
@@ -35,34 +35,19 @@ func main() {
 	// Subcommands are dispatched before the flag loop below, which is an exact-match
 	// switch over os.Args and cannot parse `--flag=value`. Each subcommand owns its own
 	// FlagSet instead.
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "upgrade":
-			if err := upgrade.Run(ctx, version.Version); err != nil {
-				log.Fatalf("upgrade failed: %v", err)
-			}
-			os.Exit(0)
-		case "check":
-			runCheck(ctx, os.Args[2:]) // exits with the verdict's code
-		case "coverage":
-			runCoverage(ctx, os.Args[2:])
-			os.Exit(0)
-		case "doctor":
-			runDoctor(os.Args[2:])
-			os.Exit(0)
-		case "baseline":
-			runBaseline(os.Args[2:])
-			os.Exit(0)
-		case "hook":
-			runHook(ctx, os.Args[2:]) // always exits 0; never disturbs a session
-		case "install":
-			runInstall(os.Args[2:], false)
-			os.Exit(0)
-		case "uninstall":
-			runInstall(os.Args[2:], true)
-			os.Exit(0)
+	//
+	// `upgrade` is handled here rather than in pkg/command because it is OSS-only: a
+	// wrapper binary ships through its own release path and must not offer to replace
+	// itself with an enola build. It is still declared to the Runner (below) so a typo
+	// like `enola upgrad` is recognised as a near-miss rather than as an unknown word.
+	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
+		if err := upgrade.Run(ctx, version.Version); err != nil {
+			log.Fatalf("upgrade failed: %v", err)
 		}
+		os.Exit(0)
 	}
+	cmds := command.New(binary(), "upgrade")
+	cmds.Dispatch(ctx, os.Args[1:]) // returns only when this was not a subcommand
 
 	generateMode := false
 	explainMode := false
@@ -112,12 +97,12 @@ func main() {
 			// --generate /does/not/exist.yaml` snapshotted the working directory. Both
 			// looked like they worked.
 			switch {
-			case isDirectory(arg):
+			case command.IsDirectory(arg):
 				repoArg = arg
-			case fileExists(arg):
+			case command.FileExists(arg):
 				cfgPath = arg
 			default:
-				log.Fatalf("%s", unknownArgHelp(arg))
+				log.Fatalf("%s", cmds.UnknownArgHelp(arg))
 			}
 		}
 	}
@@ -267,12 +252,19 @@ func main() {
 
 // helpSpec is the `--help` text for this binary: the shared engine help with
 // the OSS-only `upgrade` command documented on top.
-func helpSpec() cli.HelpSpec {
-	spec := cli.DefaultHelp(cli.Binary{
+// binary identifies this build to everything that renders its name: the shared help,
+// and the shared subcommands' usage lines and suggested remedies. One value, so a
+// wrapper cannot end up with help that names one binary and errors that name another.
+func binary() cli.Binary {
+	return cli.Binary{
 		Name:       "enola",
 		CmdPackage: "./cmd/enola",
 		VersionVar: "github.com/enola-labs/enola/internal/version.Version",
-	})
+	}
+}
+
+func helpSpec() cli.HelpSpec {
+	spec := cli.DefaultHelp(binary())
 	spec.Usage = append(spec.Usage, "enola upgrade")
 	spec.Commands = append(spec.Commands, cli.FlagDoc{
 		Flag: "upgrade",
@@ -313,68 +305,4 @@ func runExplain(ctx context.Context, eng *bootstrap.Engine, cfg *config.Config, 
 
 	report := explain.Compute(eng)
 	fmt.Print(report.Render())
-}
-
-// knownSubcommands are dispatched before the flag loop. Listed here so an argument that
-// was MEANT to be one gets a targeted message instead of a generic path error.
-var knownSubcommands = []string{"check", "coverage", "doctor", "baseline", "install", "uninstall", "upgrade"}
-
-// unknownArgHelp explains a rejected argument in terms of what the caller probably meant.
-//
-// The two cases worth separating are a mistyped subcommand and a bad path: telling someone
-// who typed `enola chekc .` that "no such file or directory" would send them looking at
-// their filesystem rather than at their spelling.
-func unknownArgHelp(arg string) string {
-	if !strings.HasPrefix(arg, "-") && !strings.ContainsAny(arg, "/\\.") {
-		if near := closestSubcommand(arg); near != "" {
-			return fmt.Sprintf("unknown command %q — did you mean %q?\n\n    enola %s --help\n\nRun `enola --help` for all commands.", arg, near, near)
-		}
-		return fmt.Sprintf("unknown command %q (expected one of: %s), and it is not a path either.\n\nRun `enola --help`.",
-			arg, strings.Join(knownSubcommands, ", "))
-	}
-	if strings.HasPrefix(arg, "-") {
-		return fmt.Sprintf("unknown flag %q — run `enola --help` for the supported flags.", arg)
-	}
-	return fmt.Sprintf("%q is neither a directory (a repository) nor an existing file (a config).\n\n"+
-		"A path naming a DIRECTORY is treated as a repository; one naming a FILE is treated as a config.", arg)
-}
-
-// closestSubcommand returns the known subcommand within edit distance 2 of arg, if any —
-// enough to catch a transposition or a doubled letter without guessing wildly.
-func closestSubcommand(arg string) string {
-	best, bestDist := "", 3
-	for _, cmd := range knownSubcommands {
-		if d := editDistance(strings.ToLower(arg), cmd); d < bestDist {
-			best, bestDist = cmd, d
-		}
-	}
-	return best
-}
-
-// editDistance is the standard Levenshtein distance over two short ASCII words.
-func editDistance(a, b string) int {
-	prev := make([]int, len(b)+1)
-	cur := make([]int, len(b)+1)
-	for j := range prev {
-		prev[j] = j
-	}
-	for i := 1; i <= len(a); i++ {
-		cur[0] = i
-		for j := 1; j <= len(b); j++ {
-			cost := 1
-			if a[i-1] == b[j-1] {
-				cost = 0
-			}
-			cur[j] = min(prev[j]+1, min(cur[j-1]+1, prev[j-1]+cost))
-		}
-		prev, cur = cur, prev
-	}
-	return prev[len(b)]
-}
-
-// isDirectory reports whether path names an existing directory. Used to tell a
-// repository argument from a config-file argument.
-func isDirectory(path string) bool {
-	fi, err := os.Stat(path)
-	return err == nil && fi.IsDir()
 }

--- a/pkg/command/check.go
+++ b/pkg/command/check.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"context"
@@ -38,7 +38,7 @@ type target struct {
 // That keeps `baseline pin` and `check` resolving identically, which matters more than it
 // looks: the config determines the ignore globs, and a pin and a check that disagreed on
 // them would differ in ignore-glob hash and make every diff decline as incomparable.
-func resolveTarget(arg string) target {
+func (r *Runner) resolveTarget(arg string) target {
 	cfgPath := "mcp-arch.yaml"
 	repoOverride := ""
 
@@ -47,7 +47,7 @@ func resolveTarget(arg string) target {
 	case isDirectory(arg):
 		abs, err := filepath.Abs(arg)
 		if err != nil {
-			checkFatal("resolving repo path %q: %v", arg, err)
+			r.checkFatal("resolving repo path %q: %v", arg, err)
 		}
 		repoOverride = abs
 		if inner := filepath.Join(abs, "mcp-arch.yaml"); fileExists(inner) {
@@ -59,7 +59,7 @@ func resolveTarget(arg string) target {
 
 	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: cfgPath})
 	if err != nil {
-		checkFatal("failed to create engine: %v", err)
+		r.checkFatal("failed to create engine: %v", err)
 	}
 
 	// The note names the config that was LOADED, not the one that was looked for.
@@ -82,14 +82,9 @@ func resolveTarget(arg string) target {
 	}
 	repoPaths, err := cfg.RepoPaths()
 	if err != nil {
-		checkFatal("failed to resolve repo path: %v", err)
+		r.checkFatal("failed to resolve repo path: %v", err)
 	}
 	return target{engine: eng, repoPaths: repoPaths, configNote: note}
-}
-
-func fileExists(path string) bool {
-	fi, err := os.Stat(path)
-	return err == nil && !fi.IsDir()
 }
 
 // runCheck is the `enola check` gate: snapshot the repo, diff it against a baseline,
@@ -97,7 +92,7 @@ func fileExists(path string) bool {
 //
 // It never returns — it exits with the verdict's code. Exit codes are the contract:
 // 0 clean, 1 regression, 2 usage/operational error, 3 declined (not comparable).
-func runCheck(ctx context.Context, args []string) {
+func (r *Runner) Check(ctx context.Context, args []string) {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	var (
@@ -111,7 +106,7 @@ func runCheck(ctx context.Context, args []string) {
 		write         = fs.Bool("write", false, "persist snapshot artifacts to .enola/ (default: read-only, nothing is written)")
 	)
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: enola check [flags] [config_path]\n\n"+
+		fmt.Fprint(os.Stderr, "Usage: "+r.name()+" check [flags] [config_path]\n\n"+
 			"Grade what a change did to the architecture, against a pinned baseline.\n\n"+
 			"Exit codes:\n"+
 			"  0  clean      no structural regression\n"+
@@ -141,9 +136,9 @@ func runCheck(ctx context.Context, args []string) {
 		}
 	}
 
-	tgt := resolveTarget(arg)
+	tgt := r.resolveTarget(arg)
 	eng, repoPaths := tgt.engine, tgt.repoPaths
-	fmt.Fprintf(os.Stderr, "enola check: %s\n", tgt.configNote)
+	fmt.Fprintf(os.Stderr, r.name()+" check: %s\n", tgt.configNote)
 
 	// Read-only unless --write. Skipping WriteArtifacts is what makes it read-only:
 	// that is where the snapshot is persisted AND where the previous/ rotation happens,
@@ -155,20 +150,20 @@ func runCheck(ctx context.Context, args []string) {
 	}
 	for i, repoPath := range repoPaths {
 		if _, err := eng.GenerateSnapshot(ctx, repoPath, i > 0); err != nil {
-			checkFatal("snapshot generation failed for %s: %v", repoPath, err)
+			r.checkFatal("snapshot generation failed for %s: %v", repoPath, err)
 		}
 	}
 	if *write {
 		for _, repoPath := range repoPaths {
 			if err := eng.WriteArtifacts(repoPath); err != nil {
-				checkFatal("failed to write artifacts for %s: %v", repoPath, err)
+				r.checkFatal("failed to write artifacts for %s: %v", repoPath, err)
 			}
 		}
 	}
 
 	snap := eng.Snapshot()
 	if snap == nil || eng.Store().Count() == 0 {
-		checkFatal("snapshot produced no facts for %s", strings.Join(repoPaths, ", "))
+		r.checkFatal("snapshot produced no facts for %s", strings.Join(repoPaths, ", "))
 	}
 	// Build current from the store so it reflects the whole (possibly multi-repo) graph
 	// rather than only the last repo indexed — the same construction diff_snapshot uses.
@@ -180,7 +175,7 @@ func runCheck(ctx context.Context, args []string) {
 	baseDir := engine.ResolveBaselineDir(eng.OutputDir(anchor), *baseline)
 	base, err := bootstrap.LoadSnapshotDir(baseDir)
 	if err != nil {
-		checkFatal("%s", baselineHelp(*baseline, baseDir, anchor, err))
+		r.checkFatal("%s", r.baselineHelp(*baseline, baseDir, anchor, err))
 	}
 
 	d := diff.Compute(base, current)
@@ -193,7 +188,7 @@ func runCheck(ctx context.Context, args []string) {
 	if *asJSON {
 		out, err := verdict.JSON()
 		if err != nil {
-			checkFatal("failed to encode verdict: %v", err)
+			r.checkFatal("failed to encode verdict: %v", err)
 		}
 		fmt.Println(string(out))
 	} else {
@@ -210,21 +205,21 @@ func runCheck(ctx context.Context, args []string) {
 // that no baseline was ever pinned.
 // repoHint is the repository the caller named, echoed back into the suggested commands so
 // they can be pasted as-is rather than adapted.
-func baselineHelp(selector, dir, repoHint string, err error) string {
+func (r *Runner) baselineHelp(selector, dir, repoHint string, err error) string {
 	switch strings.ToLower(strings.TrimSpace(selector)) {
 	case "", "pinned":
 		return fmt.Sprintf("no pinned baseline at %s\n\n"+
 			"The gate needs a \"before\" to compare against, pinned BEFORE you edit:\n"+
-			"    enola baseline pin %s\n"+
+			"    "+r.name()+" baseline pin %s\n"+
 			"    …make your change…\n"+
-			"    enola check %s\n\n"+
+			"    "+r.name()+" check %s\n\n"+
 			"Or compare against the immediately-preceding snapshot with --baseline=previous.",
 			dir, repoHint, repoHint)
 	case "previous":
 		return fmt.Sprintf("no previous snapshot at %s — that requires at least two snapshots "+
-			"written with `enola --generate` (note `enola check` is read-only by default and does "+
+			"written with `"+r.name()+" --generate` (note `"+r.name()+" check` is read-only by default and does "+
 			"not rotate it).\n\nFor a stable baseline across several rounds of edits, prefer:\n"+
-			"    enola baseline pin %s", dir, repoHint)
+			"    "+r.name()+" baseline pin %s", dir, repoHint)
 	default:
 		return fmt.Sprintf("could not load baseline from %q: %v", dir, err)
 	}
@@ -232,23 +227,23 @@ func baselineHelp(selector, dir, repoHint string, err error) string {
 
 // checkFatal reports an operational failure and exits 2 — distinct from a regression,
 // because the gate did not run at all.
-func checkFatal(format string, args ...any) { cmdFatal("check", format, args...) }
+func (r *Runner) checkFatal(format string, args ...any) { r.cmdFatal("check", format, args...) }
 
 // cmdFatal reports an operational failure and exits 2 — distinct from a regression,
 // because the command did not run at all. The command name is a parameter so a shared
 // helper cannot misattribute an error to the wrong subcommand.
-func cmdFatal(cmd, format string, args ...any) {
-	fmt.Fprintf(os.Stderr, "enola "+cmd+": "+format+"\n", args...)
+func (r *Runner) cmdFatal(cmd, format string, args ...any) {
+	fmt.Fprintf(os.Stderr, r.name()+" "+cmd+": "+format+"\n", args...)
 	os.Exit(check.StatusUsageError.ExitCode())
 }
 
 // runBaseline is `enola baseline pin|show|clear` — the CLI half of the loop, so the
 // baseline can be managed without an agent.
-func runBaseline(args []string) {
+func (r *Runner) Baseline(args []string) {
 	fs := flag.NewFlagSet("baseline", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: enola baseline <pin|show|clear> [config_path]\n\n"+
+		fmt.Fprint(os.Stderr, "Usage: "+r.name()+" baseline <pin|show|clear> [config_path]\n\n"+
 			"  pin    freeze the current .enola snapshot as the diff baseline\n"+
 			"  show   report whether a baseline exists, and what it describes\n"+
 			"  clear  remove the pinned baseline\n")
@@ -267,7 +262,7 @@ func runBaseline(args []string) {
 	if len(rest) > 1 {
 		arg = rest[1]
 	}
-	tgt := resolveTarget(arg)
+	tgt := r.resolveTarget(arg)
 	eng := tgt.engine
 	anchor := tgt.repoPaths[0]
 	outDir := eng.OutputDir(anchor)
@@ -285,40 +280,40 @@ func runBaseline(args []string) {
 		// which is precisely the staleness the diff then warns about. Snapshots are
 		// deterministic, so for an unchanged tree this costs a cached re-index and
 		// produces byte-identical facts.
-		fmt.Fprintf(os.Stderr, "enola baseline: %s\n", tgt.configNote)
+		fmt.Fprintf(os.Stderr, r.name()+" baseline: %s\n", tgt.configNote)
 		for i, repoPath := range tgt.repoPaths {
 			if _, err := eng.GenerateSnapshot(context.Background(), repoPath, i > 0); err != nil {
-				checkFatal("snapshot generation failed for %s: %v", repoPath, err)
+				r.checkFatal("snapshot generation failed for %s: %v", repoPath, err)
 			}
 		}
 		for _, repoPath := range tgt.repoPaths {
 			if err := eng.WriteArtifacts(repoPath); err != nil {
-				checkFatal("failed to write artifacts for %s: %v", repoPath, err)
+				r.checkFatal("failed to write artifacts for %s: %v", repoPath, err)
 			}
 		}
 		if err := eng.SetBaseline(anchor); err != nil {
-			checkFatal("could not pin baseline: %v", err)
+			r.checkFatal("could not pin baseline: %v", err)
 		}
 		fmt.Printf("Baseline pinned for %s\n", anchor)
 		if snap, err := bootstrap.LoadSnapshotDir(baseDir); err == nil {
 			describeBaseline(snap)
 		}
-		fmt.Printf("\nNow make your changes, then run:\n    enola check %s\n", anchor)
+		fmt.Printf("\nNow make your changes, then run:\n    %s check %s\n", r.name(), anchor)
 	case "show":
 		snap, err := bootstrap.LoadSnapshotDir(baseDir)
 		if err != nil {
-			fmt.Printf("No baseline pinned (%s does not hold a snapshot).\nRun `enola --generate` then `enola baseline pin`.\n", baseDir)
+			fmt.Printf("No baseline pinned (%s does not hold a snapshot).\nRun `%s --generate` then `%s baseline pin`.\n", baseDir, r.name(), r.name())
 			os.Exit(check.StatusUsageError.ExitCode())
 		}
 		fmt.Printf("Baseline at %s\n", baseDir)
 		describeBaseline(snap)
 	case "clear":
 		if err := os.RemoveAll(baseDir); err != nil {
-			checkFatal("could not clear baseline: %v", err)
+			r.checkFatal("could not clear baseline: %v", err)
 		}
 		fmt.Printf("Baseline cleared (%s removed).\n", baseDir)
 	default:
-		fmt.Fprintf(os.Stderr, "enola baseline: unknown action %q\n", action)
+		fmt.Fprintf(os.Stderr, r.name()+" baseline: unknown action %q\n", action)
 		fs.Usage()
 		os.Exit(check.StatusUsageError.ExitCode())
 	}

--- a/pkg/command/check_test.go
+++ b/pkg/command/check_test.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"os"
@@ -24,7 +24,7 @@ func TestResolveTarget_DirectoryArgumentIsTheRepo(t *testing.T) {
 	restore := chdir(t, cwd)
 	defer restore()
 
-	tgt := resolveTarget(repo)
+	tgt := testRunner().resolveTarget(repo)
 
 	if len(tgt.repoPaths) != 1 {
 		t.Fatalf("repoPaths = %v, want exactly one", tgt.repoPaths)
@@ -61,7 +61,7 @@ func TestResolveTarget_PicksUpConfigInsideTheRepo(t *testing.T) {
 	restore := chdir(t, t.TempDir())
 	defer restore()
 
-	tgt := resolveTarget(repo)
+	tgt := testRunner().resolveTarget(repo)
 
 	if !strings.Contains(tgt.configNote, inner) {
 		t.Errorf("configNote = %q, want it to name the in-repo config %q", tgt.configNote, inner)
@@ -89,7 +89,7 @@ func TestResolveTarget_FileArgumentIsAConfig(t *testing.T) {
 	restore := chdir(t, t.TempDir())
 	defer restore()
 
-	tgt := resolveTarget(cfg)
+	tgt := testRunner().resolveTarget(cfg)
 
 	if !strings.Contains(tgt.configNote, cfg) {
 		t.Errorf("configNote = %q, want it to name the config", tgt.configNote)
@@ -123,10 +123,10 @@ func TestUnknownArgHelp_DistinguishesTypoFromBadPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := unknownArgHelp(tc.arg)
+			got := testRunner().UnknownArgHelp(tc.arg)
 			for _, want := range tc.contains {
 				if !strings.Contains(got, want) {
-					t.Errorf("unknownArgHelp(%q) = %q, want it to mention %q", tc.arg, got, want)
+					t.Errorf("testRunner().UnknownArgHelp(%q) = %q, want it to mention %q", tc.arg, got, want)
 				}
 			}
 		})
@@ -137,8 +137,8 @@ func TestUnknownArgHelp_DistinguishesTypoFromBadPath(t *testing.T) {
 // plausible. Offering "check" for an unrelated word would be worse than no suggestion.
 func TestClosestSubcommand_DoesNotGuessWildly(t *testing.T) {
 	for _, arg := range []string{"frobnicate", "serve", "xyzzy"} {
-		if got := closestSubcommand(arg); got != "" {
-			t.Errorf("closestSubcommand(%q) = %q, want no suggestion", arg, got)
+		if got := testRunner().closestSubcommand(arg); got != "" {
+			t.Errorf("testRunner().closestSubcommand(%q) = %q, want no suggestion", arg, got)
 		}
 	}
 	for _, tc := range []struct{ arg, want string }{
@@ -147,8 +147,8 @@ func TestClosestSubcommand_DoesNotGuessWildly(t *testing.T) {
 		{"baselien", "baseline"},
 		{"upgrad", "upgrade"},
 	} {
-		if got := closestSubcommand(tc.arg); got != tc.want {
-			t.Errorf("closestSubcommand(%q) = %q, want %q", tc.arg, got, tc.want)
+		if got := testRunner().closestSubcommand(tc.arg); got != tc.want {
+			t.Errorf("testRunner().closestSubcommand(%q) = %q, want %q", tc.arg, got, tc.want)
 		}
 	}
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -1,0 +1,182 @@
+// Package command implements the subcommands every enola binary shares — the gate
+// (`check`, `baseline`), the reports (`coverage`, `doctor`), the installer
+// (`install`/`uninstall`) and the session hooks (`hook`).
+//
+// It exists because a wrapper binary cannot reach them otherwise. They are built on
+// enola's internal packages — the engine's baseline resolution, the hook heartbeat, the
+// file lock — none of which cross a module boundary, so a separate module can neither
+// import them nor reimplement them without carrying a second copy of the gate's exit-code
+// contract and the hook's silence rules. Keeping the commands here, INSIDE enola, lets
+// them go on using those internals while a wrapper reaches them through one exported
+// surface.
+//
+// Deliberately not folded into pkg/cli: that package is pure text (help and the tool
+// catalogue) and anything wanting only `--help` would otherwise pull in the whole engine.
+// This package imports pkg/cli, not the other way round.
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/enola-labs/enola/pkg/cli"
+)
+
+// Runner runs the shared subcommands on behalf of one binary.
+//
+// The binary is held rather than passed per call because it reaches almost every
+// user-facing string: usage blocks, error prefixes, and — the part that matters — the
+// commands suggested in remedies. A gate that tells an enola-enterprise user to run
+// `enola baseline pin` names a binary they may not have installed.
+type Runner struct {
+	bin cli.Binary
+	// own are subcommands the BINARY dispatches for itself, before delegating here.
+	// They are not run by this package, but they are still part of what the binary
+	// accepts, so they belong in the typo suggestions and the "expected one of" list —
+	// otherwise `enola upgrad` is told upgrade is not a command of any kind.
+	own []string
+}
+
+// New returns a Runner for the given binary. ownSubcommands names commands the binary
+// handles itself (cmd/enola passes "upgrade"); they are recognised for diagnostics but
+// never dispatched here.
+func New(bin cli.Binary, ownSubcommands ...string) *Runner {
+	return &Runner{bin: bin, own: ownSubcommands}
+}
+
+// knownSubcommands is everything the binary accepts: what this package dispatches, plus
+// whatever the binary dispatches for itself.
+func (r *Runner) knownSubcommands() []string {
+	return append(append([]string{}, Subcommands()...), r.own...)
+}
+
+// name is the binary as a user types it, used in usage lines and suggested commands.
+func (r *Runner) name() string {
+	if r.bin.Name == "" {
+		return "enola"
+	}
+	return r.bin.Name
+}
+
+// Subcommands are the commands Dispatch handles. Exported so a binary's --help can be
+// checked against what it can actually run: the shared help documents all of these, and
+// a binary that advertises one it does not dispatch sends the caller into whatever its
+// argument parser does with an unrecognised word.
+//
+// `upgrade` is deliberately absent. It is OSS-only — a wrapper ships through its own
+// release path — so cmd/enola dispatches it itself, before calling Dispatch.
+func Subcommands() []string {
+	return []string{"check", "coverage", "doctor", "baseline", "install", "uninstall", "hook"}
+}
+
+// Dispatch runs the subcommand named by args[0], if it is one of Subcommands().
+//
+// It reports whether it handled the arguments. In practice a handled command exits the
+// process — the gate exits with its verdict's code, the hook always exits 0 — so the
+// false return is the load-bearing one: it tells the caller this was not a subcommand
+// and its own flag parsing should continue.
+//
+// args is the argument list WITHOUT the program name (os.Args[1:]).
+func (r *Runner) Dispatch(ctx context.Context, args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "check":
+		r.Check(ctx, args[1:]) // exits with the verdict's code
+	case "coverage":
+		r.Coverage(ctx, args[1:])
+		os.Exit(0)
+	case "doctor":
+		r.Doctor(args[1:])
+		os.Exit(0)
+	case "baseline":
+		r.Baseline(args[1:])
+		os.Exit(0)
+	case "hook":
+		r.Hook(ctx, args[1:]) // always exits 0; never disturbs a session
+	case "install":
+		r.Install(args[1:], false)
+		os.Exit(0)
+	case "uninstall":
+		r.Install(args[1:], true)
+		os.Exit(0)
+	default:
+		return false
+	}
+	return true
+}
+
+// UnknownArgHelp explains a rejected argument in terms of what the caller probably meant.
+//
+// The two cases worth separating are a mistyped subcommand and a bad path: telling
+// someone who typed `enola chekc .` that "no such file or directory" would send them
+// looking at their filesystem rather than at their spelling.
+func (r *Runner) UnknownArgHelp(arg string) string {
+	if !strings.HasPrefix(arg, "-") && !strings.ContainsAny(arg, "/\\.") {
+		if near := r.closestSubcommand(arg); near != "" {
+			return fmt.Sprintf("unknown command %q — did you mean %q?\n\n    %s %s --help\n\nRun `%s --help` for all commands.",
+				arg, near, r.name(), near, r.name())
+		}
+		return fmt.Sprintf("unknown command %q (expected one of: %s), and it is not a path either.\n\nRun `%s --help`.",
+			arg, strings.Join(r.knownSubcommands(), ", "), r.name())
+	}
+	if strings.HasPrefix(arg, "-") {
+		return fmt.Sprintf("unknown flag %q — run `%s --help` for the supported flags.", arg, r.name())
+	}
+	return fmt.Sprintf("%q is neither a directory (a repository) nor an existing file (a config).\n\n"+
+		"A path naming a DIRECTORY is treated as a repository; one naming a FILE is treated as a config.", arg)
+}
+
+// closestSubcommand returns the known subcommand within edit distance 2 of arg, if any —
+// enough to catch a transposition or a doubled letter without guessing wildly.
+func (r *Runner) closestSubcommand(arg string) string {
+	best, bestDist := "", 3
+	for _, cmd := range r.knownSubcommands() {
+		if d := editDistance(strings.ToLower(arg), cmd); d < bestDist {
+			best, bestDist = cmd, d
+		}
+	}
+	return best
+}
+
+// editDistance is the standard Levenshtein distance over two short ASCII words.
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	cur := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		cur[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			cur[j] = min(prev[j]+1, min(cur[j-1]+1, prev[j-1]+cost))
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(b)]
+}
+
+// IsDirectory reports whether path names an existing directory. Used throughout to tell
+// a repository argument from a config-file argument — the distinction that makes
+// `--explain /path/to/repo` and `--explain cluster.yaml` both unambiguous.
+func IsDirectory(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}
+
+// FileExists reports whether path names an existing non-directory file.
+func FileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
+}
+
+// isDirectory / fileExists are the unexported spellings the moved command files use.
+func isDirectory(path string) bool { return IsDirectory(path) }
+func fileExists(path string) bool  { return FileExists(path) }

--- a/pkg/command/coverage.go
+++ b/pkg/command/coverage.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 // A report, not a gate: it exits 0 whenever it ran. `enola check` owns the meaning of a
 // non-zero exit — "your change did something" — and blurring that here would cost more
 // than a threshold flag is worth.
-func runCoverage(ctx context.Context, args []string) {
+func (r *Runner) Coverage(ctx context.Context, args []string) {
 	fs := flag.NewFlagSet("coverage", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	var (
@@ -32,7 +32,7 @@ func runCoverage(ctx context.Context, args []string) {
 	)
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr,
-			"Usage: enola coverage [flags] [repo_path|config_path]\n\n"+
+			"Usage: "+r.name()+" coverage [flags] [repo_path|config_path]\n\n"+
 				"Report which cross-repo edges enola resolved and which it could not, per service.\n"+
 				"Tells a genuinely isolated service apart from one whose outbound edges enola simply\n"+
 				"failed to follow — a distinction the graph alone cannot express.\n\n"+
@@ -48,20 +48,20 @@ func runCoverage(ctx context.Context, args []string) {
 	if rest := fs.Args(); len(rest) > 0 {
 		arg = rest[0]
 	}
-	tgt := resolveTarget(arg)
-	fmt.Fprintf(os.Stderr, "enola coverage: %s\n", tgt.configNote)
+	tgt := r.resolveTarget(arg)
+	fmt.Fprintf(os.Stderr, r.name()+" coverage: %s\n", tgt.configNote)
 
 	// Read-only, like `check` and `--explain`: reporting on a graph must not rewrite it.
 	tgt.engine.SetPersistCache(false)
 	for i, repoPath := range tgt.repoPaths {
 		if _, err := tgt.engine.GenerateSnapshot(ctx, repoPath, i > 0); err != nil {
-			coverageFatal("snapshot generation failed for %s: %v", repoPath, err)
+			r.coverageFatal("snapshot generation failed for %s: %v", repoPath, err)
 		}
 	}
 
 	report := coverage.Build(tgt.engine.Store(), *service)
 	if *service != "" && len(report) == 0 {
-		coverageFatal("no service named %q in this graph", *service)
+		r.coverageFatal("no service named %q in this graph", *service)
 	}
 	if *unresolved {
 		report = onlyUnresolved(report)
@@ -70,7 +70,7 @@ func runCoverage(ctx context.Context, args []string) {
 	if *asJSON {
 		out, err := json.MarshalIndent(report, "", "  ")
 		if err != nil {
-			coverageFatal("failed to encode report: %v", err)
+			r.coverageFatal("failed to encode report: %v", err)
 		}
 		fmt.Println(string(out))
 		return
@@ -78,7 +78,7 @@ func runCoverage(ctx context.Context, args []string) {
 	fmt.Print(report.RenderText())
 }
 
-func coverageFatal(format string, args ...any) { cmdFatal("coverage", format, args...) }
+func (r *Runner) coverageFatal(format string, args ...any) { r.cmdFatal("coverage", format, args...) }
 
 // onlyUnresolved narrows the report to services with unresolved call sites — the
 // failure-hunting view, for someone working through blind spots rather than surveying.

--- a/pkg/command/detach_unix.go
+++ b/pkg/command/detach_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package command
 
 import (
 	"os/exec"

--- a/pkg/command/detach_windows.go
+++ b/pkg/command/detach_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package main
+package command
 
 import (
 	"os/exec"

--- a/pkg/command/doctor.go
+++ b/pkg/command/doctor.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"encoding/json"
@@ -30,13 +30,13 @@ import (
 // Exit codes follow `enola coverage`, not `enola check`: this is a report, so it exits
 // 0 whenever it ran, and 2 only for a usage error. A non-zero code from enola means
 // "your change did something", and a diagnostic must not borrow that meaning.
-func runDoctor(args []string) {
+func (r *Runner) Doctor(args []string) {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "machine-readable output")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr,
-			"Usage: enola doctor [flags] [repo_path]\n\n"+
+			"Usage: "+r.name()+" doctor [flags] [repo_path]\n\n"+
 				"Report whether enola's agent hooks are actually firing in this repository.\n\n"+
 				"`install --hooks` can write a configuration the agent ignores — it reports\n"+
 				"success either way. This asks the only question that settles it: when did the\n"+
@@ -49,11 +49,11 @@ func runDoctor(args []string) {
 
 	repoDir, err := os.Getwd()
 	if err != nil {
-		cmdFatal("doctor", "cannot determine the working directory: %v", err)
+		r.cmdFatal("doctor", "cannot determine the working directory: %v", err)
 	}
 	if rest := fs.Args(); len(rest) > 0 {
 		if !isDirectory(rest[0]) {
-			cmdFatal("doctor", "%q is not a directory", rest[0])
+			r.cmdFatal("doctor", "%q is not a directory", rest[0])
 		}
 		repoDir = rest[0]
 	}
@@ -80,7 +80,7 @@ func runDoctor(args []string) {
 		return
 	}
 
-	fmt.Printf("enola doctor: %s\n\n", repoDir)
+	fmt.Printf(r.name()+" doctor: %s\n\n", repoDir)
 
 	// Asked and answered BEFORE a session ends, which is the difference between this
 	// and reading the last outcome below: an unusable baseline makes the hooks decline
@@ -91,7 +91,7 @@ func runDoctor(args []string) {
 	} else {
 		fmt.Printf("  NOT COMPARABLE: %s\n", baselineIssue)
 		fmt.Println("  Nothing will be graded against it until it is re-pinned:")
-		fmt.Println("      enola baseline pin")
+		fmt.Printf("      %s baseline pin\n", r.name())
 	}
 	fmt.Println()
 
@@ -99,7 +99,7 @@ func runDoctor(args []string) {
 
 	if !installed {
 		fmt.Println("  not configured for this repository.")
-		fmt.Println("  Run `enola install --hooks` to have the loop run itself: a baseline pinned")
+		fmt.Printf("  Run `%s install --hooks` to have the loop run itself: a baseline pinned\n", r.name())
 		fmt.Println("  at session start, and the change graded when the session ends.")
 		return
 	}
@@ -147,10 +147,10 @@ func runDoctor(args []string) {
 		fmt.Println("  The stop hook is running, but last declined to grade: the baseline was not")
 		fmt.Println("  comparable to the current snapshot. It stays silent in-session when this")
 		fmt.Println("  happens, so it looks identical to a clean run. Re-pin with")
-		fmt.Println("  `enola baseline pin` and check `enola check` for the reason.")
+		fmt.Printf("  `%s baseline pin` and check `%s check` for the reason.\n", r.name(), r.name())
 	case state.Get(hookstate.EventStop).LastOutcome == hookstate.OutcomeUnavailable:
 		fmt.Println("  The stop hook is running but has nothing to grade against — usually no")
-		fmt.Println("  baseline yet. `enola baseline pin` fixes it; the session-start hook will")
+		fmt.Printf("  baseline yet. `%s baseline pin` fixes it; the session-start hook will\n", r.name())
 		fmt.Println("  also do it on the next session.")
 	default:
 		fmt.Println("  Both hooks are firing. The loop is closed.")

--- a/pkg/command/doctor_test.go
+++ b/pkg/command/doctor_test.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"os"

--- a/pkg/command/help_consistency_test.go
+++ b/pkg/command/help_consistency_test.go
@@ -1,0 +1,88 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/pkg/cli"
+)
+
+// Every command the shared help DOCUMENTS must be one some binary can actually RUN.
+//
+// This is the assertion that would have caught the defect this package exists to fix.
+// cli.DefaultHelp is shared by every enola binary, so it advertised `check`, `baseline`,
+// `coverage`, `doctor`, `install` and `uninstall` from the wrapper's --help too — while
+// the wrapper dispatched none of them. Typing one did not produce an error: it fell
+// through the wrapper's argument loop, was taken for a config path, and started an MCP
+// server on stdio.
+//
+// Dispatchable means Subcommands() plus whatever the binary handles itself, since
+// `upgrade` is documented by cmd/enola and dispatched there.
+func TestDocumentedCommandsAreDispatchable(t *testing.T) {
+	dispatchable := map[string]bool{}
+	for _, c := range Subcommands() {
+		dispatchable[c] = true
+	}
+	// What cmd/enola adds for itself.
+	dispatchable["upgrade"] = true
+
+	spec := cli.DefaultHelp(cli.Binary{Name: "enola"})
+	for _, doc := range spec.Commands {
+		// A command entry may carry an argument placeholder ("activate <KEY>"); the
+		// command is the first word.
+		name := strings.Fields(doc.Flag)[0]
+		if !dispatchable[name] {
+			t.Errorf("help documents %q but no binary dispatches it — typing it falls through to argument parsing", name)
+		}
+	}
+}
+
+// The converse: a command this package dispatches but nothing documents is unreachable
+// in practice, since nobody is told it exists. `hook` is the deliberate exception — it is
+// invoked by the agent harness from the config `install --hooks` writes, never typed.
+func TestDispatchedCommandsAreDocumented(t *testing.T) {
+	documented := map[string]bool{}
+	for _, doc := range cli.DefaultHelp(cli.Binary{Name: "enola"}).Commands {
+		documented[strings.Fields(doc.Flag)[0]] = true
+	}
+	undocumentedByDesign := map[string]bool{"hook": true}
+
+	for _, c := range Subcommands() {
+		if !documented[c] && !undocumentedByDesign[c] {
+			t.Errorf("Dispatch handles %q but the shared help never mentions it", c)
+		}
+	}
+}
+
+// Usage lines and suggested remedies must name the binary that is running, not the one
+// the code was written for. A wrapper telling its user to run `enola baseline pin` names
+// a binary they may not have installed.
+func TestDiagnosticsNameTheRunningBinary(t *testing.T) {
+	r := New(cli.Binary{Name: "enola-enterprise"}, "upgrade")
+
+	got := r.UnknownArgHelp("chekc")
+	if !strings.Contains(got, "enola-enterprise chekc"[:len("enola-enterprise")]) {
+		t.Errorf("UnknownArgHelp does not name the running binary:\n%s", got)
+	}
+	if strings.Contains(got, "`enola --help`") {
+		t.Errorf("UnknownArgHelp suggests the OSS binary to a wrapper user:\n%s", got)
+	}
+
+	// The typo suggestion must still reach a command the wrapper dispatches.
+	if !strings.Contains(got, `did you mean "check"`) {
+		t.Errorf("UnknownArgHelp lost the near-miss suggestion:\n%s", got)
+	}
+}
+
+// A binary's own subcommands are recognised for diagnostics but never dispatched here —
+// otherwise the shared layer would claim to run something it has no implementation for.
+func TestOwnSubcommandsAreNotDispatched(t *testing.T) {
+	for _, c := range Subcommands() {
+		if c == "upgrade" {
+			t.Fatal("upgrade is OSS-only and must not be in the shared dispatch set")
+		}
+	}
+	if got := New(cli.Binary{Name: "enola"}, "upgrade").closestSubcommand("upgrad"); got != "upgrade" {
+		t.Errorf("closestSubcommand(%q) = %q, want %q — an own subcommand must still be suggested", "upgrad", got, "upgrade")
+	}
+}

--- a/pkg/command/helpers_test.go
+++ b/pkg/command/helpers_test.go
@@ -1,0 +1,9 @@
+package command
+
+import "github.com/enola-labs/enola/pkg/cli"
+
+// testRunner is the Runner this package's own tests exercise: the OSS binary, whose
+// name is what the moved tests' expectations were written against.
+// "upgrade" mirrors cmd/enola, which dispatches it itself — the moved tests assert
+// it is still offered as a typo suggestion.
+func testRunner() *Runner { return New(cli.Binary{Name: "enola"}, "upgrade") }

--- a/pkg/command/hook.go
+++ b/pkg/command/hook.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"context"
@@ -44,15 +44,15 @@ type stopHookOutput struct {
 // job in advisory mode; exit 1 is a *non-blocking error* to the harness, so forwarding
 // `enola check`'s regression code would surface as a hook failure rather than as the
 // verdict it actually is.
-func runHook(ctx context.Context, args []string) {
+func (r *Runner) Hook(ctx context.Context, args []string) {
 	if len(args) == 0 {
 		os.Exit(0)
 	}
 	switch args[0] {
 	case "stop":
-		runStopHook(ctx)
+		r.runStopHook(ctx)
 	case "session-start":
-		runSessionStartHook(ctx, args[1:])
+		r.runSessionStartHook(ctx, args[1:])
 	default:
 		// An event this build does not know about is not an error: a newer install may
 		// have written config a older binary does not understand.
@@ -62,7 +62,7 @@ func runHook(ctx context.Context, args []string) {
 
 // runStopHook grades the session's change and, only if it introduced a structural
 // regression, hands the verdict back as context.
-func runStopHook(ctx context.Context) {
+func (r *Runner) runStopHook(ctx context.Context) {
 	in, err := readHookInput()
 	if err != nil || in.CWD == "" {
 		return
@@ -105,7 +105,7 @@ func runStopHook(ctx context.Context) {
 			verdict.DeclineReason() + ".\n\n" +
 			"This is NOT a statement about your change — the comparison itself was untrustworthy, " +
 			"so no verdict was reached in either direction. Re-pin the baseline to restore grading " +
-			"(`enola baseline pin`, or the set_baseline tool), and `enola doctor` reports whether " +
+			fmt.Sprintf("(`%s baseline pin`, or the set_baseline tool), and `%s doctor` reports whether ", r.name(), r.name()) +
 			"the hooks are grading again."
 
 	default:
@@ -146,7 +146,7 @@ const autoPinMarker = ".auto-pinned"
 // of one process spawn, independent of repository size. That is the only mitigation that
 // is constant in the size of the repo rather than merely bounded — a timeout still pays
 // the timeout.
-func runSessionStartHook(ctx context.Context, args []string) {
+func (r *Runner) runSessionStartHook(ctx context.Context, args []string) {
 	if len(args) > 0 && args[0] == detachedRunFlag {
 		// The detached child: the only place any work happens.
 		if len(args) > 1 {

--- a/pkg/command/hook_sessionstart_test.go
+++ b/pkg/command/hook_sessionstart_test.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"encoding/json"

--- a/pkg/command/hook_stop_test.go
+++ b/pkg/command/hook_stop_test.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"encoding/json"

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"flag"
@@ -14,7 +14,7 @@ import (
 
 // runInstall is `enola install` / `enola uninstall`: write enola's instructions, and
 // optionally its hooks, into the config files the agents on this machine actually read.
-func runInstall(args []string, remove bool) {
+func (r *Runner) Install(args []string, remove bool) {
 	name := "install"
 	if remove {
 		name = "uninstall"
@@ -29,9 +29,9 @@ func runInstall(args []string, remove bool) {
 		yes     = fs.Bool("yes", false, "skip the confirmation prompt")
 	)
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: enola %s [flags] [repo_path]\n\n", name)
+		fmt.Fprintf(os.Stderr, "Usage: %s %s [flags] [repo_path]\n\n", r.name(), name)
 		if remove {
-			fmt.Fprint(os.Stderr, "Remove everything `enola install` wrote, leaving the rest of each file untouched.\n\n")
+			fmt.Fprintf(os.Stderr, "Remove everything `%s install` wrote, leaving the rest of each file untouched.\n\n", r.name())
 		} else {
 			fmt.Fprint(os.Stderr,
 				"Write enola's instructions into the files your coding agents read.\n\n"+
@@ -49,17 +49,17 @@ func runInstall(args []string, remove bool) {
 
 	repoDir, err := os.Getwd()
 	if err != nil {
-		installFatal("cannot determine the working directory: %v", err)
+		r.installFatal("cannot determine the working directory: %v", err)
 	}
 	if rest := fs.Args(); len(rest) > 0 {
 		if !isDirectory(rest[0]) {
-			installFatal("%q is not a directory", rest[0])
+			r.installFatal("%q is not a directory", rest[0])
 		}
 		repoDir = rest[0]
 	}
 	home, err := os.UserHomeDir()
 	if err != nil && *global {
-		installFatal("cannot determine the home directory: %v", err)
+		r.installFatal("cannot determine the home directory: %v", err)
 	}
 
 	opts := install.Options{
@@ -89,7 +89,7 @@ func runInstall(args []string, remove bool) {
 	preview.DryRun = true
 	planned, err := act(preview, remove)
 	if err != nil {
-		installFatal("%v", err)
+		r.installFatal("%v", err)
 	}
 
 	fmt.Printf("%s\n", strings.ToUpper(name[:1])+name[1:])
@@ -145,7 +145,7 @@ func runInstall(args []string, remove bool) {
 
 	applied, err := act(opts, remove)
 	if err != nil {
-		installFatal("%v", err)
+		r.installFatal("%v", err)
 	}
 	fmt.Println()
 	printPlan(applied)
@@ -169,7 +169,7 @@ func runInstall(args []string, remove bool) {
 
 	if !remove && opts.Hooks {
 		fmt.Println("\nRestart your agent session for the hooks to take effect.")
-		fmt.Println("Then `enola doctor` will tell you whether they are actually firing.")
+		fmt.Printf("Then `%s doctor` will tell you whether they are actually firing.\n", r.name())
 	}
 }
 
@@ -278,7 +278,7 @@ func wrap(text string, width int) []string {
 	return lines
 }
 
-func installFatal(format string, args ...any) {
-	fmt.Fprintf(os.Stderr, "enola install: "+format+"\n", args...)
+func (r *Runner) installFatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, r.name()+" install: "+format+"\n", args...)
 	os.Exit(2)
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -35,6 +35,14 @@ type Options struct {
 	DryRun bool
 	// Targets restricts the run to named targets; empty means every applicable one.
 	Targets []string
+	// ExtraInstructions is appended to the instruction body every target receives.
+	// The seam for a wrapper binary that serves additional tools: it can name them
+	// without this package knowing they exist, and without forking the shared text.
+	// Empty here — no binary sets it yet, and the output is unchanged while it is.
+	ExtraInstructions string
+	// ExtraHooksNote is appended only when Hooks is set, for a wrapper whose hooks do
+	// something the shared HooksNote does not describe.
+	ExtraHooksNote string
 }
 
 func (o Options) hookCommand() string {
@@ -158,7 +166,7 @@ func globalAgentsTarget(o Options, remove bool, tool, rel string) ([]Result, err
 			Reason: filepath.Base(root) + " not found in your home directory, so " + tool + " does not appear to be installed",
 		}}, nil
 	}
-	r, err := upsertSection(path, block(body(o.Hooks)), o.DryRun)
+	r, err := upsertSection(path, block(body(o)), o.DryRun)
 	return []Result{r}, err
 }
 
@@ -183,7 +191,7 @@ func copilotTarget(o Options, remove bool) ([]Result, error) {
 		r, err := removeOwnedFile(path, o.DryRun)
 		return []Result{r}, err
 	}
-	r, err := writeOwnedFile(path, copilotInstructions(o.Hooks), o.DryRun)
+	r, err := writeOwnedFile(path, copilotInstructions(o), o.DryRun)
 	return []Result{r}, err
 }
 
@@ -217,7 +225,7 @@ func claudeTarget(o Options, remove bool) ([]Result, error) {
 		return append(out, hr...), nil
 	}
 
-	r, err := writeOwnedFile(rule, claudeRule(o.Hooks), o.DryRun)
+	r, err := writeOwnedFile(rule, claudeRule(o), o.DryRun)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +258,7 @@ func cursorTarget(o Options, remove bool) ([]Result, error) {
 		r, err := removeOwnedFile(path, o.DryRun)
 		return []Result{r}, err
 	}
-	r, err := writeOwnedFile(path, cursorRule(o.Hooks), o.DryRun)
+	r, err := writeOwnedFile(path, cursorRule(o), o.DryRun)
 	return []Result{r}, err
 }
 
@@ -281,7 +289,7 @@ func agentsTarget(o Options, remove bool) ([]Result, error) {
 				agentsMdReaders + " at once — worth doing deliberately, so create it yourself and re-run",
 		}}, nil
 	}
-	r, err := upsertSection(path, block(body(o.Hooks)), o.DryRun)
+	r, err := upsertSection(path, block(body(o)), o.DryRun)
 	return []Result{r}, err
 }
 

--- a/pkg/install/instructions.go
+++ b/pkg/install/instructions.go
@@ -53,22 +53,22 @@ func block(content string) string {
 
 // claudeRule is the body of the Claude Code rule file. No `paths` frontmatter, so it
 // loads at launch with the same priority as a project CLAUDE.md.
-func claudeRule(withHooks bool) string {
-	return header() + body(withHooks) + "\n"
+func claudeRule(o Options) string {
+	return header() + body(o) + "\n"
 }
 
 // cursorRule carries Cursor's frontmatter. alwaysApply keeps it in context rather than
 // leaving it to description-matching.
-func cursorRule(withHooks bool) string {
-	return "---\nalwaysApply: true\n---\n\n" + header() + body(withHooks) + "\n"
+func cursorRule(o Options) string {
+	return "---\nalwaysApply: true\n---\n\n" + header() + body(o) + "\n"
 }
 
 // copilotInstructions carries Copilot's frontmatter. applyTo is REQUIRED for a file under
 // .github/instructions/ — without it the file governs nothing, which is the silent kind of
 // failure: it exists, it looks installed, and it never applies. "**" is what makes it
 // unconditional, the counterpart of Cursor's alwaysApply.
-func copilotInstructions(withHooks bool) string {
-	return "---\napplyTo: \"**\"\n---\n\n" + header() + body(withHooks) + "\n"
+func copilotInstructions(o Options) string {
+	return "---\napplyTo: \"**\"\n---\n\n" + header() + body(o) + "\n"
 }
 
 // header marks the file as generated, so a reader knows why it exists and how to remove
@@ -78,9 +78,25 @@ func header() string {
 		"     and `enola uninstall` will remove this file. -->\n\n"
 }
 
-func body(withHooks bool) string {
-	if withHooks {
-		return Instructions + HooksNote
+// body composes what actually gets written: the shared instructions, the hooks note when
+// hooks are installed, and whatever the calling binary appends.
+//
+// ExtraInstructions is the seam for a wrapper that serves tools the OSS build does not,
+// so it can tell the agent they exist without this package having to know about them —
+// and without a wrapper having to fork the instruction text to add two lines. Empty for
+// every current caller; the shared output is byte-identical while it stays empty.
+func body(o Options) string {
+	out := Instructions
+	if o.Hooks {
+		out += HooksNote
 	}
-	return Instructions
+	if extra := strings.TrimSpace(o.ExtraInstructions); extra != "" {
+		out += "\n\n" + extra
+	}
+	if o.Hooks {
+		if extra := strings.TrimSpace(o.ExtraHooksNote); extra != "" {
+			out += "\n\n" + extra
+		}
+	}
+	return out
 }


### PR DESCRIPTION
check, coverage, doctor, baseline, install/uninstall and hook lived in cmd/enola, so a wrapper binary could not reach them: they are built on internal packages that do not cross a module boundary.

Move them to pkg/command behind a Runner holding the cli.Binary, so usage lines, error prefixes and suggested remedies name the binary that is running. Product references stay literal; only invocations are parameterised. New(bin, ownSubcommands...) records commands a binary dispatches itself, so upgrade stays OSS-only in cmd/enola while still being offered as a typo suggestion.

cmd/enola dispatches upgrade, then delegates. --help output is unchanged.

Add install.Options.ExtraInstructions and ExtraHooksNote, set by neither binary, so a wrapper can name its own tools without forking the shared instruction text.

Tests assert every command cli.DefaultHelp documents is dispatchable by some binary, and that diagnostics name the running binary.