### PR TITLE
Make analyzer-derived values part of the snapshot and visible in a diff

### DIFF
--- a/internal/diff/changedprops_test.go
+++ b/internal/diff/changedprops_test.go
@@ -1,0 +1,113 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func factWithProps(name string, props map[string]any) facts.Fact {
+	return facts.Fact{Kind: facts.KindModule, Name: name, File: name, Props: props}
+}
+
+func TestChangedProps(t *testing.T) {
+	tests := []struct {
+		name   string
+		before map[string]any
+		after  map[string]any
+		want   []string
+	}{
+		{
+			name:   "identical props report nothing",
+			before: map[string]any{"instability": 0.5},
+			after:  map[string]any{"instability": 0.5},
+		},
+		{
+			name:   "a moved value reads as before to after",
+			before: map[string]any{"instability": 0.3},
+			after:  map[string]any{"instability": 0.72},
+			want:   []string{"instability: 0.3 → 0.72"},
+		},
+		{
+			name:   "a newly-set prop is distinguished from a changed one",
+			before: map[string]any{},
+			after:  map[string]any{"distance": 0.86},
+			want:   []string{"distance: (unset) → 0.86"},
+		},
+		{
+			name:   "a dropped prop is reported rather than silently ignored",
+			before: map[string]any{"distance": 0.86},
+			after:  map[string]any{},
+			want:   []string{"distance: 0.86 → (unset)"},
+		},
+		{
+			name:   "only the props that moved are listed",
+			before: map[string]any{"afferent": 3, "efferent": 4, "instability": 0.57},
+			after:  map[string]any{"afferent": 3, "efferent": 9, "instability": 0.75},
+			want:   []string{"efferent: 4 → 9", "instability: 0.57 → 0.75"},
+		},
+		{
+			name:   "non-numeric props are handled, not assumed numeric",
+			before: map[string]any{"symbol_kind": "function"},
+			after:  map[string]any{"symbol_kind": "method"},
+			want:   []string{"symbol_kind: function → method"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := changedProps(FactChange{
+				Before: factWithProps("m", tt.before),
+				After:  factWithProps("m", tt.after),
+			})
+			if len(got) != len(tt.want) {
+				t.Fatalf("changedProps() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("line %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Output must not reshuffle between runs. Props are a map, and a renderer whose order
+// follows map iteration makes two identical diffs look different — the same class of
+// defect that once made insights.json non-reproducible.
+func TestChangedPropsIsOrderStable(t *testing.T) {
+	before := map[string]any{"afferent": 1, "efferent": 1, "instability": 0.1, "abstractness": 0.1, "distance": 0.1}
+	after := map[string]any{"afferent": 2, "efferent": 2, "instability": 0.2, "abstractness": 0.2, "distance": 0.2}
+
+	first := changedProps(FactChange{Before: factWithProps("m", before), After: factWithProps("m", after)})
+	for i := 0; i < 50; i++ {
+		got := changedProps(FactChange{Before: factWithProps("m", before), After: factWithProps("m", after)})
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("run %d differs at line %d: %q vs %q", i, j, got[j], first[j])
+			}
+		}
+	}
+	if len(first) != 5 {
+		t.Errorf("got %d changed props, want 5: %v", len(first), first)
+	}
+}
+
+// The delta has to reach the rendered diff, not only the JSON. A changed fact used to
+// render as a bare line, so the reader could see THAT something moved but not what.
+func TestRenderNamesTheChangedProp(t *testing.T) {
+	d := &SnapshotDiff{FactsChanged: []FactChange{{
+		Before: factWithProps("internal/foo", map[string]any{"instability": 0.30}),
+		After:  factWithProps("internal/foo", map[string]any{"instability": 0.72}),
+	}}}
+
+	out := d.RenderCompact()
+
+	if !strings.Contains(out, "internal/foo") {
+		t.Fatalf("changed fact missing from the diff:\n%s", out)
+	}
+	if !strings.Contains(out, "instability: 0.3 → 0.72") {
+		t.Errorf("the diff does not say WHAT moved:\n%s", out)
+	}
+}

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -109,6 +109,14 @@ func (d *SnapshotDiff) RenderCompact() string {
 		}
 		for _, c := range shown {
 			fmt.Fprintf(&sb, "- %s %s (%s:%d)\n", c.After.Kind, c.After.Name, c.After.File, c.After.Line)
+			// Name WHAT moved. The before/after facts have always been carried here and
+			// never surfaced, so a changed fact rendered as a bare line and the reader
+			// had to open the JSON to learn whether a signature, a complexity metric or
+			// a coupling number had shifted. A count of changed facts is not a finding;
+			// the delta inside them is.
+			for _, d := range changedProps(c) {
+				fmt.Fprintf(&sb, "    %s\n", d)
+			}
 		}
 		if len(d.FactsChanged) > len(shown) {
 			fmt.Fprintf(&sb, "- … and %d more (output_mode='full' for all)\n", len(d.FactsChanged)-len(shown))
@@ -117,6 +125,53 @@ func (d *SnapshotDiff) RenderCompact() string {
 	}
 
 	return sb.String()
+}
+
+// changedProps describes what actually differs between the two versions of a fact, as
+// "key: before → after" lines.
+//
+// Props only. Kind and Name are the identity a FactChange is matched on and cannot
+// differ; File and Line moving is noise on its own (a fact shifting down a file is not
+// an architectural change) and is left to the location already printed above.
+//
+// Values are rendered with %v rather than compared numerically: props are map[string]any
+// holding whatever an extractor put there, and a differ that assumed a type would go
+// quiet the first time one changed.
+func changedProps(c FactChange) []string {
+	if len(c.Before.Props) == 0 && len(c.After.Props) == 0 {
+		return nil
+	}
+	keys := make(map[string]bool, len(c.Before.Props)+len(c.After.Props))
+	for k := range c.Before.Props {
+		keys[k] = true
+	}
+	for k := range c.After.Props {
+		keys[k] = true
+	}
+	names := make([]string, 0, len(keys))
+	for k := range keys {
+		names = append(names, k)
+	}
+	// Sorted: the map iteration order varies between runs, and a renderer whose output
+	// reshuffles makes two identical diffs look different.
+	sort.Strings(names)
+
+	var out []string
+	for _, k := range names {
+		before, hadBefore := c.Before.Props[k]
+		after, hadAfter := c.After.Props[k]
+		switch {
+		case hadBefore && hadAfter:
+			if fmt.Sprintf("%v", before) != fmt.Sprintf("%v", after) {
+				out = append(out, fmt.Sprintf("%s: %v → %v", k, before, after))
+			}
+		case hadAfter:
+			out = append(out, fmt.Sprintf("%s: (unset) → %v", k, after))
+		case hadBefore:
+			out = append(out, fmt.Sprintf("%s: %v → (unset)", k, before))
+		}
+	}
+	return out
 }
 
 // writeIncidentalShifts lists findings that appeared or cleared without a

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -872,10 +872,37 @@ func (e *Engine) runTestRefExtractors(ctx context.Context, repoPath string, test
 	}
 }
 
+// runAnnotators lets enabled explainers write derived values back onto the facts
+// before any of them run Explain.
+//
+// Two orderings matter and neither is incidental. It runs AFTER the graph is built, so
+// whole-graph derivations (afferent/efferent coupling) are computable at all; and it runs
+// BEFORE every Explain rather than interleaved per explainer, so one explainer's insights
+// can never depend on whether another happened to be registered ahead of it — which would
+// make the snapshot depend on registration order.
+//
+// An annotator failure is logged and skipped, exactly as an explainer failure is: a
+// missing derived prop costs a diff some detail, and refusing to produce a snapshot over
+// it would cost the caller everything else in the graph.
+func (e *Engine) runAnnotators(ctx context.Context) {
+	for _, exp := range e.explainers.All() {
+		ann, ok := exp.(plugin.Annotator)
+		if !ok || !e.cfg.IsExplainerEnabled(exp.Name()) {
+			continue
+		}
+		log.Printf("[engine] running annotator: %s", exp.Name())
+		if err := ann.Annotate(ctx, e.store); err != nil {
+			log.Printf("[engine] annotator %s error: %v", exp.Name(), err)
+		}
+	}
+}
+
 // runExplainers runs all enabled explainers.
 func (e *Engine) runExplainers(ctx context.Context) ([]facts.Insight, []string, error) {
 	var allInsights []facts.Insight
 	var usedNames []string
+
+	e.runAnnotators(ctx)
 
 	for _, exp := range e.explainers.All() {
 		if !e.cfg.IsExplainerEnabled(exp.Name()) {

--- a/pkg/command/check.go
+++ b/pkg/command/check.go
@@ -57,7 +57,7 @@ func (r *Runner) resolveTarget(arg string) target {
 		cfgPath = arg
 	}
 
-	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: cfgPath})
+	eng, cfg, err := r.newEngine(bootstrap.Options{ConfigPath: cfgPath})
 	if err != nil {
 		r.checkFatal("failed to create engine: %v", err)
 	}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/cli"
 )
 
@@ -37,6 +39,40 @@ type Runner struct {
 	// accepts, so they belong in the typo suggestions and the "expected one of" list —
 	// otherwise `enola upgrad` is told upgrade is not a command of any kind.
 	own []string
+	// setup configures every engine the shared commands build, so a wrapper's plugins
+	// are present in the gate, the hook and the reports — not only in its MCP server.
+	//
+	// These commands construct their OWN engines (a gate has to snapshot the tree it is
+	// grading), so a wrapper that registered plugins on the server's engine alone got a
+	// plain OSS engine here. That is how `baseline pin` came to write a snapshot with a
+	// different explainer set than `--generate` on the same tree, from the same binary.
+	setup func(*bootstrap.Engine)
+}
+
+// WithEngine registers a hook applied to every engine these commands construct. Returns
+// the Runner so it can be chained onto New.
+//
+// The callback takes only the Engine: a wrapper outside this module cannot name
+// *config.Config, but it can reach the same value through Engine.Config() and mutate it
+// there. Keeping the signature to one exported type is what makes this usable across the
+// module boundary at all.
+func (r *Runner) WithEngine(setup func(*bootstrap.Engine)) *Runner {
+	r.setup = setup
+	return r
+}
+
+// newEngine builds an engine for a shared command and applies the wrapper's setup.
+// Every command that needs an engine must go through here; calling bootstrap.NewEngine
+// directly silently opts that command out of whatever the binary registers.
+func (r *Runner) newEngine(opts bootstrap.Options) (*bootstrap.Engine, *config.Config, error) {
+	eng, cfg, err := bootstrap.NewEngine(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if r.setup != nil {
+		r.setup(eng)
+	}
+	return eng, cfg, nil
 }
 
 // New returns a Runner for the given binary. ownSubcommands names commands the binary

--- a/pkg/command/doctor.go
+++ b/pkg/command/doctor.go
@@ -65,7 +65,7 @@ func (r *Runner) Doctor(args []string) {
 	outDir := hookOutputDir(repoDir)
 	state := hookstate.Load(outDir)
 	installed := hooksConfigured(repoDir)
-	baselineIssue := baselineUsability(repoDir, outDir)
+	baselineIssue := r.baselineUsability(repoDir, outDir)
 
 	if *asJSON {
 		out := map[string]any{
@@ -160,12 +160,12 @@ func (r *Runner) Doctor(args []string) {
 // baselineUsability returns why the pinned baseline could not be graded against, or
 // "" when it can. It answers from metadata alone — no files are parsed — so `doctor`
 // stays a report rather than becoming a snapshot.
-func baselineUsability(repoDir, outDir string) string {
+func (r *Runner) baselineUsability(repoDir, outDir string) string {
 	base, err := bootstrap.LoadSnapshotDir(engine.ResolveBaselineDir(outDir, "pinned"))
 	if err != nil {
 		return "" // no baseline pinned; the hooks section covers that case
 	}
-	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
+	eng, cfg, err := r.newEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
 	if err != nil {
 		return ""
 	}

--- a/pkg/command/hook.go
+++ b/pkg/command/hook.go
@@ -71,7 +71,7 @@ func (r *Runner) runStopHook(ctx context.Context) {
 	// Silence is the norm. The gate only has something to say when a baseline was pinned
 	// during this session AND the change regressed the architecture; every other path
 	// ends here, having printed nothing.
-	verdict, outDir, ok := gradeQuietly(ctx, in.CWD)
+	verdict, outDir, ok := r.gradeQuietly(ctx, in.CWD)
 
 	// Record the run BEFORE deciding whether to speak, and on every path. The silent
 	// paths are the ones worth recording: a hook that never fires and a hook that fires
@@ -150,7 +150,7 @@ func (r *Runner) runSessionStartHook(ctx context.Context, args []string) {
 	if len(args) > 0 && args[0] == detachedRunFlag {
 		// The detached child: the only place any work happens.
 		if len(args) > 1 {
-			pinBaselineSingleFlight(ctx, args[1])
+			r.pinBaselineSingleFlight(ctx, args[1])
 		}
 		return
 	}
@@ -182,8 +182,8 @@ func (r *Runner) runSessionStartHook(ctx context.Context, args []string) {
 //
 // Everything here is silent. It has no terminal, nobody is reading its output, and a hook
 // that cannot fail loudly must not try.
-func pinBaselineSingleFlight(ctx context.Context, repoDir string) {
-	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
+func (r *Runner) pinBaselineSingleFlight(ctx context.Context, repoDir string) {
+	eng, cfg, err := r.newEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
 	if err != nil {
 		return
 	}
@@ -319,12 +319,12 @@ func baselineIsUnusable(base, current facts.SnapshotMeta) bool {
 // It also returns the engine's output directory, which the caller needs to record the
 // heartbeat. That is returned even on the failure paths wherever it is known, because
 // "the hook ran and could not grade" is precisely the state worth having on record.
-func gradeQuietly(ctx context.Context, repoDir string) (check.Verdict, string, bool) {
+func (r *Runner) gradeQuietly(ctx context.Context, repoDir string) (check.Verdict, string, bool) {
 	if !isDirectory(repoDir) {
 		return check.Verdict{}, "", false
 	}
 
-	eng, cfg, err := bootstrap.NewEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
+	eng, cfg, err := r.newEngine(bootstrap.Options{ConfigPath: configForRepo(repoDir)})
 	if err != nil {
 		return check.Verdict{}, "", false
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -72,6 +72,39 @@ type TestRefExtractor interface {
 	ExtractTestRefs(ctx context.Context, repoPath string, testFiles, prodFiles []string) ([]facts.Fact, error)
 }
 
+// Annotator is an optional interface an Explainer may implement to write DERIVED
+// VALUES back onto the facts it analysed, in addition to emitting insights.
+//
+// It exists because insights and measurements are different things. An insight is a
+// finding — discrete, evidenced, worth a reader's attention — and an analyzer that
+// computes a continuous value for every module has no honest way to publish it as one:
+// emitting a finding per module would be noise, and emitting only the outliers throws
+// the rest away. A prop on the fact is the right home, and it comes with a property
+// insights do not have: the snapshot diff already reports prop movement, so an annotated
+// metric becomes comparable across two snapshots for free, attributed to the module it
+// belongs to.
+//
+// Contract:
+//
+//   - Annotate runs AFTER extraction and linking, so the whole graph is present — which
+//     is what makes whole-graph derivations (afferent/efferent coupling) computable here
+//     and not in an extractor.
+//   - It runs BEFORE Explain, so an implementation can compute once, annotate, and read
+//     its own props back when building insights.
+//   - It may only ADD OR UPDATE PROPS on existing facts. Adding, removing or renaming
+//     facts here would make the graph depend on which explainers were enabled, and two
+//     snapshots taken with different sets would no longer be comparable.
+//   - Values MUST be deterministic and stable in their rendered form. They are written
+//     into facts.jsonl and hashed into the snapshot id, so an unrounded float — whose
+//     last bits can move with summation order — would make an unchanged tree produce a
+//     different snapshot every run. Round before storing.
+//
+// Gated exactly like Explain: an explainer excluded by config annotates nothing.
+type Annotator interface {
+	// Annotate writes derived values onto facts already in the store.
+	Annotate(ctx context.Context, store *facts.Store) error
+}
+
 // Explainer analyzes facts and produces architectural insights.
 type Explainer interface {
 	// Name returns the explainer identifier (e.g. "cycles", "layers").


### PR DESCRIPTION
An analyzer that computes a continuous value per module had no way to publish it. One insight per module is noise, and publishing only the outliers discards the rest — so the value lived inside a single snapshot's analysis, was never written down, and was out of reach of any diff.

Three pieces, in that order:

Annotator — an optional interface an Explainer may implement, to write derived values onto the facts it analysed. It runs after linking, so whole-graph derivations are computable at all, and before every Explain rather than interleaved, so no explainer's insights depend on registration order. It may only add or update props: adding or removing facts would make the graph depend on which explainers were enabled, and two snapshots taken with different sets would no longer be comparable. Values must be rounded before storing — facts are hashed into the snapshot id, so an unrounded float would let an unchanged tree produce a different snapshot each run.

The fact diff now names which prop moved, as "key: before → after". The before and after facts were always carried in FactChange and never surfaced, so a changed fact rendered as "kind name (file:line)" and a reader could see THAT something moved but not what. Output is sorted, because props are a map and a renderer following map iteration order makes two identical diffs look different.

Runner.WithEngine, so a wrapper's plugins reach the engines the shared commands build. These commands construct their own — a gate has to snapshot the tree it grades — so a binary that registered plugins on its server's engine alone produced different snapshots depending on which command was invoked. The callback takes only *bootstrap.Engine: a caller outside this module cannot name *config.Config, but reaches the same value through Engine.Config().