### PR TITLE
A caller that runs its own analysis over the two snapshots had no way to

### DIFF
--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -73,6 +73,41 @@ var DefaultFailExplainers = []string{"cycles"}
 // second out of the gate without needing a second allow-list.
 const DefaultMinConfidence = 1.0
 
+// Measurement is a count the policy can gate on that the DELTA ALONE DOES NOT CARRY —
+// something the caller computed by running its own analysis over the two snapshots.
+//
+// It exists so that grading stays in one place while measuring stays with whoever can
+// measure. A caller that owns an analyzer the engine does not ship can report what it
+// found; it does not get to decide what that means for the verdict, because two surfaces
+// deciding separately is how they come to disagree about the same change.
+type Measurement struct {
+	// Name is the stable key a Threshold refers to.
+	Name string `json:"name"`
+	// Label is the human phrasing used in the verdict line ("net-new dead-code
+	// orphan(s)"), so a breach reads as a sentence rather than a variable name.
+	Label string `json:"label"`
+	Count int    `json:"count"`
+}
+
+// Threshold turns a Measurement into a verdict contribution. A zero bound disables that
+// severity, so {FailAt: 3} warns at nothing and fails at three.
+//
+// Both bounds live here rather than in the measuring code because the whole point is
+// that one policy object describes what the gate enforces, whoever invoked it.
+type Threshold struct {
+	Measurement string `json:"measurement"`
+	WarnAt      int    `json:"warn_at,omitempty"`
+	FailAt      int    `json:"fail_at,omitempty"`
+}
+
+// Breach is a Measurement that met or exceeded one of its bounds.
+type Breach struct {
+	Measurement Measurement `json:"measurement"`
+	// Fatal distinguishes a FailAt breach from a WarnAt one. A warning breach is
+	// reported and does not change the exit code.
+	Fatal bool `json:"fatal"`
+}
+
 // Policy decides which parts of a delta are allowed to fail a build.
 type Policy struct {
 	// FailExplainers are the explainer names whose new findings fail the gate.
@@ -84,6 +119,21 @@ type Policy struct {
 	// usage errors are NOT suppressed by it — those are not judgements about the code,
 	// they are statements that the gate could not run.
 	WarnOnly bool `json:"warn_only"`
+	// Thresholds gate on Measurements the caller supplies. EMPTY BY DEFAULT, which is
+	// what keeps this additive: with no thresholds the verdict is byte-identical to
+	// what it was before measurements existed, so a build that passes today still
+	// passes. Anything that would newly fail a build has to be asked for.
+	Thresholds []Threshold `json:"thresholds,omitempty"`
+}
+
+// thresholdFor returns the bound configured for a measurement, if any.
+func (p Policy) thresholdFor(name string) (Threshold, bool) {
+	for _, t := range p.Thresholds {
+		if t.Measurement == name {
+			return t, true
+		}
+	}
+	return Threshold{}, false
 }
 
 // resolved fills in the defaults, so a Verdict records the policy that was actually
@@ -96,6 +146,7 @@ func (p Policy) resolved() Policy {
 		FailExplainers: p.failExplainers(),
 		MinConfidence:  p.minConfidence(),
 		WarnOnly:       p.WarnOnly,
+		Thresholds:     p.Thresholds,
 	}
 }
 
@@ -192,6 +243,13 @@ type Verdict struct {
 	// a drifting statistical threshold or a re-ranked top-N. Never graded.
 	Incidental []facts.Insight `json:"incidental,omitempty"`
 
+	// Measurements are every count the caller supplied, gated or not. Breaches are the
+	// subset that met a threshold; a fatal one makes the status a regression exactly as
+	// a failing finding does, so both surfaces reach the same verdict from the same
+	// numbers.
+	Measurements []Measurement `json:"measurements,omitempty"`
+	Breaches     []Breach      `json:"breaches,omitempty"`
+
 	// ComparabilityWarnings is every warning, verbatim and in full. Not split by
 	// severity: diff.Comparability records kinds as a set rather than per-message, and
 	// inventing an alignment to sort the prose would be a lie about which message
@@ -252,7 +310,7 @@ func edgeKindCounts(edges []diff.Edge) map[string]int {
 // built over different inputs, "re-run generate_snapshot" (the remedy for an inverted
 // pair) sends the caller down the wrong path. Nothing is hidden by the ordering — every
 // warning is reported regardless of which one decided the status.
-func Evaluate(d *diff.SnapshotDiff, p Policy) Verdict {
+func Evaluate(d *diff.SnapshotDiff, p Policy, measurements ...Measurement) Verdict {
 	v := Verdict{Policy: p.resolved(), Diff: d}
 	if d == nil {
 		v.Status = StatusUsageError
@@ -291,12 +349,31 @@ func Evaluate(d *diff.SnapshotDiff, p Policy) Verdict {
 	v.EdgeKindsRemoved = edgeKindCounts(d.EdgesRemoved)
 	v.FindingsChanged = d.FindingsChanged
 
+	// Measurements are carried whether or not a threshold gates them: a caller that
+	// measured something and got silence cannot tell "under the bound" from "never
+	// looked", and that ambiguity is the same one the incidental bucket exists to avoid.
+	v.Measurements = measurements
+	fatalBreach := false
+	for _, m := range measurements {
+		t, ok := p.thresholdFor(m.Name)
+		if !ok {
+			continue
+		}
+		switch {
+		case t.FailAt > 0 && m.Count >= t.FailAt:
+			v.Breaches = append(v.Breaches, Breach{Measurement: m, Fatal: true})
+			fatalBreach = true
+		case t.WarnAt > 0 && m.Count >= t.WarnAt:
+			v.Breaches = append(v.Breaches, Breach{Measurement: m})
+		}
+	}
+
 	switch {
 	case len(v.BlockingKinds) > 0:
 		v.Status = StatusIncomparable
 	case d.Comparability.HasKind(diff.WarnInvertedPair):
 		v.Status = StatusUsageError
-	case len(v.Failures) > 0 && !p.WarnOnly:
+	case (len(v.Failures) > 0 || fatalBreach) && !p.WarnOnly:
 		v.Status = StatusRegression
 	default:
 		v.Status = StatusClean

--- a/pkg/check/measurement_test.go
+++ b/pkg/check/measurement_test.go
@@ -1,0 +1,164 @@
+package check
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/diff"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func cleanDiff() *diff.SnapshotDiff { return &diff.SnapshotDiff{} }
+
+// With no thresholds configured the verdict must be exactly what it was before
+// measurements existed. This is the whole basis for the feature being additive: a build
+// that passes today has to keep passing after an upgrade, whether or not the caller
+// happens to measure things.
+func TestMeasurementsWithoutThresholdsChangeNothing(t *testing.T) {
+	m := []Measurement{
+		{Name: "net_new_orphans", Label: "net-new dead-code orphan(s)", Count: 99},
+		{Name: "new_high_perf", Label: "new high-severity performance finding(s)", Count: 42},
+	}
+
+	v := Evaluate(cleanDiff(), Policy{}, m...)
+
+	if v.Status != StatusClean {
+		t.Errorf("Status = %q, want %q — an ungated measurement must not grade", v.Status, StatusClean)
+	}
+	if v.ExitCode() != 0 {
+		t.Errorf("ExitCode = %d, want 0", v.ExitCode())
+	}
+	if len(v.Breaches) != 0 {
+		t.Errorf("Breaches = %v, want none", v.Breaches)
+	}
+	// Carried even though ungated: a caller that measured something and got silence
+	// cannot otherwise tell "under the bound" from "nobody looked".
+	if len(v.Measurements) != 2 {
+		t.Errorf("Measurements = %d, want 2 — measurements must be reported even when not gated", len(v.Measurements))
+	}
+}
+
+func TestThresholdGrading(t *testing.T) {
+	tests := []struct {
+		name       string
+		count      int
+		threshold  Threshold
+		wantStatus Status
+		wantBreach bool
+		wantFatal  bool
+	}{
+		{
+			name:       "below both bounds is clean and silent",
+			count:      1,
+			threshold:  Threshold{Measurement: "orphans", WarnAt: 2, FailAt: 4},
+			wantStatus: StatusClean,
+		},
+		{
+			name:       "at the warn bound reports without failing",
+			count:      2,
+			threshold:  Threshold{Measurement: "orphans", WarnAt: 2, FailAt: 4},
+			wantStatus: StatusClean,
+			wantBreach: true,
+		},
+		{
+			name:       "at the fail bound is a regression",
+			count:      4,
+			threshold:  Threshold{Measurement: "orphans", WarnAt: 2, FailAt: 4},
+			wantStatus: StatusRegression,
+			wantBreach: true,
+			wantFatal:  true,
+		},
+		{
+			name:       "a zero bound disables that severity",
+			count:      50,
+			threshold:  Threshold{Measurement: "orphans", FailAt: 0, WarnAt: 0},
+			wantStatus: StatusClean,
+		},
+		{
+			name:       "fail-only threshold still fails",
+			count:      3,
+			threshold:  Threshold{Measurement: "orphans", FailAt: 3},
+			wantStatus: StatusRegression,
+			wantBreach: true,
+			wantFatal:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := Evaluate(cleanDiff(), Policy{Thresholds: []Threshold{tt.threshold}},
+				Measurement{Name: "orphans", Label: "orphan(s)", Count: tt.count})
+
+			if v.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", v.Status, tt.wantStatus)
+			}
+			if got := len(v.Breaches) > 0; got != tt.wantBreach {
+				t.Errorf("breach reported = %v, want %v", got, tt.wantBreach)
+			}
+			if tt.wantBreach && v.Breaches[0].Fatal != tt.wantFatal {
+				t.Errorf("Fatal = %v, want %v", v.Breaches[0].Fatal, tt.wantFatal)
+			}
+		})
+	}
+}
+
+// A threshold naming a measurement nobody reported must not fire. Otherwise a policy
+// would grade on the ABSENCE of a signal, and a caller that simply cannot measure
+// something would fail every build.
+func TestThresholdWithoutItsMeasurementIsInert(t *testing.T) {
+	v := Evaluate(cleanDiff(), Policy{Thresholds: []Threshold{{Measurement: "never_reported", FailAt: 1}}})
+
+	if v.Status != StatusClean {
+		t.Errorf("Status = %q, want %q", v.Status, StatusClean)
+	}
+	if len(v.Breaches) != 0 {
+		t.Errorf("Breaches = %v, want none", v.Breaches)
+	}
+}
+
+// --warn-only must suppress a fatal breach exactly as it suppresses a failing finding.
+func TestWarnOnlySuppressesFatalBreach(t *testing.T) {
+	v := Evaluate(cleanDiff(),
+		Policy{WarnOnly: true, Thresholds: []Threshold{{Measurement: "orphans", FailAt: 1}}},
+		Measurement{Name: "orphans", Label: "orphan(s)", Count: 5})
+
+	if v.Status != StatusClean {
+		t.Errorf("Status = %q, want %q under --warn-only", v.Status, StatusClean)
+	}
+	if len(v.Breaches) != 1 || !v.Breaches[0].Fatal {
+		t.Errorf("the breach must still be REPORTED under --warn-only; got %v", v.Breaches)
+	}
+}
+
+// The headline counts breaches, not only findings. A change failing solely on a
+// measurement would otherwise read "FAIL — 0 structural regressions introduced".
+func TestRenderCountsBreachesInTheHeadline(t *testing.T) {
+	out := Evaluate(cleanDiff(),
+		Policy{Thresholds: []Threshold{{Measurement: "orphans", FailAt: 1}}},
+		Measurement{Name: "orphans", Label: "net-new dead-code orphan(s)", Count: 3}).Render()
+
+	if strings.Contains(out, "0 structural regressions") {
+		t.Errorf("headline contradicts the verdict:\n%s", out)
+	}
+	if !strings.Contains(out, "FAIL — 1 structural regression introduced") {
+		t.Errorf("headline does not count the breach:\n%s", out)
+	}
+	if !strings.Contains(out, "net-new dead-code orphan(s)") {
+		t.Errorf("breach not reported in the text verdict:\n%s", out)
+	}
+}
+
+// Findings and breaches are counted together, so a change tripping both reads as one
+// total rather than two competing numbers.
+func TestRenderCombinesFindingsAndBreaches(t *testing.T) {
+	d := &diff.SnapshotDiff{FindingsNew: []facts.Insight{
+		{Source: "cycles", Title: "Cyclic dependency detected (2 modules)", Confidence: 1.0},
+	}}
+
+	out := Evaluate(d, Policy{Thresholds: []Threshold{{Measurement: "orphans", FailAt: 1}}},
+		Measurement{Name: "orphans", Label: "orphan(s)", Count: 2}).Render()
+
+	if !strings.Contains(out, "FAIL — 2 structural regressions introduced") {
+		t.Errorf("headline does not combine the failing finding and the breach:\n%s", out)
+	}
+}

--- a/pkg/check/render.go
+++ b/pkg/check/render.go
@@ -82,7 +82,17 @@ func (v Verdict) Render() string {
 			sb.WriteString("PASS — no architectural change.\n")
 		}
 	case StatusRegression:
-		fmt.Fprintf(&sb, "FAIL — %s introduced.\n", plural(len(v.Failures), "structural regression", "structural regressions"))
+		// Breaches count toward the headline. A change that trips only a measurement
+		// threshold has zero failing FINDINGS, and reporting "0 structural regressions
+		// introduced" above a FAIL is the kind of contradiction that makes a reader stop
+		// believing the first line.
+		n := len(v.Failures)
+		for _, b := range v.Breaches {
+			if b.Fatal {
+				n++
+			}
+		}
+		fmt.Fprintf(&sb, "FAIL — %s introduced.\n", plural(n, "structural regression", "structural regressions"))
 	case StatusUsageError:
 		sb.WriteString("ERROR — the gate could not run.\n")
 	case StatusIncomparable:
@@ -91,6 +101,7 @@ func (v Verdict) Render() string {
 	}
 
 	v.writeComparability(&sb)
+	v.writeBreaches(&sb)
 
 	if len(v.Failures) > 0 {
 		// The header has to agree with the verdict. Labelling these "(fail)" under a
@@ -479,6 +490,25 @@ func writeKinds(sb *strings.Builder, kinds []diff.WarningKind) {
 		} else {
 			fmt.Fprintf(sb, "    %s\n", k)
 		}
+	}
+}
+
+// writeBreaches reports the measurement thresholds this change met.
+//
+// Measurements the caller supplied but no threshold gates are deliberately NOT printed
+// here: they are carried in the JSON for a consumer that wants them, and a text verdict
+// that listed every number it chose not to act on would bury the ones it did.
+func (v Verdict) writeBreaches(sb *strings.Builder) {
+	if len(v.Breaches) == 0 {
+		return
+	}
+	sb.WriteString("\nMeasurements over threshold:\n")
+	for _, b := range v.Breaches {
+		severity := "warn"
+		if b.Fatal {
+			severity = "fail"
+		}
+		fmt.Fprintf(sb, "  - [%s] %d %s\n", severity, b.Measurement.Count, b.Measurement.Label)
 	}
 }
 


### PR DESCRIPTION
feed the result into the verdict, so it had to grade itself — which is how two surfaces come to disagree about the same change.

Add Measurement, Threshold and Breach. The caller reports counts; the policy decides what they mean. Evaluate is variadic so existing calls compile unchanged, and Policy.Thresholds is empty by default, so a verdict with no thresholds is byte-identical to before.

Measurements are carried whether or not a threshold gates them — otherwise a caller cannot tell "under the bound" from "nobody looked" — and the FAIL headline counts breaches alongside findings, so a change failing only on a measurement does not report zero regressions.