### PR TITLE
Add graph view to dashboard

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,3 +19,29 @@ tree-sitter-swift — Swift grammar for tree-sitter
   the upstream grammar.json (see that directory's ATTRIBUTION.md for details and
   the regeneration command). The surrounding cgo glue (binding.go, cgo_parser.c,
   cgo_scanner.c) is enola's own code and is not part of the upstream grammar.
+
+--------------------------------------------------------------------------------
+
+The dashboard's interactive graph viewer loads the following third-party
+JavaScript packages at runtime from unpkg. Each package is distributed under
+the MIT License:
+
+cytoscape
+  Version:  3.31.2
+  Source:   https://github.com/cytoscape/cytoscape.js
+  License:  MIT — https://github.com/cytoscape/cytoscape.js/blob/3.31.2/LICENSE
+
+layout-base
+  Version:  2.0.1
+  Source:   https://github.com/iVis-at-Bilkent/layout-base
+  License:  MIT — https://github.com/iVis-at-Bilkent/layout-base/blob/2.0.1/LICENSE
+
+cose-base
+  Version:  2.2.0
+  Source:   https://github.com/iVis-at-Bilkent/cose-base
+  License:  MIT — https://github.com/iVis-at-Bilkent/cose-base/blob/2.2.0/LICENSE
+
+cytoscape-fcose
+  Version:  2.2.0
+  Source:   https://github.com/iVis-at-Bilkent/cytoscape.js-fcose
+  License:  MIT — https://github.com/cytoscape/cytoscape.js-fcose/blob/2.2.0/LICENSE

--- a/README.md
+++ b/README.md
@@ -679,6 +679,17 @@ Starting the MCP server also starts a **read-only dashboard** on a free loopback
 - the **insights** grouped by explainer, filterable by confidence band, so you can see what each finding is and how certain it is;
 - **extraction quality** - per-service coverage, unresolved routes, and samples of skipped files and parse errors, which is where you look when a snapshot seems thin.
 
+The **Interactive graph** link opens a full-screen, read-only graph viewer for the
+same snapshot. It starts with a module-level overview: select or search for a
+module to load its bounded neighborhood of symbols and relations, then use the
+node- and edge-kind filters to focus the view. Search can find nodes across the
+loaded snapshot, while each focused request remains capped so the browser is
+not sent the entire repository at once. If the snapshot changes while the
+viewer is open, it asks you to reload before requesting more data. The viewer
+loads its pinned Cytoscape libraries from unpkg, so browser access to that CDN
+is required for the interactive graph; the receipt tables remain available
+without it.
+
 It is strictly a viewer: every request reads through the same concurrency-safe accessors the MCP tools use and never mutates server state. It binds loopback only and serves nothing but that one page. Pass `--no-dashboard` to skip it.
 
 #### Several servers at once

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -167,6 +167,9 @@ func Start(eng *bootstrap.Engine, opts Options) (*Server, error) {
 
 	s.mux = http.NewServeMux()
 	s.mux.HandleFunc("/", s.handleIndex)
+	s.mux.HandleFunc("/view", s.handleView)
+	s.mux.HandleFunc("/api/graph", s.handleGraph)
+	s.mux.HandleFunc("/api/graph/search", s.handleGraphSearch)
 
 	go func() {
 		if err := http.Serve(ln, s.mux); err != nil {
@@ -278,6 +281,120 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/view" {
+		http.NotFound(w, r)
+		return
+	}
+	data := s.buildPage()
+	data.ViewOnly = true
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.Execute(w, data); err != nil {
+		log.Printf("dashboard: render failed: %v", err)
+	}
+}
+
+// handleGraph serves a bounded neighborhood of the live graph. The dashboard
+// keeps the complete graph server-side and requests only the current focus
+// scope rather than transferring the entire repository again.
+func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/graph" {
+		http.NotFound(w, r)
+		return
+	}
+	receipt := s.eng.GraphReceipt()
+	if receipt == nil {
+		http.Error(w, "no graph loaded", http.StatusNotFound)
+		return
+	}
+	query := r.URL.Query()
+	if expected := query.Get("snapshot_id"); expected != "" && expected != receipt.SnapshotID {
+		http.Error(w, "snapshot changed; reload the dashboard", http.StatusConflict)
+		return
+	}
+	focus := strings.TrimSpace(query.Get("focus"))
+	if focus == "" {
+		http.Error(w, "focus is required", http.StatusBadRequest)
+		return
+	}
+	direction := query.Get("direction")
+	if direction == "" {
+		direction = "both"
+	}
+	if direction != "forward" && direction != "reverse" && direction != "both" && direction != "" {
+		http.Error(w, "direction must be forward, reverse, or both", http.StatusBadRequest)
+		return
+	}
+	depth := boundedInt(query.Get("depth"), 1, 1, 5)
+	maxNodes := boundedInt(query.Get("max_nodes"), 150, 1, 300)
+	result := buildFocusedGraph(
+		s.eng.Store(), receipt.SnapshotID, focus, query.Get("kind"),
+		query.Get("repo"), direction, depth, maxNodes,
+	)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+type graphSearchResult struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	Repo string `json:"repo,omitempty"`
+}
+
+// handleGraphSearch returns a small set of full-snapshot node suggestions.
+// Unlike the focused graph endpoint, search is intentionally not bounded by
+// the currently loaded browser neighborhood.
+func (s *Server) handleGraphSearch(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/graph/search" {
+		http.NotFound(w, r)
+		return
+	}
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if query == "" {
+		_ = json.NewEncoder(w).Encode([]graphSearchResult{})
+		return
+	}
+	needle := strings.ToLower(query)
+	var results []graphSearchResult
+	for _, f := range s.eng.Store().All() {
+		if f.Kind == facts.KindDependency || f.Name == "" ||
+			!strings.Contains(strings.ToLower(f.Name), needle) {
+			continue
+		}
+		results = append(results, graphSearchResult{Name: f.Name, Kind: f.Kind, Repo: f.Repo})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		iPrefix := strings.HasPrefix(strings.ToLower(results[i].Name), needle)
+		jPrefix := strings.HasPrefix(strings.ToLower(results[j].Name), needle)
+		if iPrefix != jPrefix {
+			return iPrefix
+		}
+		return results[i].Name < results[j].Name
+	})
+	if len(results) > 20 {
+		results = results[:20]
+	}
+	_ = json.NewEncoder(w).Encode(results)
+}
+
+func boundedInt(raw string, fallback, min, max int) int {
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	if n < min {
+		return min
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
 // titleOr returns the configured product name, or the default when unset.
 func titleOr(title string) string {
 	if title == "" {
@@ -362,6 +479,7 @@ type valueRow struct {
 type pageData struct {
 	RefreshSeconds int
 	Title          string
+	ViewOnly       bool
 
 	// This server's own identity. Never sourced from the cross-process aggregate:
 	// with several agent terminals open, that would name a sibling process.
@@ -401,6 +519,8 @@ type pageData struct {
 	HasGraph  bool
 	Graph     *facts.GraphReceipt
 	GraphNote string
+	GraphView *graphView
+	GraphJSON template.JS
 
 	// Services and CrossRepoEdges are enumerated from the live fact store (not the
 	// receipt, which holds only counts) to back the clickable graph-receipt cards.
@@ -507,6 +627,10 @@ func (s *Server) buildPage() pageData {
 	if gv := s.eng.GraphReceipt(); gv != nil {
 		data.HasGraph = true
 		data.Graph = gv
+		data.GraphView = buildGraphView(s.eng.Store(), gv.SnapshotID)
+		if data.GraphView != nil {
+			data.GraphJSON = template.JS(data.GraphView.BootstrapJSON())
+		}
 	} else {
 		data.GraphNote = "No graph loaded in this server yet — run generate_snapshot to populate this."
 	}

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -202,6 +202,77 @@ func TestHandlerNotFound(t *testing.T) {
 	}
 }
 
+func TestGraphEndpointReturnsBoundedFocusedScope(t *testing.T) {
+	isolateHome(t)
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "a", Repo: "repo", File: "a", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "b"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "b", Repo: "repo", File: "b"},
+	)
+	store.BuildGraph()
+	s := newTestServer(1, fakeArtifacts{
+		store: store,
+		graph: &facts.GraphReceipt{SnapshotID: "snap"},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/graph?focus=b&kind=module&repo=repo&snapshot_id=snap", nil)
+	s.handleGraph(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{`"snapshot_id":"snap"`, `"scope":"symbols"`, `"name":"b"`, `"name":"a"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("response missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestGraphEndpointRequiresMatchingSnapshot(t *testing.T) {
+	isolateHome(t)
+	store := facts.NewStore()
+	store.Add(facts.Fact{Kind: facts.KindModule, Name: "a", Repo: "repo", File: "a"})
+	store.BuildGraph()
+	s := newTestServer(1, fakeArtifacts{
+		store: store,
+		graph: &facts.GraphReceipt{SnapshotID: "current"},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/graph?focus=a&snapshot_id=stale", nil)
+	s.handleGraph(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestGraphSearchReturnsMatchingNodes(t *testing.T) {
+	isolateHome(t)
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "api/domain/fulfilment", Repo: "api", File: "api/domain/fulfilment"},
+		facts.Fact{Kind: facts.KindSymbol, Name: "api/domain/fulfilment/notions.Fulfilment", Repo: "api", File: "api/domain/fulfilment/notions.py"},
+		facts.Fact{Kind: facts.KindDependency, Name: "api/app -> api/domain/fulfilment", Repo: "api", File: "api/app.py"},
+	)
+	s := newTestServer(1, fakeArtifacts{store: store})
+
+	rec := httptest.NewRecorder()
+	s.handleGraphSearch(rec, httptest.NewRequest(http.MethodGet, "/api/graph/search?q=Fulfilment", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{`"name":"api/domain/fulfilment"`, `"name":"api/domain/fulfilment/notions.Fulfilment"`, `"kind":"module"`, `"kind":"symbol"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("search response missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "api/app -> api/domain/fulfilment") {
+		t.Error("search response should not include dependency edge facts")
+	}
+}
+
 func TestStartBindsLoopbackPort(t *testing.T) {
 	s, err := Start(nil, Options{})
 	if err != nil {

--- a/pkg/dashboard/graphview.go
+++ b/pkg/dashboard/graphview.go
@@ -1,0 +1,553 @@
+package dashboard
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+// graphView is the browser contract for the graph inspector. Nodes and edges
+// contain the complete current graph; OverviewNodes/OverviewEdges are the
+// smaller module-level projection rendered first by the browser.
+type graphView struct {
+	SnapshotID    string      `json:"snapshot_id,omitempty"`
+	Nodes         []graphNode `json:"nodes"`
+	Edges         []graphEdge `json:"edges"`
+	OverviewNodes []graphNode `json:"overview_nodes"`
+	OverviewEdges []graphEdge `json:"overview_edges"`
+	NodeKinds     []string    `json:"node_kinds"`
+	EdgeKinds     []string    `json:"edge_kinds"`
+	FactCount     int         `json:"fact_count"`
+	EdgeCount     int         `json:"edge_count"`
+	Unresolved    int         `json:"unresolved"`
+}
+
+type graphNode struct {
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Label      string         `json:"label"`
+	Kind       string         `json:"kind"`
+	Repo       string         `json:"repo,omitempty"`
+	File       string         `json:"file,omitempty"`
+	Line       int            `json:"line,omitempty"`
+	Count      int            `json:"count,omitempty"`
+	Props      map[string]any `json:"props,omitempty"`
+	Unresolved bool           `json:"unresolved,omitempty"`
+	Conflated  []string       `json:"conflated,omitempty"`
+}
+
+type graphEdge struct {
+	ID         string `json:"id"`
+	Source     string `json:"source"`
+	Target     string `json:"target"`
+	Kind       string `json:"kind"`
+	Count      int    `json:"count"`
+	Aggregated bool   `json:"aggregated,omitempty"`
+}
+
+type focusedGraph struct {
+	SnapshotID string      `json:"snapshot_id,omitempty"`
+	Scope      string      `json:"scope"`
+	Focus      string      `json:"focus,omitempty"`
+	Nodes      []graphNode `json:"nodes"`
+	Edges      []graphEdge `json:"edges"`
+	Truncated  bool        `json:"truncated"`
+	HasMore    bool        `json:"has_more"`
+	NodeCount  int         `json:"node_count"`
+	EdgeCount  int         `json:"edge_count"`
+}
+
+type graphBootstrap struct {
+	SnapshotID    string      `json:"snapshot_id,omitempty"`
+	OverviewNodes []graphNode `json:"overview_nodes"`
+	OverviewEdges []graphEdge `json:"overview_edges"`
+	NodeKinds     []string    `json:"node_kinds"`
+	EdgeKinds     []string    `json:"edge_kinds"`
+	FactCount     int         `json:"fact_count"`
+	EdgeCount     int         `json:"edge_count"`
+	Unresolved    int         `json:"unresolved"`
+}
+
+// buildGraphView creates a deterministic, JSON-safe graph payload. The fact
+// index is used to give each fact a stable-in-response ID instead of treating a
+// display name as a unique key: names may be shared by facts of different kinds.
+func buildGraphView(store *facts.Store, snapshotID string) *graphView {
+	if store == nil {
+		return nil
+	}
+	all := store.All()
+	view := &graphView{SnapshotID: snapshotID, FactCount: len(all)}
+	if len(all) == 0 {
+		return view
+	}
+
+	ids := make([]string, len(all))
+	byName := make(map[string][]int)
+	for i, f := range all {
+		ids[i] = factID(f, i)
+		byName[f.Name] = append(byName[f.Name], i)
+	}
+
+	nodeKinds := map[string]bool{}
+	edgeKinds := map[string]bool{}
+	for i, f := range all {
+		n := graphNode{
+			ID: ids[i], Name: f.Name, Kind: f.Kind, Repo: f.Repo,
+			Label: f.Name, File: f.File, Line: f.Line, Count: 1, Props: f.Props,
+		}
+		if n.Kind == "" {
+			n.Kind = "unknown"
+		}
+		n.Conflated = conflatedKinds(byName[f.Name], all)
+		nodeKinds[n.Kind] = true
+		view.Nodes = append(view.Nodes, n)
+	}
+
+	// Resolve relation targets using the same natural target kinds as the
+	// internal graph. If no fact backs a target, create one explicit unresolved
+	// node rather than silently dropping the edge.
+	unresolvedIDs := map[string]string{}
+	for i, f := range all {
+		for j, rel := range f.Relations {
+			target := chooseFact(byName[rel.Target], all, relationTargetKind(rel.Kind))
+			targetID := ""
+			if target >= 0 {
+				targetID = ids[target]
+			} else {
+				key := f.Repo + "\x00" + rel.Target
+				targetID = unresolvedIDs[key]
+				if targetID == "" {
+					targetID = "unresolved-" + shortHash(key)
+					unresolvedIDs[key] = targetID
+					view.Nodes = append(view.Nodes, graphNode{
+						ID: targetID, Name: rel.Target, Label: rel.Target,
+						Kind: "unresolved", Repo: f.Repo, Count: 1, Unresolved: true,
+					})
+					view.Unresolved++
+				}
+			}
+			edge := graphEdge{
+				ID:     "edge-" + shortHash(ids[i]+"\x00"+rel.Kind+"\x00"+targetID+"\x00"+strconv.Itoa(j)),
+				Source: ids[i], Target: targetID, Kind: rel.Kind, Count: 1,
+			}
+			view.Edges = append(view.Edges, edge)
+			edgeKinds[rel.Kind] = true
+		}
+	}
+	view.EdgeCount = len(view.Edges)
+
+	view.OverviewNodes, view.OverviewEdges = overviewGraph(store, all, byName)
+	view.NodeKinds = orderedNodeKinds(nodeKinds)
+	view.EdgeKinds = sortedKeys(edgeKinds)
+	sort.Slice(view.Nodes, func(i, j int) bool { return view.Nodes[i].ID < view.Nodes[j].ID })
+	sort.Slice(view.Edges, func(i, j int) bool { return view.Edges[i].ID < view.Edges[j].ID })
+	return view
+}
+
+// buildFocusedGraph converts a bounded graph traversal into the browser
+// contract. The traversal is intentionally capped before serialization so a
+// zoom or focus event cannot accidentally send the whole repository to the
+// browser.
+func buildFocusedGraph(store *facts.Store, snapshotID, focus, kind, repo, direction string, depth, maxNodes int) *focusedGraph {
+	result := &focusedGraph{SnapshotID: snapshotID, Scope: "symbols", Focus: focus}
+	if store == nil || store.Graph() == nil || focus == "" {
+		return result
+	}
+	resolved := resolveFocus(store, focus, kind, repo)
+	if resolved == "" {
+		return result
+	}
+	if depth <= 0 {
+		depth = 1
+	}
+	if maxNodes <= 0 {
+		maxNodes = 150
+	}
+	if maxNodes > 300 {
+		maxNodes = 300
+	}
+	nodeKinds := focusedNodeKinds()
+	traversals := make([]facts.TraversalResult, 0, 2)
+	if direction == "reverse" || direction == "both" {
+		traversals = append(traversals, store.Graph().Traverse(resolved, "reverse", nil, nodeKinds, depth, maxNodes))
+	}
+	if direction == "forward" || direction == "both" || direction == "" {
+		traversals = append(traversals, store.Graph().Traverse(resolved, "forward", nil, nodeKinds, depth, maxNodes))
+	}
+
+	nodeByName := map[string]graphNode{}
+	edgeByKey := map[string]graphEdge{}
+	for _, traversal := range traversals {
+		result.Truncated = result.Truncated || traversal.Stats.Truncated
+		for _, n := range traversal.Nodes {
+			if _, exists := nodeByName[n.Name]; exists {
+				continue
+			}
+			nodeByName[n.Name] = graphNode{
+				ID: focusedNodeID(n), Name: n.Name, Label: n.Name,
+				Kind: n.Kind, Repo: n.Repo, File: n.File, Line: n.Line,
+				Count: 1, Unresolved: n.Unresolved, Conflated: n.Conflated,
+			}
+		}
+		for _, e := range traversal.Edges {
+			source, sourceOK := nodeByName[e.Source]
+			target, targetOK := nodeByName[e.Target]
+			if !sourceOK || !targetOK {
+				continue
+			}
+			key := source.ID + "\x00" + e.Kind + "\x00" + target.ID
+			edge := edgeByKey[key]
+			if edge.ID == "" {
+				edge = graphEdge{
+					ID:     "focused-edge-" + shortHash(key),
+					Source: source.ID, Target: target.ID, Kind: e.Kind, Count: 0,
+				}
+			}
+			edge.Count++
+			edgeByKey[key] = edge
+		}
+	}
+	addFocusedImplements(store, nodeByName, edgeByKey, maxNodes)
+	for _, n := range nodeByName {
+		result.Nodes = append(result.Nodes, n)
+	}
+	for _, e := range edgeByKey {
+		result.Edges = append(result.Edges, e)
+	}
+	sort.Slice(result.Nodes, func(i, j int) bool { return result.Nodes[i].ID < result.Nodes[j].ID })
+	sort.Slice(result.Edges, func(i, j int) bool { return result.Edges[i].ID < result.Edges[j].ID })
+	result.NodeCount = len(result.Nodes)
+	result.EdgeCount = len(result.Edges)
+	result.HasMore = result.Truncated
+	return result
+}
+
+// addFocusedImplements preserves the direct inheritance edges of symbols that
+// made it into a bounded scope. A module traversal reaches its member symbols
+// through their declares edges, but their base types are one relation further
+// away; requiring the traversal to expand another hop would pull in unrelated
+// neighborhoods. Add only those direct implements targets instead.
+func addFocusedImplements(store *facts.Store, nodeByName map[string]graphNode, edgeByKey map[string]graphEdge, maxNodes int) {
+	if store == nil {
+		return
+	}
+	sources := make([]graphNode, 0, len(nodeByName))
+	for _, node := range nodeByName {
+		if node.Kind == facts.KindSymbol {
+			sources = append(sources, node)
+		}
+	}
+	for _, source := range sources {
+		for _, fact := range store.LookupByExactName(source.Name) {
+			if fact.Kind != facts.KindSymbol {
+				continue
+			}
+			for _, rel := range fact.Relations {
+				if rel.Kind != facts.RelImplements {
+					continue
+				}
+				target, exists := nodeByName[rel.Target]
+				if !exists {
+					backing := chooseFocusedFact(store.LookupByExactName(rel.Target), facts.KindSymbol)
+					if backing != nil {
+						target = graphNode{
+							ID: focusedNodeID(facts.TraversalNode{
+								Name: backing.Name, Kind: backing.Kind, Repo: backing.Repo,
+								File: backing.File, Line: backing.Line,
+							}),
+							Name: backing.Name, Label: backing.Name, Kind: backing.Kind,
+							Repo: backing.Repo, File: backing.File, Line: backing.Line, Count: 1,
+						}
+					} else {
+						target = graphNode{
+							ID: "focused-node-" + shortHash(source.Repo + "\x00" + rel.Target),
+							Name: rel.Target, Label: rel.Target, Kind: "unresolved",
+							Repo: source.Repo, Count: 1, Unresolved: true,
+						}
+					}
+					if maxNodes > 0 && len(nodeByName) >= maxNodes {
+						continue
+					}
+					nodeByName[rel.Target] = target
+				}
+				key := source.ID + "\x00" + rel.Kind + "\x00" + target.ID
+				edge := edgeByKey[key]
+				if edge.ID == "" {
+					edge = graphEdge{
+						ID: "focused-edge-" + shortHash(key),
+						Source: source.ID, Target: target.ID, Kind: rel.Kind, Count: 0,
+					}
+				}
+				edge.Count++
+				edgeByKey[key] = edge
+			}
+		}
+	}
+}
+
+func chooseFocusedFact(candidates []facts.Fact, preferred string) *facts.Fact {
+	for i := range candidates {
+		if candidates[i].Kind == preferred {
+			return &candidates[i]
+		}
+	}
+	return nil
+}
+
+func resolveFocus(store *facts.Store, name, kind, repo string) string {
+	for _, f := range store.LookupByExactName(name) {
+		if (kind == "" || f.Kind == kind) && (repo == "" || f.Repo == repo) {
+			return f.Name
+		}
+	}
+	return ""
+}
+
+func focusedNodeKinds() []string {
+	return []string{facts.KindModule, facts.KindService, facts.KindSymbol, facts.KindRoute, facts.KindStorage}
+}
+
+func focusedNodeID(n facts.TraversalNode) string {
+	return "focused-node-" + shortHash(n.Repo+"\x00"+n.Kind+"\x00"+n.Name+"\x00"+n.File+"\x00"+strconv.Itoa(n.Line))
+}
+
+func overviewGraph(store *facts.Store, all []facts.Fact, byName map[string][]int) ([]graphNode, []graphEdge) {
+	buckets := make([]string, len(all))
+	nodes := map[string]graphNode{}
+	for i, f := range all {
+		bucket, kind, name := overviewBucket(f, all)
+		if bucket == "" {
+			continue
+		}
+		buckets[i] = bucket
+		if _, exists := nodes[bucket]; !exists {
+			nodes[bucket] = graphNode{
+				ID: "overview-" + shortHash(bucket), Name: name, Label: name,
+				Kind: kind, Repo: f.Repo, Count: 0,
+			}
+		}
+		nodes[bucket] = incrementOverviewNode(nodes[bucket])
+	}
+
+	edges := map[string]graphEdge{}
+	bucketsByName := map[string]map[string]bool{}
+	for i, f := range all {
+		if buckets[i] != "" {
+			if bucketsByName[f.Name] == nil {
+				bucketsByName[f.Name] = map[string]bool{}
+			}
+			bucketsByName[f.Name][buckets[i]] = true
+		}
+	}
+	if store != nil && store.Graph() != nil {
+		// Use the graph index rather than only raw fact relations. The index
+		// includes normalized cross-repo calls and synthetic edges, so calls
+		// from hidden members still roll up to their containing modules.
+		for source, relations := range store.Graph().Forward() {
+			for _, rel := range relations {
+				for sourceBucket := range bucketsByName[source] {
+					for targetBucket := range bucketsByName[rel.Target] {
+						if sourceBucket == targetBucket {
+							continue
+						}
+						sourceID := nodes[sourceBucket].ID
+						targetID := nodes[targetBucket].ID
+						key := sourceID + "\x00" + rel.RelKind + "\x00" + targetID
+						edge := edges[key]
+						if edge.ID == "" {
+							edge = graphEdge{
+								ID: "overview-edge-" + shortHash(key), Source: sourceID,
+								Target: targetID, Kind: rel.RelKind, Count: 0, Aggregated: true,
+							}
+						}
+						edge.Count++
+						edges[key] = edge
+					}
+				}
+			}
+		}
+	} else {
+		// Store graphs are normally built before dashboard rendering. Keep a
+		// direct-relation fallback for lightweight test fakes and empty stores.
+		for i, f := range all {
+			if buckets[i] == "" {
+				continue
+			}
+			for _, rel := range f.Relations {
+				target := chooseFact(byName[rel.Target], all, relationTargetKind(rel.Kind))
+				if target < 0 || buckets[target] == "" || buckets[target] == buckets[i] {
+					continue
+				}
+				sourceID := nodes[buckets[i]].ID
+				targetID := nodes[buckets[target]].ID
+				key := sourceID + "\x00" + rel.Kind + "\x00" + targetID
+				edge := edges[key]
+				if edge.ID == "" {
+					edge = graphEdge{
+						ID: "overview-edge-" + shortHash(key), Source: sourceID,
+						Target: targetID, Kind: rel.Kind, Count: 0, Aggregated: true,
+					}
+				}
+				edge.Count++
+				edges[key] = edge
+			}
+		}
+	}
+	nodeList := make([]graphNode, 0, len(nodes))
+	for _, n := range nodes {
+		n.Label = n.Name + " (" + strconv.Itoa(n.Count) + ")"
+		nodeList = append(nodeList, n)
+	}
+	sort.Slice(nodeList, func(i, j int) bool { return nodeList[i].ID < nodeList[j].ID })
+	edgeList := make([]graphEdge, 0, len(edges))
+	for _, e := range edges {
+		edgeList = append(edgeList, e)
+	}
+	sort.Slice(edgeList, func(i, j int) bool { return edgeList[i].ID < edgeList[j].ID })
+	return nodeList, edgeList
+}
+
+func orderedNodeKinds(kinds map[string]bool) []string {
+	preferred := []string{"module", "symbol", "dependency", "file_ref"}
+	ordered := make([]string, 0, len(kinds))
+	seen := make(map[string]bool, len(preferred))
+	for _, kind := range preferred {
+		if kinds[kind] {
+			ordered = append(ordered, kind)
+			seen[kind] = true
+		}
+	}
+	remaining := make(map[string]bool)
+	for kind := range kinds {
+		if !seen[kind] {
+			remaining[kind] = true
+		}
+	}
+	return append(ordered, sortedKeys(remaining)...)
+}
+
+func incrementOverviewNode(node graphNode) graphNode {
+	node.Count++
+	return node
+}
+
+func overviewBucket(f facts.Fact, all []facts.Fact) (bucket, kind, name string) {
+	if f.Kind == facts.KindService {
+		return "service\x00" + f.Repo + "\x00" + f.Name, facts.KindService, f.Name
+	}
+	if f.Kind == facts.KindModule {
+		return "module\x00" + f.Repo + "\x00" + f.Name, facts.KindModule, f.Name
+	}
+	if f.File != "" {
+		// Extractors are not uniform about whether repository names are part of
+		// fact paths. Try the original path first because Python package/module
+		// facts commonly retain the repository prefix (for example
+		// "api/domain/booking"), then try the repo-relative path used by other
+		// extractors.
+		files := []string{f.File}
+		if relative := strings.TrimPrefix(f.File, f.Repo+"/"); relative != f.File {
+			files = append(files, relative)
+		}
+		for _, file := range files {
+			dir := path.Dir(file)
+			for {
+				for _, candidate := range all {
+					if candidate.Kind == facts.KindModule && candidate.Repo == f.Repo && candidate.Name == dir {
+						return "module\x00" + f.Repo + "\x00" + candidate.Name, facts.KindModule, candidate.Name
+					}
+				}
+				parent := path.Dir(dir)
+				if parent == dir || dir == "." {
+					break
+				}
+				dir = parent
+			}
+		}
+	}
+	if f.Repo != "" {
+		return "service\x00" + f.Repo, facts.KindService, f.Repo
+	}
+	return "", "", ""
+}
+
+func relationTargetKind(kind string) string {
+	switch kind {
+	case facts.RelDependsOn:
+		return facts.KindService
+	case facts.RelImports:
+		return facts.KindModule
+	case facts.RelHandledBy:
+		return facts.KindRoute
+	default:
+		return facts.KindSymbol
+	}
+}
+
+func chooseFact(indices []int, all []facts.Fact, preferred string) int {
+	if len(indices) == 0 {
+		return -1
+	}
+	for _, i := range indices {
+		if all[i].Kind == preferred {
+			return i
+		}
+	}
+	return indices[0]
+}
+
+func conflatedKinds(indices []int, all []facts.Fact) []string {
+	kinds := map[string]bool{}
+	for _, i := range indices {
+		kinds[all[i].Kind] = true
+	}
+	if len(kinds) < 2 {
+		return nil
+	}
+	return sortedKeys(kinds)
+}
+
+func factID(f facts.Fact, index int) string {
+	key := f.Repo + "\x00" + f.Kind + "\x00" + f.Name + "\x00" + f.File + "\x00" + strconv.Itoa(f.Line) + "\x00" + strconv.Itoa(index)
+	return "node-" + shortHash(key)
+}
+
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (v graphView) JSON() string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+func (v graphView) BootstrapJSON() string {
+	b, err := json.Marshal(graphBootstrap{
+		SnapshotID: v.SnapshotID, OverviewNodes: v.OverviewNodes,
+		OverviewEdges: v.OverviewEdges, NodeKinds: v.NodeKinds,
+		EdgeKinds: v.EdgeKinds, FactCount: v.FactCount,
+		EdgeCount: v.EdgeCount, Unresolved: v.Unresolved,
+	})
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}

--- a/pkg/dashboard/graphview_test.go
+++ b/pkg/dashboard/graphview_test.go
@@ -1,0 +1,267 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+func TestBuildGraphViewPreservesTypedDuplicateNamesAndUnresolvedTargets(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{
+			Kind: facts.KindModule, Name: "pkg", Repo: "repo",
+			File: "repo/pkg/types.go", Relations: []facts.Relation{
+				{Kind: facts.RelImports, Target: "missing/module"},
+				{Kind: facts.RelDeclares, Target: "pkg.Foo"},
+			},
+		},
+		facts.Fact{Kind: facts.KindSymbol, Name: "pkg.Foo", Repo: "repo", File: "repo/pkg/types.go", Line: 4},
+		facts.Fact{Kind: facts.KindModule, Name: "pkg.Foo", Repo: "repo", File: "repo/pkg/Foo"},
+	)
+
+	view := buildGraphView(store, "snap-1")
+	if view == nil {
+		t.Fatal("buildGraphView returned nil")
+	}
+	if view.SnapshotID != "snap-1" || view.FactCount != 3 {
+		t.Fatalf("metadata = %+v, want snapshot snap-1 and three facts", view)
+	}
+	if len(view.Nodes) != 4 {
+		t.Fatalf("nodes = %d, want three facts plus one unresolved target", len(view.Nodes))
+	}
+	if view.Unresolved != 1 {
+		t.Errorf("unresolved = %d, want 1", view.Unresolved)
+	}
+	seenIDs := map[string]bool{}
+	for _, node := range view.Nodes {
+		if seenIDs[node.ID] {
+			t.Fatalf("duplicate node ID %q", node.ID)
+		}
+		seenIDs[node.ID] = true
+	}
+	if len(view.Edges) != 2 {
+		t.Fatalf("edges = %d, want 2", len(view.Edges))
+	}
+	if got := view.JSON(); got == "{}" {
+		t.Fatal("JSON serialization returned fallback object")
+	} else {
+		var decoded graphView
+		if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+			t.Fatalf("JSON is invalid: %v", err)
+		}
+	}
+	bootstrap := view.BootstrapJSON()
+	if strings.Contains(bootstrap, `"nodes":[`) || !strings.Contains(bootstrap, `"overview_nodes"`) {
+		t.Fatalf("bootstrap payload should contain overview data without full nodes: %s", bootstrap)
+	}
+}
+
+func TestBuildGraphViewOverviewAggregatesModuleRelations(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "a", Repo: "repo", File: "a"},
+		facts.Fact{
+			Kind: facts.KindModule, Name: "b", Repo: "repo", File: "b",
+			Relations: []facts.Relation{
+				{Kind: facts.RelImports, Target: "a"},
+				{Kind: facts.RelImports, Target: "a"},
+			},
+		},
+	)
+
+	view := buildGraphView(store, "")
+	if len(view.OverviewNodes) != 2 {
+		t.Fatalf("overview nodes = %d, want 2", len(view.OverviewNodes))
+	}
+	if len(view.OverviewEdges) != 1 {
+		t.Fatalf("overview edges = %d, want one aggregated edge", len(view.OverviewEdges))
+	}
+	if !view.OverviewEdges[0].Aggregated {
+		t.Error("overview edge is not marked aggregated")
+	}
+	if view.OverviewEdges[0].Count != 2 {
+		t.Errorf("overview edge count = %d, want 2", view.OverviewEdges[0].Count)
+	}
+	for _, node := range view.OverviewNodes {
+		if node.Count != 1 || node.Label != node.Name+" (1)" {
+			t.Errorf("overview node = %+v, want count 1 and counted label", node)
+		}
+	}
+}
+
+func TestBuildFocusedGraphIsBounded(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "a", Repo: "repo", File: "a", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "b"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "b", Repo: "repo", File: "b", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "c"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "c", Repo: "repo", File: "c"},
+	)
+	store.BuildGraph()
+
+	view := buildFocusedGraph(store, "snap", "b", facts.KindModule, "repo", "both", 1, 10)
+	if view.SnapshotID != "snap" || view.Scope != "symbols" {
+		t.Fatalf("focused metadata = %+v", view)
+	}
+	if len(view.Nodes) != 3 {
+		t.Fatalf("focused nodes = %d, want focus plus two neighbors", len(view.Nodes))
+	}
+	if len(view.Edges) != 2 {
+		t.Fatalf("focused edges = %d, want two", len(view.Edges))
+	}
+	for _, node := range view.Nodes {
+		if node.ID == "" || node.Label == "" {
+			t.Errorf("focused node lacks browser identity or label: %+v", node)
+		}
+	}
+}
+
+func TestBuildFocusedGraphIncludesDirectImplements(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "api/domain/fulfilment", Repo: "api", File: "api/domain/fulfilment"},
+		facts.Fact{
+			Kind: facts.KindSymbol, Name: "api/domain/fulfilment/notions.Fulfilment",
+			Repo: "api", File: "api/domain/fulfilment/notions.py",
+			Relations: []facts.Relation{
+				{Kind: facts.RelDeclares, Target: "api/domain/fulfilment"},
+				{Kind: facts.RelImplements, Target: "api/infra/db/model.Model"},
+				{Kind: facts.RelImplements, Target: "api/domain/fulfilment/notions.RawFulfilment"},
+				{Kind: facts.RelImplements, Target: "api/infra/state_machine.StateMachine"},
+			},
+		},
+		facts.Fact{Kind: facts.KindSymbol, Name: "api/domain/fulfilment/notions.RawFulfilment", Repo: "api", File: "api/domain/fulfilment/notions.py"},
+		facts.Fact{Kind: facts.KindSymbol, Name: "api/infra/db/model.Model", Repo: "api", File: "api/infra/db/model.py"},
+		facts.Fact{Kind: facts.KindSymbol, Name: "api/infra/state_machine.StateMachine", Repo: "api", File: "api/infra/state_machine.py"},
+	)
+	store.BuildGraph()
+
+	view := buildFocusedGraph(store, "snap", "api/domain/fulfilment", facts.KindModule, "api", "both", 1, 150)
+	implements := map[string]bool{}
+	for _, edge := range view.Edges {
+		if edge.Kind != facts.RelImplements {
+			continue
+		}
+		for _, node := range view.Nodes {
+			if node.ID == edge.Target {
+				implements[node.Name] = true
+			}
+		}
+	}
+	for _, want := range []string{
+		"api/infra/db/model.Model",
+		"api/domain/fulfilment/notions.RawFulfilment",
+		"api/infra/state_machine.StateMachine",
+	} {
+		if !implements[want] {
+			t.Errorf("focused graph missing implements target %q", want)
+		}
+	}
+}
+
+func TestBuildGraphViewRollsUpMemberCalls(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "a", Repo: "repo", File: "a"},
+		facts.Fact{
+			Kind: facts.KindSymbol, Name: "a.Foo", Repo: "repo", File: "a/foo.go",
+			Relations: []facts.Relation{{Kind: facts.RelCalls, Target: "b.Bar"}},
+		},
+		facts.Fact{Kind: facts.KindModule, Name: "b", Repo: "repo", File: "b"},
+		facts.Fact{Kind: facts.KindSymbol, Name: "b.Bar", Repo: "repo", File: "b/bar.go"},
+	)
+	store.BuildGraph()
+
+	view := buildGraphView(store, "snap")
+	var calls *graphEdge
+	for i := range view.OverviewEdges {
+		if view.OverviewEdges[i].Kind == facts.RelCalls {
+			calls = &view.OverviewEdges[i]
+			break
+		}
+	}
+	if calls == nil {
+		t.Fatal("module overview has no aggregated calls edge")
+	}
+	if calls.Count != 1 {
+		t.Errorf("aggregated calls count = %d, want 1", calls.Count)
+	}
+}
+
+func TestBuildGraphViewRollsUpPrefixedPythonMemberCalls(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "api/domain/source", Repo: "api", File: "api/domain/source"},
+		facts.Fact{Kind: facts.KindModule, Name: "api/domain/target", Repo: "api", File: "api/domain/target"},
+		facts.Fact{
+			Kind: facts.KindSymbol, Name: "api/domain/source.run", Repo: "api",
+			File:      "api/domain/source/run.py",
+			Relations: []facts.Relation{{Kind: facts.RelCalls, Target: "api/domain/target.handle"}},
+		},
+		facts.Fact{
+			Kind: facts.KindSymbol, Name: "api/domain/target.handle", Repo: "api",
+			File: "api/domain/target/handle.py",
+		},
+	)
+	store.BuildGraph()
+
+	view := buildGraphView(store, "snap")
+	for _, edge := range view.OverviewEdges {
+		if edge.Kind == facts.RelCalls {
+			return
+		}
+	}
+	t.Fatal("module overview has no calls edge for repo-prefixed Python facts")
+}
+
+func BenchmarkBuildFocusedGraph(b *testing.B) {
+	store := facts.NewStore()
+	for i := 0; i < 1000; i++ {
+		name := fmt.Sprintf("module/%04d", i)
+		var relations []facts.Relation
+		if i > 0 {
+			relations = []facts.Relation{{Kind: facts.RelImports, Target: fmt.Sprintf("module/%04d", i-1)}}
+		}
+		store.Add(facts.Fact{Kind: facts.KindModule, Name: name, Repo: "repo", File: name, Relations: relations})
+	}
+	store.BuildGraph()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = buildFocusedGraph(store, "benchmark", "module/0500", facts.KindModule, "repo", "both", 1, 150)
+	}
+}
+
+func TestHandlerRendersInteractiveGraphPayload(t *testing.T) {
+	isolateHome(t)
+	store := facts.NewStore()
+	store.Add(facts.Fact{
+		Kind: facts.KindModule, Name: "pkg", Repo: "repo", File: "pkg",
+		Relations: []facts.Relation{{Kind: facts.RelImports, Target: "missing"}},
+	})
+	s := newTestServer(7171, fakeArtifacts{
+		store: store,
+		graph: &facts.GraphReceipt{SnapshotID: "graph-snap"},
+	})
+
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		`id="graph-data"`,
+		`Open graph viewer`,
+		`graph-snap`,
+		`"fact_count":1`,
+		`cytoscape@3.31.2`,
+		`data-graph-node="module"`,
+		`data-graph-edge="imports"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -85,6 +85,54 @@
     .edge-graph #edge-arrow path { fill: var(--muted); }
     .edge-graph .node circle { fill: var(--accent); }
     .edge-graph .node text { fill: var(--fg); font-size: 12px; dominant-baseline: middle; }
+    .graph-modal { padding: 0; }
+    .graph-modal .modal-panel {
+      width: 100vw; height: 100vh; max-width: none; max-height: none;
+      border-radius: 0; display: flex; flex-direction: column;
+    }
+    .graph-snapshot-hash { color: var(--muted); font-size: .72em; font-weight: 400; }
+    .graph-repo-title { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .graph-view-page .wrap { display: none; }
+    .graph-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: .55rem; margin-bottom: .65rem; }
+    .graph-toolbar button { font: inherit; color: var(--fg); background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: .25rem .5rem; cursor: pointer; }
+    .graph-toolbar button:hover { border-color: var(--muted); }
+    .graph-filters { display: flex; flex-wrap: wrap; gap: .45rem .75rem; color: var(--muted); font-size: .82rem; }
+    .graph-filters label { white-space: nowrap; }
+    .graph-layout { min-height: 0; flex: 1 1 auto; display: grid; grid-template-columns: minmax(0, 1fr) 250px; gap: .75rem; }
+    #graph-canvas { position: relative; min-height: 480px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); }
+    .graph-loading { position: absolute; inset: 0; z-index: 10; display: flex; align-items: center; justify-content: center; background: rgba(255,255,255,.68); pointer-events: none; }
+    .graph-loading[hidden] { display: none; }
+    .graph-spinner { width: 2rem; height: 2rem; border: 3px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: graph-spin .75s linear infinite; }
+    @keyframes graph-spin { to { transform: rotate(360deg); } }
+    .graph-side { min-width: 0; overflow: auto; }
+    .graph-search { margin-bottom: 1rem; }
+    .graph-search > button { margin-bottom: .4rem; }
+    .graph-search-hint { margin-left: .35rem; color: var(--muted); font-size: .82rem; }
+    .graph-search-row { display: flex; gap: .35rem; }
+    .graph-search input {
+      min-width: 0; width: 100%; font: inherit; color: var(--fg);
+      background: var(--card); border: 1px solid var(--border); border-radius: 6px;
+      padding: .3rem .4rem;
+    }
+    .graph-search button {
+      font: inherit; color: #fff; background: var(--accent);
+      border: 1px solid var(--border); border-radius: 6px; padding: .3rem .45rem;
+      cursor: pointer;
+    }
+    .graph-search button:hover { border-color: var(--muted); }
+    .graph-side h4 { margin: 0 0 .35rem; font-size: .88rem; }
+    .graph-selection-heading { display: flex; align-items: center; justify-content: space-between; gap: .5rem; margin-bottom: .45rem; }
+    .graph-selection-heading h4 { margin: 0; }
+    .graph-selection-hint { color: var(--muted); font-size: .75rem; }
+    .graph-selection-list { display: flex; flex-direction: column; gap: .45rem; margin: 0 0 .45rem; }
+    .graph-selection-item { position: relative; border: 1px solid var(--border); border-radius: 6px; padding: .45rem .6rem; font-size: .82rem; }
+    .graph-selection-meta { min-width: 0; padding-right: 1.25rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    .graph-selection-key { font-weight: 700; }
+    .graph-selection-remove { position: absolute; top: .25rem; right: .35rem; border: 0; padding: 0 .2rem; background: none; color: var(--muted); cursor: pointer; font-size: 1rem; line-height: 1; }
+    .graph-selection-remove:hover { color: var(--fg); }
+    .graph-unselect-all { font-size: .75rem; color: var(--muted); white-space: nowrap; }
+    .graph-side pre { white-space: pre-wrap; overflow-wrap: anywhere; font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--muted); margin: 0; }
+    @media (max-width: 760px) { .graph-layout { grid-template-columns: 1fr; } .graph-side { max-height: 180px; } }
     .insight-summary { color: var(--muted); font-size: .85rem; margin: -.25rem 0 .6rem; }
     .insight-filter { display: flex; align-items: center; gap: .5rem; margin: 0 0 .9rem; font-size: .85rem; }
     .insight-filter label { color: var(--muted); }
@@ -113,7 +161,7 @@
     {{block "extra-styles" $}}{{end}}
   </style>
 </head>
-<body>
+<body{{if .ViewOnly}} class="graph-view-page"{{end}}>
 <div class="wrap">
   <header>
     <h1>{{.Title}}</h1>
@@ -123,6 +171,13 @@
 
   <h2>This server</h2>
   <p class="note">Everything on this page describes this one process and the graph it holds. Other servers are listed below.</p>
+  {{if $.GraphView}}
+  <div class="card" style="margin:.75rem 0">
+    <div class="k">Interactive graph</div>
+    <div class="v"><a href="/view">Open graph viewer</a></div>
+    <div class="note" style="margin-top:.25rem">{{$.GraphView.FactCount}} facts · {{$.GraphView.EdgeCount}} edges · {{$.GraphView.Unresolved}} unresolved targets</div>
+  </div>
+  {{end}}
   <div class="grid">
     <div class="card"><div class="k">Process</div><div class="v">PID {{.PID}}</div></div>
     {{if .Binary}}<div class="card"><div class="k">Binary</div><div class="v">{{.Binary}}</div></div>{{end}}
@@ -229,6 +284,13 @@
     </tbody>
   </table></div>
   {{end}}
+  {{if $.GraphView}}
+  <div class="card" style="margin-top:.75rem">
+    <div class="k">Interactive graph</div>
+    <div class="v"><a href="/view">Open graph viewer</a></div>
+    <div class="note" style="margin-top:.25rem">{{$.GraphView.FactCount}} facts · {{$.GraphView.EdgeCount}} edges · {{$.GraphView.Unresolved}} unresolved targets</div>
+  </div>
+  {{end}}
   {{end}}{{else}}<p class="note">{{.GraphNote}}</p>{{end}}
 
   <footer>{{.Title}} dashboard · read-only · localhost only</footer>
@@ -247,6 +309,58 @@
         {{range .Services}}<tr><td>{{.Name}}</td><td class="num">{{.DependsOn}}</td></tr>{{end}}
       </tbody>
     </table></div>
+  </div>
+</div>
+{{end}}
+
+{{if .GraphView}}
+<script type="application/json" id="graph-data">{{.GraphJSON}}</script>
+<script src="https://unpkg.com/cytoscape@3.31.2/dist/cytoscape.min.js"></script>
+<script src="https://unpkg.com/layout-base@2.0.1/layout-base.js"></script>
+<script src="https://unpkg.com/cose-base@2.2.0/cose-base.js"></script>
+<script src="https://unpkg.com/cytoscape-fcose@2.2.0/cytoscape-fcose.js"></script>
+<div class="modal graph-modal{{if .ViewOnly}} open{{end}}" id="graph-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel" role="dialog" aria-modal="true" aria-label="Interactive graph">
+    <div class="modal-head">
+      <h3>Graph View <span class="graph-repo-title">{{.ReposLoaded}}</span> <span class="graph-snapshot-hash">({{.GraphView.SnapshotID}})</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="graph-filters">
+      <strong>Nodes:</strong>
+      {{range .GraphView.NodeKinds}}<label><input type="checkbox" {{if eq . "module"}}checked{{end}} data-graph-node="{{.}}" onchange="graphFilterGraph()"> {{.}}</label>{{end}}
+    </div>
+    <div class="graph-filters">
+      <strong>Edges:</strong>
+      {{range .GraphView.EdgeKinds}}<label><input type="checkbox" checked data-graph-edge="{{.}}" onchange="graphFilterGraph()"> {{.}}</label>{{end}}
+    </div>
+    {{if eq .GraphView.FactCount 0}}<p class="note">This snapshot contains no facts to visualize. The graph receipt and table views remain available.</p>{{end}}
+    <div class="graph-layout">
+      <div id="graph-canvas" role="img" aria-label="Interactive architecture graph">
+        <div id="graph-loading" class="graph-loading" hidden aria-label="Loading graph"><div class="graph-spinner"></div></div>
+      </div>
+      <aside class="graph-side">
+        <div class="graph-search">
+          <button type="button" onclick="graphGoToSearch()">Select Node</button><span class="graph-search-hint">or click a Node</span>
+          <div class="graph-search-row">
+            <input id="graph-search-input" type="search" list="graph-search-suggestions"
+              placeholder="Search nodes…" autocomplete="off"
+              oninput="graphSearchNodes(this.value)"
+              onchange="graphGoToSearch()"
+              onkeydown="if(event.key==='Enter'){event.preventDefault();graphGoToSearch()}">
+          </div>
+          <datalist id="graph-search-suggestions"></datalist>
+        </div>
+        <div id="graph-selection-section" hidden>
+          <div id="graph-selection-heading" class="graph-selection-heading">
+            <h4>Selection</h4>
+            <span class="graph-selection-hint">Shift+Click to Select Multiple Nodes</span>
+            <label id="graph-unselect-all-control" class="graph-unselect-all"><input type="checkbox" id="graph-unselect-all" onchange="if(this.checked) graphClearSelection()"> Unselect all</label>
+          </div>
+          <div id="graph-selection-list" class="graph-selection-list"></div>
+          <pre id="graph-detail">Select a node or edge to inspect its source metadata.</pre>
+        </div>
+      </aside>
+    </div>
   </div>
 </div>
 {{end}}
@@ -409,10 +523,942 @@
     if (!m) return;
     stopRefresh();
     m.classList.add('open');
+    if (id === 'graph-modal') initGraph();
     if (id === 'insights-modal') {
       var sel = document.getElementById('insight-band');
       if (sel) { sel.value = 'all'; filterInsights('all'); } // reopen starts unfiltered
     }
+  }
+
+  var graphPayload = null;
+  var graphCy = null;
+  var graphLevel = 'overview';
+  var graphZoomChanging = false;
+  var graphScopes = {};
+  var graphRequest = null;
+  var graphRequestGeneration = 0;
+  var graphZoomCenter = null;
+  var graphTransition = null;
+  var graphScopeHasMore = false;
+  var graphBaseline = null;
+  var graphViewportRequestTimer = null;
+  var graphZoomGesture = false;
+  var graphZoomGestureTimer = null;
+  var graphSelection = [];
+  var graphSelectionEnabledSymbol = false;
+  var graphSearchTimer = null;
+  var graphSearchRequest = null;
+  var graphSearchResults = {};
+  function graphData() {
+    if (!graphPayload) {
+      var script = document.getElementById('graph-data');
+      if (script) graphPayload = JSON.parse(script.textContent || '{}');
+    }
+    return graphPayload || {};
+  }
+  function graphSetLoading(loading) {
+    var overlay = document.getElementById('graph-loading');
+    if (overlay) overlay.hidden = !loading;
+  }
+  function graphSearchNodes(query) {
+    if (graphSearchTimer) clearTimeout(graphSearchTimer);
+    if (graphSearchRequest) graphSearchRequest.abort();
+    graphSearchResults = {};
+    var list = document.getElementById('graph-search-suggestions');
+    if (list) list.replaceChildren();
+    query = String(query || '').trim();
+    if (query.length < 2) return;
+    graphSearchTimer = setTimeout(function () {
+      graphSearchRequest = new AbortController();
+      fetch('/api/graph/search?q=' + encodeURIComponent(query), { signal: graphSearchRequest.signal })
+        .then(function (response) {
+          if (!response.ok) throw new Error('node search failed (' + response.status + ')');
+          return response.json();
+        })
+        .then(function (results) {
+          graphSearchResults = {};
+          if (!list) return;
+          list.replaceChildren();
+          (results || []).forEach(function (result) {
+            graphSearchResults[result.name] = result;
+            var option = document.createElement('option');
+            option.value = result.name;
+            option.label = result.kind + (result.repo ? ' · ' + result.repo : '');
+            list.appendChild(option);
+          });
+        })
+        .catch(function (error) {
+          if (error.name !== 'AbortError') {
+            var detail = document.getElementById('graph-detail');
+            if (detail) detail.textContent = error.message;
+          }
+        });
+    }, 150);
+  }
+  function graphSyncSelectionStyles() {
+    if (!graphCy) return;
+    graphCy.nodes().unselect();
+    graphCy.nodes().forEach(function (node) {
+      var selected = graphSelection.some(function (item) {
+        return item.name === node.data('name') && item.repo === node.data('repo');
+      });
+      if (selected) node.addClass('graph-selected');
+      else node.removeClass('graph-selected');
+    });
+  }
+  function graphSelectNode(node, append) {
+    if (!graphCy || !node) return;
+    var data = node.data();
+    var item = {
+      name: data.name, repo: data.repo, kind: data.kind, file: data.file,
+      line: data.line, unresolved: data.unresolved, conflated: data.conflated,
+      aggregated: data.aggregated
+    };
+    if (!append) {
+      graphCy.nodes().unselect();
+      graphSelection = [];
+    }
+    var existingIndex = graphSelection.findIndex(function (selected) {
+      return selected.name === item.name && selected.repo === item.repo;
+    });
+    if (existingIndex >= 0) graphSelection[existingIndex] = item;
+    else graphSelection.push(item);
+    if (node.data('kind') === 'module') {
+      var symbolCheckbox = document.querySelector('[data-graph-node="symbol"]');
+      graphSelectionEnabledSymbol = graphSelectionEnabledSymbol ||
+        (!!symbolCheckbox && !symbolCheckbox.checked);
+      graphEnableNodeKind('symbol');
+    }
+    graphRenderSelectionPanel();
+    graphSyncSelectionStyles();
+    graphFilterGraph();
+    graphShowDetail(node.data(), 'node');
+  }
+  function graphRenderSelectionPanel() {
+    var list = document.getElementById('graph-selection-list');
+    if (list) {
+      list.replaceChildren();
+      graphSelection.forEach(function (item, index) {
+        var row = document.createElement('div');
+        row.className = 'graph-selection-item';
+        var label = document.createElement('div');
+        label.className = 'graph-selection-meta';
+        var fields = [
+          ['name', item.name || ''],
+          ['kind', item.kind || ''],
+          item.repo ? ['repository', item.repo] : null,
+          item.file ? ['source', item.file + (item.line ? ':' + item.line : '')] : null,
+          item.unresolved ? ['status', 'unresolved target'] : null,
+          item.conflated && item.conflated.length ? ['also represents', item.conflated.join(', ')] : null,
+          item.aggregated ? ['scope', 'aggregated module overview'] : null
+        ].filter(function (field) { return field; });
+        fields.forEach(function (field, fieldIndex) {
+          if (fieldIndex > 0) label.appendChild(document.createElement('br'));
+          var key = document.createElement('span');
+          key.className = 'graph-selection-key';
+          key.textContent = field[0] + ': ';
+          label.appendChild(key);
+          label.appendChild(document.createTextNode(field[1]));
+        });
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'graph-selection-remove';
+        remove.textContent = '×';
+        remove.setAttribute('aria-label', 'Unselect ' + item.name);
+        remove.addEventListener('click', function () { graphRemoveSelection(index); });
+        row.appendChild(remove);
+        row.appendChild(label);
+        list.appendChild(row);
+      });
+    }
+    var all = document.getElementById('graph-unselect-all');
+    if (all) all.checked = false;
+    var allControl = document.getElementById('graph-unselect-all-control');
+    if (allControl) allControl.hidden = graphSelection.length < 2;
+    var section = document.getElementById('graph-selection-section');
+    if (section) section.hidden = graphSelection.length === 0;
+    var heading = document.getElementById('graph-selection-heading');
+    if (heading) heading.hidden = false;
+  }
+  function graphRemoveSelection(index) {
+    if (index < 0 || index >= graphSelection.length) return;
+    var item = graphSelection[index];
+    graphSelection.splice(index, 1);
+    graphSyncSelectionStyles();
+    if (graphSelection.length === 0) {
+      graphClearSelection();
+      return;
+    }
+    graphRenderSelectionPanel();
+    graphFilterGraph();
+  }
+  function graphFocusLoadedNode(item, activate) {
+    if (!graphCy || !item) return false;
+    var matches = graphCy.nodes().filter(function (node) {
+      return node.data('name') === item.name &&
+        (!item.repo || node.data('repo') === item.repo);
+    });
+    if (matches.length === 0) return false;
+    var node = matches[0];
+    graphSelectNode(node, true);
+    if (activate) {
+      if (node.data('kind') === 'module') {
+        graphZoomCenter = node.renderedPosition();
+        graphSearchLoad(node.data());
+      } else {
+        graphCy.animate({ center: { eles: node }, duration: 250 });
+      }
+      return true;
+    }
+    graphFilterGraph();
+    graphCy.animate({ center: { eles: node }, zoom: Math.max(graphCy.zoom(), 1.5), duration: 350 });
+    graphShowDetail(node.data(), 'node');
+    return true;
+  }
+  function graphSearchLoad(item, merge) {
+    if (!graphCy || !item) return;
+    var data = graphData();
+    var level = 'symbols';
+    var key = [data.snapshot_id, level, item.name, item.kind, item.repo || ''].join('|');
+    var finish = function (scope) {
+      graphSetLoading(false);
+      graphScopes[key] = scope;
+      graphPayload.nodes = graphMergeItems(
+        merge ? graphPayload.nodes : [],
+        graphAbbreviateMemberLabels(scope.nodes, item)
+      );
+      graphPayload.edges = graphMergeItems(merge ? graphPayload.edges : [], scope.edges);
+      graphRenderLevel(level, false);
+      graphFocusLoadedNode(item);
+    };
+    if (graphScopes[key]) {
+      finish(graphScopes[key]);
+      return;
+    }
+    var params = new URLSearchParams({
+      direction: 'both', depth: '1', max_nodes: '150',
+      focus: item.name, kind: item.kind || '', repo: item.repo || '',
+      snapshot_id: data.snapshot_id || ''
+    });
+    var mode = document.getElementById('graph-mode');
+    if (mode) mode.textContent = 'loading search result…';
+    graphSetLoading(true);
+    graphRequest = new AbortController();
+    fetch('/api/graph?' + params.toString(), { signal: graphRequest.signal })
+      .then(function (response) {
+        if (!response.ok) throw new Error('graph request failed (' + response.status + ')');
+        return response.json();
+      })
+      .then(finish)
+      .catch(function (error) {
+        if (error.name === 'AbortError') return;
+        graphSetLoading(false);
+        if (mode) mode.textContent = 'focused graph unavailable';
+        var detail = document.getElementById('graph-detail');
+        if (detail) detail.textContent = error.message;
+      });
+  }
+  function graphGoToSearch() {
+    var input = document.getElementById('graph-search-input');
+    if (!input) return;
+    var query = input.value.trim();
+    if (!query) return;
+    var item = graphSearchResults[query];
+    if (!item) {
+      var data = graphData();
+      var loaded = (data.overview_nodes || []).concat(data.nodes || []);
+      var match = loaded.find(function (node) { return node.name === query; });
+      if (match) item = match;
+    }
+    if (!item) {
+      fetch('/api/graph/search?q=' + encodeURIComponent(query))
+        .then(function (response) { return response.ok ? response.json() : []; })
+        .then(function (results) {
+          var exact = (results || []).find(function (result) { return result.name === query; });
+          if (exact) {
+            graphSearchResults[exact.name] = exact;
+            graphGoToSearch();
+          } else {
+            var detail = document.getElementById('graph-detail');
+            if (detail) detail.textContent = 'No node found for "' + query + '".';
+          }
+        });
+      return;
+    }
+    if (graphFocusLoadedNode(item, true)) return;
+    graphSearchLoad(item);
+  }
+  function graphElements(level) {
+    var data = graphData();
+    var nodes;
+    var edges;
+    if (level === 'overview') {
+      nodes = data.overview_nodes || [];
+      edges = data.overview_edges || [];
+    } else {
+      var allowed = {
+        symbols: { module: true, service: true, symbol: true, route: true, storage: true, unresolved: true },
+        all: null
+      }[level] || null;
+      nodes = (data.nodes || []).filter(function (n) { return !allowed || allowed[n.kind]; });
+      var nodeIDs = {};
+      nodes.forEach(function (n) { nodeIDs[n.id] = true; });
+      edges = (data.edges || []).filter(function (e) {
+        return nodeIDs[e.source] && nodeIDs[e.target];
+      });
+    }
+    return {
+      nodes: (nodes || []).map(function (n) { return { data: n }; }),
+      edges: (edges || []).map(function (e) { return { data: e }; })
+    };
+  }
+  function initGraph() {
+    if (typeof cytoscape === 'undefined') {
+      var detail = document.getElementById('graph-detail');
+      if (detail) detail.textContent = 'The graph library could not be loaded. Use the graph receipt tables instead.';
+      return;
+    }
+    if (graphCy) {
+      graphCy.resize();
+      if (graphLevel === 'symbols') graphCy.center();
+      else graphCy.fit();
+      return;
+    }
+    graphCy = cytoscape({
+      container: document.getElementById('graph-canvas'),
+      elements: graphElements('overview'),
+      wheelSensitivity: 0.2,
+      style: [
+        { selector: 'node', style: { 'background-color': '#2563eb', 'label': 'data(label)', 'color': '#1a1a1a', 'font-size': 9, 'text-wrap': 'wrap', 'text-max-width': 100, 'text-valign': 'bottom', 'text-margin-y': 4, 'width': 10, 'height': 10 } },
+        { selector: 'node[kind = "symbol"]', style: { 'background-color': '#8b5cf6' } },
+        { selector: 'node[kind = "route"]', style: { 'background-color': '#f59e0b' } },
+        { selector: 'node[kind = "storage"]', style: { 'background-color': '#10b981' } },
+        { selector: 'node[kind = "dependency"]', style: { 'background-color': '#64748b' } },
+        { selector: 'node[kind = "test_ref"]', style: { 'background-color': '#ec4899' } },
+        { selector: 'node[kind = "file_ref"]', style: { 'background-color': '#94a3b8' } },
+        { selector: 'node[kind = "unresolved"]', style: { 'background-color': '#b91c1c', 'border-width': 2, 'border-style': 'dashed' } },
+        { selector: 'edge', style: { 'curve-style': 'bezier', 'line-style': 'solid', 'target-arrow-shape': 'vee', 'arrow-scale': 0.7, 'line-color': '#94a3b8', 'target-arrow-color': '#94a3b8', 'width': 'mapData(count, 1, 50, 0.7, 2.5)', 'opacity': 0.75 } },
+        { selector: 'edge[kind = "calls"]', style: { 'line-color': '#8b5cf6', 'target-arrow-color': '#8b5cf6' } },
+        { selector: 'edge[kind = "imports"]', style: { 'line-color': '#2563eb', 'target-arrow-color': '#2563eb' } },
+        { selector: 'edge[kind = "depends_on"]', style: { 'line-color': '#f59e0b', 'target-arrow-color': '#f59e0b' } },
+        { selector: 'edge[kind = "implements"]', style: { 'line-color': '#10b981', 'target-arrow-color': '#10b981' } },
+        { selector: 'edge[kind = "declares"]', style: { 'line-color': '#64748b', 'target-arrow-color': '#64748b' } },
+        { selector: 'edge[kind = "instantiates"]', style: { 'line-color': '#ec4899', 'target-arrow-color': '#ec4899' } },
+        { selector: 'node.graph-selected', style: { 'border-width': 3, 'border-color': '#111827' } }
+      ],
+      layout: graphLayoutOptions('overview')
+    });
+    graphCy.on('tap', 'node', function (event) {
+      var node = event.target;
+      if (!node || typeof node.id !== 'function') return;
+      var shift = !!(event.originalEvent && event.originalEvent.shiftKey);
+      var selectionIndex = graphSelection.findIndex(function (selected) {
+        return selected.name === node.data('name') && selected.repo === node.data('repo');
+      });
+      if (selectionIndex >= 0) {
+        if (graphSelection.length === 1) {
+          graphClearSelection();
+        } else {
+          graphRemoveSelection(selectionIndex);
+        }
+        return;
+      }
+      graphSelectNode(node, shift);
+      if (node.data('kind') === 'module') {
+        graphZoomCenter = node.renderedPosition();
+        graphSearchLoad(node.data(), shift || graphSelection.length > 1);
+      }
+    });
+    graphCy.on('tap', 'edge', function (event) { graphShowDetail(event.target.data(), 'edge'); });
+    graphCy.container().addEventListener('wheel', function (event) {
+      var rect = graphCy.container().getBoundingClientRect();
+      graphZoomCenter = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    }, { passive: true });
+    graphAvoidLabelOverlaps();
+    graphCaptureBaseline();
+  }
+  function graphLayoutOptions(level) {
+    var dense = level === 'symbols';
+    var spacing = {
+      overview: { separation: 180, edgeLength: 260, repulsion: 12000 },
+      symbols:  { separation: 120, edgeLength: 180, repulsion: 14000 }
+    }[level] || { separation: 180, edgeLength: 260, repulsion: 12000 };
+    var fcoseAvailable = typeof cytoscape !== 'undefined' && cytoscape('layout', 'fcose');
+    if (fcoseAvailable) {
+      return {
+        name: 'fcose', quality: 'proof', animate: false, fit: !dense, padding: 100,
+        nodeSeparation: spacing.separation,
+        idealEdgeLength: function (edge) {
+          switch (edge.data('kind')) {
+            case 'declares': return 70;
+            case 'calls': return Math.min(170, spacing.edgeLength);
+            default: return spacing.edgeLength;
+          }
+        },
+        edgeElasticity: function (edge) {
+          switch (edge.data('kind')) {
+            case 'declares': return 0.95;
+            case 'calls': return 0.65;
+            default: return 0.35;
+          }
+        },
+        nodeRepulsion: spacing.repulsion,
+        numIter: 2500, tile: true, tilingPaddingVertical: 140,
+        tilingPaddingHorizontal: 140
+      };
+    }
+    return {
+      name: 'cose', animate: false, fit: !dense, padding: 100,
+      idealEdgeLength: spacing.edgeLength, nodeRepulsion: spacing.repulsion,
+      nodeOverlap: spacing.separation,
+      componentSpacing: 300, gravity: 0.1
+    };
+  }
+  function graphLabelBox(node) {
+    var label = node.data('label') || node.data('name') || '';
+    var lines = String(label).split('\n');
+    var longest = 0;
+    lines.forEach(function (line) { longest = Math.max(longest, line.length); });
+    var width = Math.min(150, Math.max(24, longest * 6));
+    var wrappedLines = Math.ceil(longest / 14);
+    var height = Math.max(16, Math.max(lines.length, wrappedLines) * 12 + 6);
+    var p = node.position();
+    return { left: p.x - width / 2, right: p.x + width / 2, top: p.y - 8, bottom: p.y + height };
+  }
+  function graphBoxesOverlap(a, b) {
+    return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+  }
+  function graphAvoidLabelOverlaps() {
+    if (!graphCy) return;
+    var nodes = graphCy.nodes().toArray();
+    if (nodes.length > 600) return;
+    for (var iteration = 0; iteration < 30; iteration++) {
+      var moved = false;
+      for (var i = 0; i < nodes.length; i++) {
+        for (var j = i + 1; j < nodes.length; j++) {
+          var a = graphLabelBox(nodes[i]);
+          var b = graphLabelBox(nodes[j]);
+          if (!graphBoxesOverlap(a, b)) continue;
+          var pa = nodes[i].position();
+          var pb = nodes[j].position();
+          var dx = pa.x - pb.x;
+          var dy = pa.y - pb.y;
+          var distance = Math.sqrt(dx * dx + dy * dy) || 1;
+          var push = 12 + Math.min(a.right, b.right) - Math.max(a.left, b.left);
+          nodes[i].position({
+            x: pa.x + dx / distance * push / 2,
+            y: pa.y + dy / distance * push / 2
+          });
+          nodes[j].position({
+            x: pb.x - dx / distance * push / 2,
+            y: pb.y - dy / distance * push / 2
+          });
+          moved = true;
+        }
+      }
+      if (!moved) break;
+    }
+  }
+  function graphHandleZoom() {
+    // Zoom changes the viewport only. Visibility is controlled by node
+    // checkboxes and the explicit selection filter.
+  }
+  function graphColorForEdgeKind(kind) {
+    switch (kind) {
+      case 'calls':      return '#8b5cf6';
+      case 'imports':    return '#2563eb';
+      case 'depends_on': return '#f59e0b';
+      case 'implements': return '#10b981';
+      case 'declares':   return '#64748b';
+      case 'instantiates': return '#ec4899';
+      default:           return '#94a3b8';
+    }
+  }
+  function graphColorForNodeKind(kind) {
+    switch (kind) {
+      case 'module':
+      case 'service':     return '#2563eb';
+      case 'symbol':      return '#8b5cf6';
+      case 'route':       return '#f59e0b';
+      case 'storage':     return '#10b981';
+      case 'dependency':  return '#64748b';
+      case 'test_ref':    return '#ec4899';
+      case 'file_ref':    return '#94a3b8';
+      case 'unresolved':  return '#b91c1c';
+      default:            return '#94a3b8';
+    }
+  }
+  function graphApplyCheckboxColors() {
+    document.querySelectorAll('[data-graph-edge]').forEach(function (checkbox) {
+      checkbox.style.accentColor = graphColorForEdgeKind(checkbox.getAttribute('data-graph-edge'));
+    });
+    document.querySelectorAll('[data-graph-node]').forEach(function (checkbox) {
+      checkbox.style.accentColor = graphColorForNodeKind(checkbox.getAttribute('data-graph-node'));
+    });
+  }
+  function graphShowDetail(item, type) {
+    var detail = document.getElementById('graph-detail');
+    if (!detail) return;
+    if (type === 'edge') {
+      detail.hidden = false;
+      var data = graphData();
+      var nodes = (data.nodes || []).concat(data.overview_nodes || []);
+      var endpoints = {};
+      nodes.forEach(function (n) { endpoints[n.id] = n; });
+      var source = endpoints[item.source];
+      var target = endpoints[item.target];
+      if (graphCy) {
+        source = (graphCy.getElementById(item.source).data() || source);
+        target = (graphCy.getElementById(item.target).data() || target);
+      }
+      source = source || { name: item.source, kind: 'unknown' };
+      target = target || { name: item.target, kind: 'unknown' };
+      detail.textContent = [
+        'kind: ' + item.kind,
+        'underlying edges: ' + (item.count || 1),
+        'source: ' + source.name,
+        'target: ' + target.name,
+        item.aggregated ? 'scope: aggregated module overview' : 'scope: direct fact relation'
+      ].join('\n');
+      return;
+    }
+    detail.hidden = true;
+    detail.textContent = [
+      'name: ' + (item.name || ''),
+      'kind: ' + (item.kind || ''),
+      item.repo ? 'repository: ' + item.repo : '',
+      item.file ? 'source: ' + item.file + (item.line ? ':' + item.line : '') : '',
+      item.unresolved ? 'status: unresolved target' : '',
+      item.conflated && item.conflated.length ? 'also represents: ' + item.conflated.join(', ') : '',
+      item.aggregated ? 'scope: aggregated module overview' : ''
+    ].filter(function (line) { return line; }).join('\n');
+  }
+  function graphRenderLevel(level, preserveViewport) {
+    if (!graphCy) return;
+    var viewport = preserveViewport ? { pan: graphCy.pan(), zoom: graphCy.zoom() } : null;
+    graphZoomChanging = true;
+    graphLevel = level;
+    graphCy.elements().remove();
+    graphCy.add(graphElements(level));
+    graphCy.layout(graphLayoutOptions(level)).run();
+    if (level === 'symbols') {
+      if (viewport) {
+        graphCy.zoom(viewport.zoom);
+        graphCy.pan(viewport.pan);
+      } else {
+        graphCy.center();
+      }
+    }
+    graphAvoidLabelOverlaps();
+    if (graphTransition) {
+      var transitionNode = graphCy.nodes().filter(function (node) {
+        return node.data('name') === graphTransition.name &&
+          (!graphTransition.repo || node.data('repo') === graphTransition.repo);
+      });
+      if (transitionNode.length > 0) {
+        var after = transitionNode[0].renderedPosition();
+        var desired = {
+          x: graphTransition.anchor.x + graphTransition.offset.x,
+          y: graphTransition.anchor.y + graphTransition.offset.y
+        };
+        var pan = graphCy.pan();
+        graphCy.pan({
+          x: pan.x + desired.x - after.x,
+          y: pan.y + desired.y - after.y
+        });
+      }
+      graphTransition = null;
+    }
+    var mode = document.getElementById('graph-mode');
+    var labels = {
+      overview: 'module overview',
+      symbols: 'modules, symbols & endpoints',
+      all: 'all facts'
+    };
+    if (mode) mode.textContent = labels[level] || level;
+    graphFilterGraph();
+    graphCaptureBaseline();
+    graphZoomChanging = false;
+  }
+  function graphCaptureBaseline() {
+    if (!graphCy) return;
+    var positions = {};
+    graphCy.nodes().forEach(function (node) {
+      positions[node.id()] = { x: node.position('x'), y: node.position('y') };
+    });
+    graphBaseline = { positions: positions, pan: graphCy.pan(), zoom: graphCy.zoom() };
+  }
+  function graphFocusForRequest() {
+    if (!graphCy) return null;
+    var selected = graphCy.nodes().filter(function (node) {
+      return graphSelection.some(function (item) {
+        return item.name === node.data('name') && item.repo === node.data('repo');
+      });
+    });
+    if (selected.length > 0) {
+      var selectedData = selected[0].data();
+      var selectedPoint = selected[0].renderedPosition();
+      var selectedAnchor = graphZoomCenter || selectedPoint;
+      graphTransition = {
+        name: selectedData.name, repo: selectedData.repo,
+        anchor: selectedAnchor,
+        offset: { x: selectedPoint.x - selectedAnchor.x, y: selectedPoint.y - selectedAnchor.y }
+      };
+      graphZoomCenter = null;
+      return selectedData;
+    }
+    var cursorAnchor = graphZoomCenter;
+    var closestNode = graphNearestNode(cursorAnchor);
+    graphZoomCenter = null;
+    if (closestNode) {
+      var closestPoint = closestNode.renderedPosition();
+      var closestAnchor = cursorAnchor || closestPoint;
+      graphTransition = {
+        name: closestNode.data('name'), repo: closestNode.data('repo'),
+        anchor: closestAnchor,
+        offset: { x: closestPoint.x - closestAnchor.x, y: closestPoint.y - closestAnchor.y }
+      };
+      return closestNode.data();
+    }
+    return null;
+  }
+  function graphNearestNode(center) {
+    if (!graphCy) return null;
+    center = center || { x: graphCy.width() / 2, y: graphCy.height() / 2 };
+    var closest = null;
+    var distance = Infinity;
+    graphCy.nodes().forEach(function (node) {
+      var p = node.renderedPosition();
+      var dx = p.x - center.x;
+      var dy = p.y - center.y;
+      var d = dx * dx + dy * dy;
+      if (d < distance) {
+        distance = d;
+        closest = node;
+      }
+    });
+    return closest;
+  }
+  function graphNeighborhoodVisible() {
+    if (!graphCy || graphScopeHasMore) return false;
+    var selected = graphCy.nodes().filter(function (node) {
+      return graphSelection.some(function (item) {
+        return item.name === node.data('name') && item.repo === node.data('repo');
+      });
+    });
+    var focus = selected.length > 0 ? selected[0] : graphNearestNode(graphZoomCenter);
+    if (!focus) return false;
+    var relevant = focus.closedNeighborhood().nodes().filter(function (node) {
+      return node.visible();
+    });
+    var margin = 24;
+    var width = graphCy.width();
+    var height = graphCy.height();
+    return relevant.every(function (node) {
+      var box = node.renderedBoundingBox({ includeLabels: true });
+      return box.x1 >= margin && box.y1 >= margin &&
+        box.x2 <= width - margin && box.y2 <= height - margin;
+    });
+  }
+  function graphCaptureSelectedTransition() {
+    if (!graphCy) return;
+    var selected = graphCy.nodes().filter(function (node) {
+      return graphSelection.some(function (item) {
+        return item.name === node.data('name') && item.repo === node.data('repo');
+      });
+    });
+    if (selected.length === 0) return;
+    var node = selected[0];
+    var point = node.renderedPosition();
+    graphTransition = {
+      name: node.data('name'), repo: node.data('repo'),
+      anchor: point, offset: { x: 0, y: 0 }
+    };
+  }
+  function graphViewportModules() {
+    if (!graphCy) return [];
+    var width = graphCy.width();
+    var height = graphCy.height();
+    var visible = [];
+    graphCy.nodes().forEach(function (node) {
+      if (node.data('kind') !== 'module' || !node.visible()) return;
+      var box = node.renderedBoundingBox({ includeLabels: true });
+      if (box.x2 >= 0 && box.y2 >= 0 && box.x1 <= width && box.y1 <= height) {
+        visible.push(node.data());
+      }
+    });
+    return visible;
+  }
+  function graphHandleViewportChange() {
+    if (graphZoomChanging || graphZoomGesture || graphLevel !== 'symbols') return;
+    if (graphViewportRequestTimer) clearTimeout(graphViewportRequestTimer);
+    graphViewportRequestTimer = setTimeout(function () {
+      graphViewportRequestTimer = null;
+      graphFetchVisibleSymbols(false);
+    }, 120);
+  }
+  function graphHandleViewportZoom() {
+    graphZoomGesture = true;
+    if (graphViewportRequestTimer) {
+      clearTimeout(graphViewportRequestTimer);
+      graphViewportRequestTimer = null;
+    }
+    if (graphZoomGestureTimer) clearTimeout(graphZoomGestureTimer);
+    graphZoomGestureTimer = setTimeout(function () {
+      graphZoomGesture = false;
+      graphZoomGestureTimer = null;
+    }, 0);
+  }
+  function graphFetchVisibleSymbols(setTransition) {
+    var data = graphData();
+    var modules = graphViewportModules();
+    if (modules.length === 0) {
+      var nearest = graphNearestNode(null);
+      if (nearest && nearest.data('kind') === 'module') modules = [nearest.data()];
+    }
+    if (modules.length === 0) return;
+    if (setTransition) graphFocusForRequest();
+    var scopes = modules.map(function (focus) {
+      return {
+        focus: focus,
+        key: [data.snapshot_id, 'symbols', focus.name, focus.kind, focus.repo || ''].join('|')
+      };
+    });
+    var missing = scopes.filter(function (item) { return !graphScopes[item.key]; });
+    if (missing.length === 0) {
+      graphScopeHasMore = scopes.some(function (item) { return graphScopes[item.key].has_more; });
+      graphPayload.nodes = graphMergeItems(graphLevel === 'symbols' ? graphPayload.nodes : [], scopes.map(function (item) {
+        return graphAbbreviateMemberLabels(graphScopes[item.key].nodes, item.focus);
+      }).reduce(function (all, nodes) { return all.concat(nodes); }, []));
+      graphPayload.edges = graphMergeItems(graphLevel === 'symbols' ? graphPayload.edges : [], scopes.map(function (item) {
+        return graphScopes[item.key].edges;
+      }).reduce(function (all, edges) { return all.concat(edges); }, []));
+      if (graphLevel === 'symbols') graphCaptureSelectedTransition();
+      graphRenderLevel('symbols', graphLevel === 'symbols');
+      return;
+    }
+    if (graphRequest) graphRequest.abort();
+    var generation = ++graphRequestGeneration;
+    var mode = document.getElementById('graph-mode');
+    if (mode) mode.textContent = 'loading visible module symbols…';
+    graphSetLoading(true);
+    graphRequest = new AbortController();
+    var renderTimer = null;
+    var rendered = false;
+    function renderLoadedScopes() {
+      if (renderTimer) return;
+      renderTimer = setTimeout(function () {
+        renderTimer = null;
+        if (generation !== graphRequestGeneration) return;
+        var nodes = [];
+        var edges = [];
+        scopes.forEach(function (item) {
+          var scope = graphScopes[item.key];
+          if (!scope) return;
+          nodes = nodes.concat(graphAbbreviateMemberLabels(scope.nodes, item.focus));
+          edges = edges.concat(scope.edges);
+        });
+        graphPayload.nodes = graphMergeItems(graphLevel === 'symbols' ? graphPayload.nodes : [], nodes);
+        graphPayload.edges = graphMergeItems(graphLevel === 'symbols' ? graphPayload.edges : [], edges);
+        var preserveViewport = rendered || graphLevel === 'symbols';
+        if (preserveViewport) graphCaptureSelectedTransition();
+        graphRenderLevel('symbols', preserveViewport);
+        rendered = true;
+      }, 100);
+    }
+    var requests = missing.map(function (item) {
+      var params = new URLSearchParams({
+        direction: 'both', depth: '1', max_nodes: '150',
+        focus: item.focus.name, kind: item.focus.kind || '', repo: item.focus.repo || '',
+        snapshot_id: data.snapshot_id || ''
+      });
+      return fetch('/api/graph?' + params.toString(), { signal: graphRequest.signal })
+        .then(function (response) {
+          if (!response.ok) throw new Error('graph request failed (' + response.status + ')');
+          return response.json();
+        })
+        .then(function (scope) {
+          graphScopes[item.key] = scope;
+          renderLoadedScopes();
+          return scope;
+        });
+    });
+    Promise.all(requests)
+      .then(function () {
+        if (generation !== graphRequestGeneration) return;
+        graphScopeHasMore = scopes.some(function (item) { return graphScopes[item.key].has_more; });
+        graphSetLoading(false);
+        renderLoadedScopes();
+      })
+      .catch(function (error) {
+        if (error.name === 'AbortError') return;
+        if (generation !== graphRequestGeneration) return;
+        graphSetLoading(false);
+        var detail = document.getElementById('graph-detail');
+        if (detail) detail.textContent = error.message;
+        if (mode) mode.textContent = 'focused graph unavailable';
+      });
+  }
+  function graphFetchLevel(level) {
+    if (level === 'symbols') {
+      graphFetchVisibleSymbols(true);
+      return;
+    }
+    var focus = graphFocusForRequest();
+    if (!focus) return;
+    var data = graphData();
+    var key = [data.snapshot_id, level, focus.name, focus.kind, focus.repo || ''].join('|');
+    if (graphScopes[key]) {
+      graphScopeHasMore = graphScopes[key].has_more;
+      graphPayload.nodes = graphMergeItems(
+        graphLevel === level ? graphAbbreviateMemberLabels(graphPayload.nodes, focus) : [],
+        graphAbbreviateMemberLabels(graphScopes[key].nodes, focus)
+      );
+      graphPayload.edges = graphMergeItems(graphLevel === level ? graphPayload.edges : [], graphScopes[key].edges);
+      graphRenderLevel(level);
+      return;
+    }
+    if (graphRequest) graphRequest.abort();
+    var generation = ++graphRequestGeneration;
+    var mode = document.getElementById('graph-mode');
+    if (mode) mode.textContent = 'loading focused graph…';
+    graphSetLoading(true);
+    var params = new URLSearchParams({
+      direction: 'both', depth: '1', max_nodes: '150',
+      focus: focus.name, kind: focus.kind || '', repo: focus.repo || '',
+      snapshot_id: data.snapshot_id || ''
+    });
+    graphRequest = new AbortController();
+    fetch('/api/graph?' + params.toString(), { signal: graphRequest.signal })
+      .then(function (response) {
+        if (!response.ok) throw new Error('graph request failed (' + response.status + ')');
+        return response.json();
+      })
+      .then(function (scope) {
+        if (generation !== graphRequestGeneration) return;
+        graphSetLoading(false);
+        graphScopes[key] = scope;
+        graphScopeHasMore = scope.has_more;
+        graphPayload.nodes = graphMergeItems(
+          graphLevel === level ? graphAbbreviateMemberLabels(graphPayload.nodes, focus) : [],
+          graphAbbreviateMemberLabels(scope.nodes, focus)
+        );
+        graphPayload.edges = graphMergeItems(graphLevel === level ? graphPayload.edges : [], scope.edges);
+        graphRenderLevel(level);
+        if (scope.has_more) {
+          var notice = document.getElementById('graph-detail');
+          if (notice) notice.textContent = 'This focused view is truncated. Expand or refocus to inspect more.';
+        }
+      })
+      .catch(function (error) {
+        if (error.name === 'AbortError') return;
+        if (generation !== graphRequestGeneration) return;
+        graphSetLoading(false);
+        var detail = document.getElementById('graph-detail');
+        if (detail) detail.textContent = error.message;
+        if (mode) mode.textContent = 'focused graph unavailable';
+      });
+  }
+  function graphMergeItems(existing, incoming) {
+    var byID = {};
+    (existing || []).forEach(function (item) { byID[item.id] = item; });
+    (incoming || []).forEach(function (item) { byID[item.id] = item; });
+    return Object.keys(byID).map(function (id) { return byID[id]; });
+  }
+  function graphAbbreviateMemberLabels(nodes, focus) {
+    var prefix = focus && focus.kind === 'module' ? focus.name + '/' : '';
+    if (!prefix) return nodes || [];
+    return (nodes || []).map(function (node) {
+      if (node.kind !== 'symbol' || node.name.indexOf(prefix) !== 0) return node;
+      var copy = {};
+      Object.keys(node).forEach(function (key) { copy[key] = node[key]; });
+      copy.label = './' + node.name.slice(prefix.length);
+      return copy;
+    });
+  }
+  function graphShowNeighbors() {
+    graphLoad(graphLevel === 'overview' ? 'symbols' : graphLevel);
+  }
+  function graphLoad(level) {
+    if (!graphCy) return;
+    if (level === 'overview') {
+      if (graphRequest) graphRequest.abort();
+      graphRequest = null;
+      graphRequestGeneration++;
+      graphScopeHasMore = false;
+      graphRenderLevel(level);
+    } else {
+      graphFetchLevel(level);
+    }
+  }
+  function graphFit() { if (graphCy) { graphCy.resize(); graphCy.fit(undefined, 35); } }
+  function graphResetLayout() {
+    if (!graphCy) return;
+    if (!graphBaseline) return;
+    graphZoomChanging = true;
+    graphCy.nodes().forEach(function (node) {
+      var position = graphBaseline.positions[node.id()];
+      if (position) node.position(position);
+    });
+    graphCy.zoom(graphBaseline.zoom);
+    graphCy.pan(graphBaseline.pan);
+    graphZoomChanging = false;
+  }
+  function graphClearSelection() {
+    if (!graphCy) return;
+    graphSelection = [];
+    if (graphSelectionEnabledSymbol) {
+      var symbolCheckbox = document.querySelector('[data-graph-node="symbol"]');
+      if (symbolCheckbox) symbolCheckbox.checked = false;
+      graphSelectionEnabledSymbol = false;
+    }
+    graphSyncSelectionStyles();
+    var input = document.getElementById('graph-search-input');
+    if (input) input.value = '';
+    graphSearchResults = {};
+    if (graphSearchTimer) clearTimeout(graphSearchTimer);
+    if (graphSearchRequest) graphSearchRequest.abort();
+    var detail = document.getElementById('graph-detail');
+    if (detail) detail.textContent = 'Select a node or edge to inspect its source metadata.';
+    graphRenderSelectionPanel();
+    if (graphLevel !== 'overview') {
+      graphRenderLevel('overview', false);
+    } else {
+      graphFilterGraph();
+    }
+  }
+  function graphEnableNodeKind(kind) {
+    var checkbox = document.querySelector('[data-graph-node="' + kind + '"]');
+    if (checkbox) checkbox.checked = true;
+  }
+  function graphFilterGraph() {
+    if (!graphCy) return;
+    graphSyncSelectionStyles();
+    var selected = graphCy.nodes().filter(function (node) {
+      return graphSelection.some(function (item) {
+        return item.name === node.data('name') && item.repo === node.data('repo');
+      });
+    });
+    var neighborhood = null;
+    if (selected.length > 0) {
+      neighborhood = {};
+      selected.forEach(function (focused) {
+        focused.closedNeighborhood().nodes().forEach(function (node) {
+          neighborhood[node.id()] = true;
+        });
+      });
+    }
+    graphCy.nodes().forEach(function (node) {
+      var checkbox = document.querySelector('[data-graph-node="' + node.data('kind') + '"]');
+      var inSelection = !neighborhood || neighborhood[node.id()];
+      node.style('display', checkbox && checkbox.checked && inSelection ? 'element' : 'none');
+    });
+    graphCy.edges().forEach(function (edge) {
+      var edgeCheckbox = document.querySelector('[data-graph-edge="' + edge.data('kind') + '"]');
+      var sourceVisible = graphCy.getElementById(edge.data('source')).style('display') !== 'none';
+      var targetVisible = graphCy.getElementById(edge.data('target')).style('display') !== 'none';
+      edge.style('display', edgeCheckbox && edgeCheckbox.checked && sourceVisible && targetVisible ? 'element' : 'none');
+    });
   }
 
   // insightBandMatch reports whether a row's confidence percent falls in the band.
@@ -488,7 +1534,8 @@
       if (open) closeModal(open);
     }
   });
-  startRefresh();
+  graphApplyCheckboxColors();
+  {{if .ViewOnly}}initGraph();{{else}}startRefresh();{{end}}
 </script>
 </body>
 </html>

--- a/pkg/facts/facts.go
+++ b/pkg/facts/facts.go
@@ -39,9 +39,11 @@ type (
 // Re-exported so out-of-module consumers (the enterprise architecture validator)
 // can run reverse-dependency impact analysis over a snapshot's facts.
 type (
-	Graph         = internal.Graph
-	ImpactResult  = internal.ImpactResult
-	TraversalNode = internal.TraversalNode
+	Graph           = internal.Graph
+	ImpactResult    = internal.ImpactResult
+	TraversalResult = internal.TraversalResult
+	TraversalNode   = internal.TraversalNode
+	TraversalEdge   = internal.TraversalEdge
 )
 
 // NewStore builds an empty fact store; callers Add() facts (e.g. those read from a


### PR DESCRIPTION
Adding an interactive, snapshot-aware architecture graph viewer to the localhost dashboard. Graph data is bounded and loaded on demand, with search, filtering, focused traversal, and stale-snapshot protection.

<img width="2547" height="1172" alt="Screenshot 2026-08-02 at 15 45 25" src="https://github.com/user-attachments/assets/c61c1a2b-777e-4315-8e78-9f5254241b00" />