### PR TITLE
Add support for Codex hooks management and related tests

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -409,7 +409,7 @@ enola uninstall               # remove it all again
 | Cursor | `.cursor/rules/enola.mdc` *(owned)* | — no user-level rules directory |
 | GitHub Copilot | `.github/instructions/enola.instructions.md` *(owned)* | — lives in IDE/account settings |
 | Codex · Copilot · Pi | `AGENTS.md` *(marked block, only if it already exists)* | — |
-| Codex | *covered by `AGENTS.md`* | `~/.codex/AGENTS.md` *(marked block)* |
+| Codex | `.codex/hooks.json` *(managed entries, `--hooks` only)*, covered by `AGENTS.md` otherwise | `~/.codex/AGENTS.md` *(marked block)*, `~/.codex/hooks.json` *(managed entries, `--hooks` only)* |
 | Pi | *covered by `AGENTS.md`* | `~/.pi/agent/AGENTS.md` *(marked block)* |
 
 **Codex, Copilot and Pi all read the repository's `AGENTS.md`**, so locally one block serves all three - enola won't write a second repo-local file for them, which would only put the same instruction into the same context window twice. Their `--global` entries add what `AGENTS.md` can't: guidance in projects where nobody has run `enola install`. Those are written only when the tool's config directory already exists, so enola never creates `~/.codex` for someone who doesn't use Codex.
@@ -441,7 +441,9 @@ It is deliberately opt-in and deliberately quiet:
 - **It never breaks your session.** Every failure path - no snapshot, unreadable input, a directory that isn't a repository - exits cleanly and says nothing. A broken enola must never look like a broken session.
 - **It merges into your config.** Your existing hooks, permissions and settings are preserved; `uninstall` removes exactly enola's entries and nothing else.
 
-The hooks shell out to `enola hook session-start` and `enola hook stop`, which is what you'll see in `.claude/settings.json`, pinned to the absolute path of the binary you installed with. You never run them yourself.
+The hooks shell out to `enola hook session-start` and `enola hook stop`, which is what you'll see in `.claude/settings.json` (or Codex's `hooks.json`), pinned to the absolute path of the binary you installed with. You never run them yourself.
+
+Codex additionally requires you to approve a new hook once before it will run it - inside Codex, run `/hooks`. That's a Codex requirement, not something `enola install` can do for you.
 
 ### The gate - `enola check`
 
@@ -651,4 +653,3 @@ enola --generate ci/cluster.yaml
 Entries resolve **relative to the config file**, not to your working directory, so a cluster config can be checked in and means the same thing on a laptop and in CI. (`repo:` is unchanged: a single repository, relative to the working directory.) Order matters - the first entry resets the graph and the rest are added to it.
 
 ---
-

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -170,7 +170,23 @@ func (r *Runner) Install(args []string, remove bool) {
 	if !remove && opts.Hooks {
 		fmt.Println("\nRestart your agent session for the hooks to take effect.")
 		fmt.Printf("Then `%s doctor` will tell you whether they are actually firing.\n", r.name())
+		if touchedCodexHooks(applied) {
+			fmt.Println("Codex also requires you to approve a new hook once before it runs — inside Codex, run `/hooks`.")
+		}
 	}
+}
+
+// touchedCodexHooks reports whether this run wrote or updated Codex's hooks.json.
+func touchedCodexHooks(rs []install.Result) bool {
+	for _, r := range rs {
+		if !strings.HasSuffix(filepath.ToSlash(r.Path), "/.codex/hooks.json") {
+			continue
+		}
+		if r.Action == install.ActionCreated || r.Action == install.ActionUpdated {
+			return true
+		}
+	}
+	return false
 }
 
 // hookOutputDir resolves a repository's enola output directory without building an

--- a/pkg/install/hooks.go
+++ b/pkg/install/hooks.go
@@ -59,14 +59,43 @@ func HookSummary() []string {
 	return out
 }
 
-// writeHooks merges enola's hooks into the agent's settings.json, or removes them.
-//
-// Merging rather than replacing is the whole job: settings.json belongs to the user and
-// very likely already contains hooks, permissions and other configuration that must
-// survive untouched. Only the entries carrying enolaHookMarker are ever added or removed.
+// writeHooks merges enola's hooks into Claude Code's settings.json, or removes them.
 func writeHooks(o Options, remove bool) ([]Result, error) {
-	path := filepath.Join(claudeDir(o), "settings.json")
+	return writeHooksAt(filepath.Join(claudeDir(o), "settings.json"), o, remove, claudeHookEntry)
+}
 
+// writeCodexHooks merges hooks into Codex's hooks.json. Codex uses the same matcher-group
+// envelope as Claude, but its command handler contract differs: async is required and the
+// timeout field is named timeoutSec.
+func writeCodexHooks(path string, o Options, remove bool) ([]Result, error) {
+	return writeHooksAt(path, o, remove, codexHookEntry)
+}
+
+type hookEntry func(command string) map[string]any
+
+func claudeHookEntry(command string) map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": command,
+		"timeout": hookTimeoutSeconds,
+		"source":  enolaHookMarker,
+	}
+}
+
+func codexHookEntry(command string) map[string]any {
+	return map[string]any{
+		"type":       "command",
+		"command":    command,
+		"async":      false,
+		"timeoutSec": hookTimeoutSeconds,
+		"source":     enolaHookMarker,
+	}
+}
+
+// writeHooksAt shares the matcher-group merge mechanics while allowing each agent to
+// encode command handlers according to its own schema. Only entries carrying
+// enolaHookMarker are ever replaced or removed.
+func writeHooksAt(path string, o Options, remove bool, makeEntry hookEntry) ([]Result, error) {
 	r, err := mutateJSON(path, func(doc map[string]any) {
 		hooks, _ := doc["hooks"].(map[string]any)
 		if hooks == nil {
@@ -87,12 +116,7 @@ func writeHooks(o Options, remove bool) ([]Result, error) {
 		// states: everything looks configured and the half that produces the value is
 		// absent. Verified against a real session, both shapes, one variable.
 		for _, h := range installedHooks {
-			entry := map[string]any{
-				"type":    "command",
-				"command": o.hookCommand() + " " + h.Subcommand,
-				"timeout": hookTimeoutSeconds,
-				"source":  enolaHookMarker,
-			}
+			entry := makeEntry(o.hookCommand() + " " + h.Subcommand)
 			hooks[h.Event] = mergeMatcher(hooks[h.Event], h.Matcher, entry, remove)
 		}
 

--- a/pkg/install/hooks_codex_test.go
+++ b/pkg/install/hooks_codex_test.go
@@ -1,0 +1,119 @@
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// codexHooksAfter runs an install (or uninstall) and returns the parsed hooks map from
+// .codex/hooks.json, or nil if the file was not written.
+func codexHooksAfter(t *testing.T, o Options, remove bool) map[string]any {
+	t.Helper()
+	var err error
+	if remove {
+		_, err = Uninstall(o)
+	} else {
+		_, err = Install(o)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(codexDir(o), "hooks.json"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("reading hooks.json: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("hooks.json is not valid JSON: %v\n%s", err, raw)
+	}
+	hooks, _ := doc["hooks"].(map[string]any)
+	return hooks
+}
+
+// Without --hooks, Codex gets no hooks.json at all — same rule as every other target.
+func TestInstall_CodexHooksNotWrittenWithoutFlag(t *testing.T) {
+	o := opts(t, false)
+	if hooks := codexHooksAfter(t, o, false); hooks != nil {
+		t.Errorf("hooks.json written without --hooks: %#v", hooks)
+	}
+}
+
+// Locally, hooks.json is its own file and is written unconditionally, like Cursor's
+// rule file — .codex/ existing beforehand is not required.
+func TestInstall_CodexHooksWrittenLocally(t *testing.T) {
+	o := opts(t, true)
+	hooks := codexHooksAfter(t, o, false)
+
+	for _, h := range installedHooks {
+		list, ok := hooks[h.Event].([]any)
+		if !ok || len(list) == 0 {
+			t.Errorf("%s: not written:\n%#v", h.Event, hooks)
+			continue
+		}
+		entries, _ := enolaEntries(t, hooks, h.Event)
+		if len(entries) != 1 {
+			t.Errorf("%s: got %d enola entries, want 1", h.Event, len(entries))
+			continue
+		}
+		entry := entries[0]
+		if async, ok := entry["async"].(bool); !ok || async {
+			t.Errorf("%s: async = %#v, want required value false", h.Event, entry["async"])
+		}
+		if entry["timeoutSec"] != float64(hookTimeoutSeconds) {
+			t.Errorf("%s: timeoutSec = %#v, want %d", h.Event, entry["timeoutSec"], hookTimeoutSeconds)
+		}
+		if _, legacy := entry["timeout"]; legacy {
+			t.Errorf("%s: contains Claude-only timeout field: %#v", h.Event, entry)
+		}
+	}
+}
+
+// Globally, hooks.json follows the same rule as ~/.codex/AGENTS.md: only written when
+// ~/.codex already exists, so enola never creates it for a non-Codex user.
+func TestInstall_CodexHooksGlobalOnlyWhenInstalled(t *testing.T) {
+	o := opts(t, true)
+	o.Scope = ScopeGlobal
+
+	if hooks := codexHooksAfter(t, o, false); hooks != nil {
+		t.Errorf("hooks.json written under a home directory with no ~/.codex: %#v", hooks)
+	}
+
+	if err := os.MkdirAll(filepath.Join(o.HomeDir, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hooks := codexHooksAfter(t, o, false)
+	if hooks[installedHooks[0].Event] == nil {
+		t.Errorf("hooks.json not written under an existing ~/.codex: %#v", hooks)
+	}
+}
+
+// Uninstall must remove only enola's entries, leaving a hand-written hook in the same
+// file untouched.
+func TestInstall_CodexHooksUninstallPreservesUserEntries(t *testing.T) {
+	o := opts(t, true)
+	path := filepath.Join(codexDir(o), "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userHooks := `{"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "notify-send done"}]}]}}`
+	if err := os.WriteFile(path, []byte(userHooks), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	codexHooksAfter(t, o, false)
+	hooks := codexHooksAfter(t, o, true)
+
+	entries, _ := enolaEntries(t, hooks, "Stop")
+	if len(entries) != 0 {
+		t.Errorf("uninstall left enola entries behind: %#v", entries)
+	}
+	list, _ := hooks["Stop"].([]any)
+	if len(list) == 0 {
+		t.Error("uninstall removed the user's own Stop hook")
+	}
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -124,7 +124,7 @@ func runTarget(name string, o Options, remove bool) ([]Result, error) {
 	case "agents":
 		return agentsTarget(o, remove)
 	case "codex":
-		return globalAgentsTarget(o, remove, "codex", filepath.Join(".codex", "AGENTS.md"))
+		return codexTarget(o, remove)
 	case "pi":
 		return globalAgentsTarget(o, remove, "pi", filepath.Join(".pi", "agent", "AGENTS.md"))
 	case "copilot":
@@ -132,6 +132,42 @@ func runTarget(name string, o Options, remove bool) ([]Result, error) {
 	default:
 		return nil, fmt.Errorf("unknown target %q", name)
 	}
+}
+
+// codexDir is .codex/ under the repo (local) or the home directory (global).
+func codexDir(o Options) string {
+	if o.Scope == ScopeGlobal {
+		return filepath.Join(o.HomeDir, ".codex")
+	}
+	return filepath.Join(o.RepoDir, ".codex")
+}
+
+// codexTarget combines Codex's AGENTS.md block with its own hooks.json. Global scope
+// only writes hooks.json when ~/.codex already exists, same rule as globalAgentsTarget.
+func codexTarget(o Options, remove bool) ([]Result, error) {
+	out, err := globalAgentsTarget(o, remove, "codex", filepath.Join(".codex", "AGENTS.md"))
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(codexDir(o), "hooks.json")
+	if o.Scope == ScopeGlobal {
+		if _, err := os.Stat(codexDir(o)); os.IsNotExist(err) {
+			return append(out, Result{
+				Path:   path,
+				Action: ActionSkipped,
+				Reason: ".codex not found in your home directory, so codex does not appear to be installed",
+			}), nil
+		}
+	}
+	if !remove && !o.Hooks {
+		return out, nil
+	}
+	hr, err := writeCodexHooks(path, o, remove)
+	if err != nil {
+		return nil, err
+	}
+	return append(out, hr...), nil
 }
 
 // globalAgentsTarget maintains enola's block in a tool's USER-level AGENTS.md — Codex


### PR DESCRIPTION
## Summary
- `enola install --hooks` now wires real SessionStart/Stop hooks for Codex — writes `.codex/hooks.json` (local, unconditional) or `~/.codex/hooks.json` (global, only if `~/.codex` exists), matching Codex's matcher-group schema (`timeoutSec`, required `async`).
- CLI now notes that Codex requires a one-time `/hooks` approval before a new hook runs as enola can't do that for the user. (Some codex internal stuff)

## Test plan
- [x] `go build ./...`, `go test ./pkg/install/... ./pkg/command/...`
- [x] New tests: no-flag skip, local write, global gate on `~/.codex`, uninstall preserves user's own hooks
- [x] Manual dry-run/apply verified against Codex's actual `hooks.json` schema