### PR TITLE
Add conformance: did the change stay inside its declared scope?

### DIFF
--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -1,0 +1,316 @@
+// Package conformance answers a question a delta cannot: did the change stay inside the
+// scope you declared for it?
+//
+// A diff is a function of two snapshots, so it can report what changed and nothing about
+// what you MEANT to change. Conformance takes a third input — a declared target, or a
+// list of packages you expected to touch — runs reverse-dependency impact analysis on the
+// PRE-CHANGE graph, and compares the blast radius that was predicted against the one that
+// actually happened.
+//
+// The interesting output is the mismatch. A change that reaches a package outside its
+// predicted radius is a change that did something its author did not describe, and that
+// is worth knowing even when every finding is clean and the build is green.
+//
+// It lives beside the delta rather than inside it: diff.Compute must stay a pure function
+// of two snapshots, and folding a third input into it would make every diff depend on
+// something most callers never supply.
+package conformance
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/enola-labs/enola/internal/diff"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// maxResolvedTargets caps how many nodes a substring target expands to, so a short or
+// common string cannot turn one declaration into a whole-graph traversal.
+const maxResolvedTargets = 25
+
+// Options declares the intended scope. With both fields empty the mode is AUTO: the
+// targets are derived from the delta and the packages the change edited are taken as its
+// own intent, which reports spillover beyond the edit sites without requiring anyone to
+// have declared anything.
+type Options struct {
+	// Target is the symbol, type or package the caller intended to change. Matched
+	// exactly if such a node exists, else as a case-insensitive substring.
+	Target string
+	// ExpectedPackages are packages the caller expected to touch, in addition to
+	// whatever the impact analysis predicts.
+	ExpectedPackages []string
+	// MaxDepth / MaxNodes bound the reverse-dependency traversal. Zero means the
+	// defaults below.
+	MaxDepth int
+	MaxNodes int
+}
+
+const (
+	defaultMaxDepth = 3
+	defaultMaxNodes = 200
+)
+
+// Report is the predicted-vs-actual comparison. Package lists are sorted, so two runs
+// over the same inputs render identically.
+type Report struct {
+	// Declared is true when the caller supplied a target or expected packages. It
+	// changes what spillover MEANS: in declared mode it is a conformance failure, in
+	// auto mode it is an observation about a radius nobody claimed.
+	Declared bool `json:"declared"`
+	// Targets are the graph nodes the impact analysis actually ran on.
+	Targets []string `json:"analyzed_targets,omitempty"`
+
+	PredictedPackages []string `json:"predicted_packages"`
+	ActualPackages    []string `json:"actual_packages"`
+	Matched           []string `json:"matched"`
+	// Spillover are packages the change touched that were neither predicted nor
+	// declared — the finding this package exists to produce.
+	Spillover []string `json:"spillover"`
+	// Unrealized are predicted packages the change did not touch. Usually benign: a
+	// change narrower than its blast radius is a change that avoided trouble.
+	Unrealized []string `json:"unrealized,omitempty"`
+
+	MatchRatio          float64 `json:"match_ratio"`
+	PredictedDependents int     `json:"predicted_total_dependents"`
+}
+
+// Compute compares the predicted blast radius against the actual one.
+//
+// base is the pre-change store (the baseline's facts, with a graph built over them);
+// cur is the post-change store, needed only to attribute a new edge's source to a package.
+func Compute(base, cur *facts.Store, d *diff.SnapshotDiff, opts Options) Report {
+	if d == nil || base == nil {
+		return Report{}
+	}
+	declared := strings.TrimSpace(opts.Target) != "" || len(opts.ExpectedPackages) > 0
+
+	// Packages whose code directly changed.
+	editSites := map[string]bool{}
+	for _, f := range d.FactsAdded {
+		addPkg(editSites, packageOf(f))
+	}
+	for _, c := range d.FactsChanged {
+		addPkg(editSites, packageOf(c.After))
+	}
+	for _, f := range d.FactsRemoved {
+		addPkg(editSites, packageOf(f))
+	}
+	// Plus packages that gained an outbound dependency. A package can be reached by a
+	// change without any of its own facts moving — that is the coupling footprint, and
+	// leaving it out would under-report exactly the case worth catching.
+	actual := map[string]bool{}
+	for p := range editSites {
+		actual[p] = true
+	}
+	for _, e := range d.EdgesAdded {
+		addPkg(actual, pkgOfName(cur, e.Source))
+	}
+
+	targets := opts.resolveTargets(base, d)
+
+	// Predicted radius: reverse dependents on the PRE-change graph. Built explicitly
+	// because a store assembled from a loaded baseline has no graph index until asked.
+	predicted := map[string]bool{}
+	dependents := 0
+	g := facts.NewGraph(base.All())
+	for _, t := range targets {
+		addPkg(predicted, pkgOfName(base, t)) // the target's own package is always expected
+		res := g.ImpactSet(t, opts.maxDepth(), opts.maxNodes(), false)
+		dependents += res.TotalDependents
+		for _, nodes := range res.ByDepth {
+			for _, n := range nodes {
+				addPkg(predicted, pkgOfNode(base, n))
+			}
+		}
+	}
+	for _, p := range opts.ExpectedPackages {
+		addPkg(predicted, strings.TrimSpace(p))
+	}
+
+	// In AUTO mode the edit sites ARE the intent — nobody declared anything, so the
+	// places the author edited are the best available statement of what they meant. In
+	// DECLARED mode the caller's scope stands alone, which is what lets an edit in an
+	// undeclared package count as spillover.
+	expected := clone(predicted)
+	if !declared {
+		for p := range editSites {
+			expected[p] = true
+		}
+	}
+
+	matched := intersect(actual, expected)
+	ratio := 1.0
+	if len(actual) > 0 {
+		ratio = float64(len(matched)) / float64(len(actual))
+	}
+
+	return Report{
+		Declared:            declared,
+		Targets:             targets,
+		PredictedPackages:   sortedKeys(predicted),
+		ActualPackages:      sortedKeys(actual),
+		Matched:             sortedKeys(matched),
+		Spillover:           sortedKeys(minus(actual, expected)),
+		Unrealized:          sortedKeys(minus(predicted, actual)),
+		MatchRatio:          round2(ratio),
+		PredictedDependents: dependents,
+	}
+}
+
+func (o Options) maxDepth() int {
+	if o.MaxDepth <= 0 {
+		return defaultMaxDepth
+	}
+	return o.MaxDepth
+}
+
+func (o Options) maxNodes() int {
+	if o.MaxNodes <= 0 {
+		return defaultMaxNodes
+	}
+	return o.MaxNodes
+}
+
+// resolveTargets turns the declaration into concrete nodes present in the baseline graph,
+// or derives them from the delta when nothing was declared.
+func (o Options) resolveTargets(base *facts.Store, d *diff.SnapshotDiff) []string {
+	target := strings.TrimSpace(o.Target)
+	if target == "" {
+		return derivedTargets(d)
+	}
+	// An exact node wins outright: a caller who named a real symbol meant that symbol,
+	// and expanding it by substring would drag in every namesake.
+	if len(base.LookupByExactName(target)) > 0 {
+		return []string{target}
+	}
+	needle := strings.ToLower(target)
+	seen := map[string]bool{}
+	var out []string
+	for _, f := range base.All() {
+		if f.Name == "" || seen[f.Name] {
+			continue
+		}
+		if strings.Contains(strings.ToLower(f.Name), needle) {
+			seen[f.Name] = true
+			out = append(out, f.Name)
+			if len(out) >= maxResolvedTargets {
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// derivedTargets extracts the PRE-EXISTING symbols the change touched — the ones whose
+// reverse dependents form an auto-derived blast radius.
+//
+// Added facts and edges contribute nothing: they are absent from the baseline graph, so
+// they have no pre-change dependents to find.
+func derivedTargets(d *diff.SnapshotDiff) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	for _, c := range d.FactsChanged {
+		add(c.After.Name)
+	}
+	for _, f := range d.FactsRemoved {
+		add(f.Name)
+	}
+	for _, e := range d.EdgesRemoved {
+		add(e.Source)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// packageOf returns the package a fact belongs to: its own name for a module fact,
+// otherwise the target of its `declares` relation, falling back to the file's directory.
+func packageOf(f facts.Fact) string {
+	if f.Kind == facts.KindModule {
+		return f.Name
+	}
+	for _, r := range f.Relations {
+		if r.Kind == facts.RelDeclares {
+			return r.Target
+		}
+	}
+	if f.File != "" {
+		return filepath.Dir(f.File)
+	}
+	return ""
+}
+
+func pkgOfName(store *facts.Store, name string) string {
+	if store == nil {
+		return ""
+	}
+	for _, f := range store.ByName(name) {
+		if p := packageOf(f); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func pkgOfNode(store *facts.Store, n facts.TraversalNode) string {
+	if p := pkgOfName(store, n.Name); p != "" {
+		return p
+	}
+	if n.File != "" {
+		return filepath.Dir(n.File)
+	}
+	return ""
+}
+
+func addPkg(set map[string]bool, p string) {
+	if p = strings.TrimSpace(p); p != "" && p != "." {
+		set[p] = true
+	}
+}
+
+func clone(a map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(a))
+	for k := range a {
+		out[k] = true
+	}
+	return out
+}
+
+func intersect(a, b map[string]bool) map[string]bool {
+	out := map[string]bool{}
+	for k := range a {
+		if b[k] {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+func minus(a, b map[string]bool) map[string]bool {
+	out := map[string]bool{}
+	for k := range a {
+		if !b[k] {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// round2 keeps the ratio stable in its rendered form; it is reported, not compared.
+func round2(f float64) float64 { return float64(int(f*100+0.5)) / 100 }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -1,0 +1,158 @@
+package conformance
+
+import (
+	"testing"
+
+	"github.com/enola-labs/enola/internal/diff"
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// A small graph: api and web both import core. Changing core has a predicted radius of
+// {core, api, web}; changing it and also editing an unrelated package does not.
+func baseStore() *facts.Store {
+	s := facts.NewStore()
+	s.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "core", File: "core"},
+		facts.Fact{Kind: facts.KindModule, Name: "api", File: "api"},
+		facts.Fact{Kind: facts.KindModule, Name: "web", File: "web"},
+		facts.Fact{Kind: facts.KindModule, Name: "unrelated", File: "unrelated"},
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "api -> core", File: "api/a.go",
+			Relations: []facts.Relation{{Kind: facts.RelImports, Target: "core"}},
+		},
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "web -> core", File: "web/w.go",
+			Relations: []facts.Relation{{Kind: facts.RelImports, Target: "core"}},
+		},
+	)
+	s.BuildGraph()
+	return s
+}
+
+func moduleFact(name string) facts.Fact {
+	return facts.Fact{Kind: facts.KindModule, Name: name, File: name}
+}
+
+// The finding this package exists to produce: a change that reached a package the caller
+// never declared. Everything else can be green and this still matters.
+func TestSpilloverIsReportedInDeclaredMode(t *testing.T) {
+	base := baseStore()
+	d := &diff.SnapshotDiff{FactsChanged: []diff.FactChange{
+		{Before: moduleFact("core"), After: moduleFact("core")},
+		{Before: moduleFact("unrelated"), After: moduleFact("unrelated")},
+	}}
+
+	got := Compute(base, base, d, Options{Target: "core", ExpectedPackages: []string{"core"}})
+
+	if !got.Declared {
+		t.Error("Declared = false, want true — a target was supplied")
+	}
+	if len(got.Spillover) != 1 || got.Spillover[0] != "unrelated" {
+		t.Errorf("Spillover = %v, want [unrelated]", got.Spillover)
+	}
+	if got.MatchRatio >= 1.0 {
+		t.Errorf("MatchRatio = %v, want < 1 when a package spilled over", got.MatchRatio)
+	}
+}
+
+// A change confined to what was declared reports no spillover and a perfect ratio.
+func TestNoSpilloverWhenTheChangeStaysInScope(t *testing.T) {
+	base := baseStore()
+	d := &diff.SnapshotDiff{FactsChanged: []diff.FactChange{
+		{Before: moduleFact("core"), After: moduleFact("core")},
+	}}
+
+	got := Compute(base, base, d, Options{Target: "core"})
+
+	if len(got.Spillover) != 0 {
+		t.Errorf("Spillover = %v, want none", got.Spillover)
+	}
+	if got.MatchRatio != 1.0 {
+		t.Errorf("MatchRatio = %v, want 1.0", got.MatchRatio)
+	}
+}
+
+// In AUTO mode the packages the author edited are the best available statement of intent,
+// so editing two packages without declaring anything is not spillover. Without this, every
+// undeclared multi-package change would report a false conformance failure.
+func TestAutoModeTreatsEditSitesAsIntent(t *testing.T) {
+	base := baseStore()
+	d := &diff.SnapshotDiff{FactsChanged: []diff.FactChange{
+		{Before: moduleFact("core"), After: moduleFact("core")},
+		{Before: moduleFact("unrelated"), After: moduleFact("unrelated")},
+	}}
+
+	got := Compute(base, base, d, Options{})
+
+	if got.Declared {
+		t.Error("Declared = true with no target or expected packages")
+	}
+	if len(got.Spillover) != 0 {
+		t.Errorf("Spillover = %v, want none in auto mode", got.Spillover)
+	}
+}
+
+// A package can be reached without any of its own facts moving — it gained an outbound
+// dependency. Leaving that out would under-report the coupling case, which is the one
+// most worth catching.
+func TestNewCouplingCountsAsReached(t *testing.T) {
+	base := baseStore()
+	cur := facts.NewStore()
+	cur.Add(
+		moduleFact("core"),
+		facts.Fact{
+			Kind: facts.KindDependency, Name: "unrelated -> core", File: "unrelated/u.go",
+			Relations: []facts.Relation{{Kind: facts.RelDeclares, Target: "unrelated"}},
+		},
+	)
+	d := &diff.SnapshotDiff{EdgesAdded: []diff.Edge{{Source: "unrelated -> core", Target: "core"}}}
+
+	got := Compute(base, cur, d, Options{Target: "core", ExpectedPackages: []string{"core"}})
+
+	found := false
+	for _, p := range got.ActualPackages {
+		if p == "unrelated" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ActualPackages = %v, want it to include the package that gained the edge", got.ActualPackages)
+	}
+}
+
+// An exactly-named target must not be expanded by substring: a caller who named a real
+// symbol meant that symbol, and expanding would drag in every namesake.
+func TestExactTargetIsNotExpanded(t *testing.T) {
+	base := baseStore()
+	got := Compute(base, base, &diff.SnapshotDiff{}, Options{Target: "core"})
+
+	if len(got.Targets) != 1 || got.Targets[0] != "core" {
+		t.Errorf("Targets = %v, want exactly [core]", got.Targets)
+	}
+}
+
+// A substring that matches nothing yields no targets rather than the whole graph.
+func TestUnmatchedTargetYieldsNothing(t *testing.T) {
+	base := baseStore()
+	got := Compute(base, base, &diff.SnapshotDiff{}, Options{Target: "nosuchthing"})
+
+	if len(got.Targets) != 0 {
+		t.Errorf("Targets = %v, want none", got.Targets)
+	}
+}
+
+// Added facts have no pre-change dependents, so they cannot contribute to a radius
+// computed on the baseline graph. Deriving targets from them would predict a blast radius
+// for something that did not exist to be depended upon.
+func TestDerivedTargetsIgnoreAdditions(t *testing.T) {
+	d := &diff.SnapshotDiff{
+		FactsAdded:   []facts.Fact{{Kind: facts.KindSymbol, Name: "core.New"}},
+		FactsRemoved: []facts.Fact{{Kind: facts.KindSymbol, Name: "core.Old"}},
+	}
+
+	got := derivedTargets(d)
+
+	if len(got) != 1 || got[0] != "core.Old" {
+		t.Errorf("derivedTargets = %v, want only the removed symbol", got)
+	}
+}


### PR DESCRIPTION
A delta is a function of two snapshots, so it can report what changed and nothing about what was meant to change. Conformance takes a third input — a declared target, or the packages the caller expected to touch — runs reverse-dependency impact analysis on the pre-change graph, and compares the predicted blast radius against the one that happened.

The output worth having is the mismatch: a change that reaches a package outside its predicted radius did something its author did not describe, and that is worth knowing even when every finding is clean.

It sits beside the delta rather than inside it. diff.Compute stays a function of two snapshots; folding a third input in would make every diff depend on something most callers never supply.

Two behaviours are load-bearing rather than incidental. With nothing declared, the packages the author edited are taken as the statement of intent — otherwise every undeclared multi-package change reports a false conformance failure. And a package counts as reached when it gains an outbound dependency, even if none of its own facts moved, which is the coupling case most worth catching.

Internal, not exported: nothing outside this module needs it.