### PR TITLE
fix: uninstall leaves no empty files or directories behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ enola install --hooks
 claude mcp add enola enola
 ```
 
-`enola install` adds a short instruction to the files your agents already read — Claude Code, Cursor, Copilot, Codex, Pi — and `--hooks` adds the two hooks that run the loop automatically. It previews every change and asks before writing, never creates files you didn't already have, and `enola uninstall` reverses everything byte-for-byte.
+`enola install` adds a short instruction to the files your agents already read — Claude Code, Cursor, Copilot, Codex, Pi — and `--hooks` adds the two hooks that run the loop automatically. It previews every change and asks before writing, never creates a shared file like `AGENTS.md` that wasn't already there, and `enola uninstall` reverses everything byte-for-byte — including the files and directories it created itself.
 
 After your next session, `enola doctor` reports whether those hooks actually fired. Worth running once: a hook configuration is a contract with your agent, and one it quietly ignores looks exactly like one it honours.
 

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -158,9 +158,7 @@ func (r *Runner) Install(args []string, remove bool) {
 		if outDir := hookOutputDir(repoDir); outDir != "" {
 			switch {
 			case remove:
-				// A stale "never fired since <date>" after the hooks were deliberately
-				// removed would be a false alarm, so the record goes with them.
-				hookstate.Clear(outDir)
+				clearHookHeartbeat(repoDir, outDir)
 			case opts.Hooks:
 				hookstate.RecordInstalled(outDir, opts.HookCommand)
 			}
@@ -187,6 +185,26 @@ func touchedCodexHooks(rs []install.Result) bool {
 		}
 	}
 	return false
+}
+
+// clearHookHeartbeat drops the record `install --hooks` stamped, and the output directory
+// with it when that record was the only thing in it.
+//
+// A stale "installed on X, never fired since" after the hooks were deliberately removed
+// would be a false alarm, so the record goes with them. The directory has to go too: in a
+// repository that has never been snapshotted, `install --hooks` is what created it, and
+// uninstall that leaves an empty `.enola/` behind is not the byte-for-byte reversal the
+// README promises.
+//
+// os.Remove is the guard as well as the mechanism — an output directory still holding a
+// baseline or a snapshot refuses to go, and those are the user's work, not the installer's
+// leftovers. The repoDir comparison covers an output directory configured as the
+// repository itself, which is not ours to remove under any circumstances.
+func clearHookHeartbeat(repoDir, outDir string) {
+	hookstate.Clear(outDir)
+	if filepath.Clean(outDir) != filepath.Clean(repoDir) {
+		_ = os.Remove(outDir)
+	}
 }
 
 // hookOutputDir resolves a repository's enola output directory without building an

--- a/pkg/command/install_test.go
+++ b/pkg/command/install_test.go
@@ -1,0 +1,66 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/hookstate"
+)
+
+// The heartbeat is the one thing `install --hooks` writes outside the agents' own config
+// files, and in a repository that has never been snapshotted it is also what creates the
+// output directory. Uninstall has to take both back, or the reversal stops one empty
+// directory short of complete.
+func TestClearHookHeartbeat_RemovesTheDirectoryItCreated(t *testing.T) {
+	repo := t.TempDir()
+	outDir := filepath.Join(repo, ".enola")
+
+	hookstate.RecordInstalled(outDir, "enola")
+	if _, err := os.Stat(hookstate.Path(outDir)); err != nil {
+		t.Fatalf("the heartbeat was not written: %v", err)
+	}
+
+	clearHookHeartbeat(repo, outDir)
+
+	if _, err := os.Stat(outDir); !os.IsNotExist(err) {
+		entries, _ := os.ReadDir(outDir)
+		t.Errorf("uninstall left the output directory behind (err=%v, %d entries)", err, len(entries))
+	}
+}
+
+// It is the emptiness that licenses the removal, never the uninstall. A baseline or a
+// snapshot in there is the user's work, and losing it to an uninstall would cost far more
+// than the empty directory this is here to clean up.
+func TestClearHookHeartbeat_KeepsAnOutputDirectoryHoldingWork(t *testing.T) {
+	repo := t.TempDir()
+	outDir := filepath.Join(repo, ".enola")
+
+	hookstate.RecordInstalled(outDir, "enola")
+	baseline := filepath.Join(outDir, "baseline.json")
+	if err := os.WriteFile(baseline, []byte(`{"pinned":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	clearHookHeartbeat(repo, outDir)
+
+	if _, err := os.Stat(baseline); err != nil {
+		t.Errorf("uninstall removed a pinned baseline: %v", err)
+	}
+	if _, err := os.Stat(hookstate.Path(outDir)); !os.IsNotExist(err) {
+		t.Errorf("the heartbeat survived an uninstall (err=%v)", err)
+	}
+}
+
+// An output directory configured as the repository itself is not ours to remove, however
+// empty it happens to be.
+func TestClearHookHeartbeat_NeverRemovesTheRepositoryItself(t *testing.T) {
+	repo := t.TempDir()
+
+	hookstate.RecordInstalled(repo, "enola")
+	clearHookHeartbeat(repo, repo)
+
+	if _, err := os.Stat(repo); err != nil {
+		t.Errorf("uninstall removed the repository directory: %v", err)
+	}
+}

--- a/pkg/install/fileops.go
+++ b/pkg/install/fileops.go
@@ -105,6 +105,49 @@ func writeOwnedFile(path, content string, dryRun bool) (Result, error) {
 	}
 }
 
+// removeOwnedFile deletes a file enola owns outright, and any directory left holding
+// nothing once it is gone.
+func removeOwnedFile(path, stop string, dryRun bool) (Result, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return Result{Path: path, Action: ActionUnchanged}, nil
+	}
+	if dryRun {
+		return Result{Path: path, Action: ActionRemoved}, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return Result{}, fmt.Errorf("removing %s: %w", path, err)
+	}
+	pruneEmptyDirs(filepath.Dir(path), stop)
+	return Result{Path: path, Action: ActionRemoved}, nil
+}
+
+// pruneEmptyDirs removes now-empty parent directories up to but excluding stop, so
+// uninstalling does not leave `.cursor/rules/` sitting there as the only trace of a tool
+// that is gone.
+//
+// os.Remove is the guard as well as the mechanism: it refuses to delete a non-empty
+// directory, so a `.claude/` that still holds the user's settings.json survives without
+// needing an explicit check for it.
+//
+// stop is a bound on what the tool is entitled to reverse, not an optimisation. Climbing
+// past the repository or the home directory would be one thing; more subtly, `~/.codex`
+// and `~/.pi` are directories enola never creates and whose existence is the evidence it
+// gates a global install on. Removing an empty one would delete something it did not
+// write, and change what the NEXT install decides. Those targets stop at their own root.
+func pruneEmptyDirs(dir, stop string) {
+	dir, stop = filepath.Clean(dir), filepath.Clean(stop)
+	for dir != stop {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return // reached the filesystem root without meeting stop
+		}
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+		dir = parent
+	}
+}
+
 // upsertSection replaces, appends, or leaves alone an enola-owned block inside a file the
 // user also maintains.
 //
@@ -153,8 +196,10 @@ func upsertSection(path, block string, dryRun bool) (Result, error) {
 	}
 }
 
-// removeSection strips enola's block, leaving everything else byte-identical.
-func removeSection(path string, dryRun bool) (Result, error) {
+// removeSection strips enola's block, leaving everything else byte-identical. stop bounds
+// the directory pruning that follows if the file turns out to have held nothing else; see
+// pruneEmptyDirs.
+func removeSection(path, stop string, dryRun bool) (Result, error) {
 	raw, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return Result{Path: path, Action: ActionUnchanged}, nil
@@ -178,7 +223,8 @@ func removeSection(path string, dryRun bool) (Result, error) {
 	}
 
 	// A file that exists only because enola created it is removed outright rather than
-	// left behind as an empty artifact of a tool that is no longer installed.
+	// left behind as an empty artifact of a tool that is no longer installed — and with it
+	// any directory that existed only to hold it.
 	if strings.TrimSpace(updated) == "" {
 		if dryRun {
 			return Result{Path: path, Action: ActionRemoved}, nil
@@ -186,6 +232,7 @@ func removeSection(path string, dryRun bool) (Result, error) {
 		if err := os.Remove(path); err != nil {
 			return Result{}, fmt.Errorf("removing %s: %w", path, err)
 		}
+		pruneEmptyDirs(filepath.Dir(path), stop)
 		return Result{Path: path, Action: ActionRemoved}, nil
 	}
 	return applySection(path, content, updated, ActionUpdated, dryRun)
@@ -215,7 +262,10 @@ func applySection(path, before, after string, action Action, dryRun bool) (Resul
 //     of churning the file and its mtime.
 //   - mutate receives the whole document and edits in place, so every key enola does not
 //     know about survives untouched.
-func mutateJSON(path string, mutate func(doc map[string]any), dryRun bool) (Result, error) {
+//
+// stop bounds the directory pruning that follows if the mutation empties the file; see
+// pruneEmptyDirs.
+func mutateJSON(path, stop string, mutate func(doc map[string]any), dryRun bool) (Result, error) {
 	doc := map[string]any{}
 	existed := false
 
@@ -256,11 +306,27 @@ func mutateJSON(path string, mutate func(doc map[string]any), dryRun bool) (Resu
 	if string(before) == string(afterCompact) && existed {
 		return Result{Path: path, Action: ActionUnchanged}, nil
 	}
-	// Nothing to say and no file to say it in. Without this, uninstalling from a project
-	// that never had hooks CREATED an empty settings.json — and with it the .claude
-	// directory — so removing enola left more behind than installing it without hooks did.
+	// An empty document has two forms and both once left residue behind.
+	//
+	// Nothing to say and no file to say it in: uninstalling from a project that never had
+	// hooks CREATED an empty settings.json, and with it the .claude directory, so removing
+	// enola left more behind than installing it without hooks did.
 	if !existed && len(doc) == 0 {
 		return Result{Path: path, Action: ActionUnchanged}, nil
+	}
+	// Or the mutation emptied a file enola had created: writing `{}` back left a scaffold
+	// configuring nothing, plus the directory around it, advertising a tool that is gone.
+	// Reaching here means the mutation actually removed something — a `{}` enola never
+	// touched compares equal above and is reported unchanged, never deleted.
+	if len(doc) == 0 {
+		if dryRun {
+			return Result{Path: path, Action: ActionRemoved}, nil
+		}
+		if err := os.Remove(path); err != nil {
+			return Result{}, fmt.Errorf("removing %s: %w", path, err)
+		}
+		pruneEmptyDirs(filepath.Dir(path), stop)
+		return Result{Path: path, Action: ActionRemoved}, nil
 	}
 
 	action := ActionUpdated

--- a/pkg/install/hooks.go
+++ b/pkg/install/hooks.go
@@ -61,14 +61,14 @@ func HookSummary() []string {
 
 // writeHooks merges enola's hooks into Claude Code's settings.json, or removes them.
 func writeHooks(o Options, remove bool) ([]Result, error) {
-	return writeHooksAt(filepath.Join(claudeDir(o), "settings.json"), o, remove, claudeHookEntry)
+	return writeHooksAt(filepath.Join(claudeDir(o), "settings.json"), pruneStop(o), o, remove, claudeHookEntry)
 }
 
 // writeCodexHooks merges hooks into Codex's hooks.json. Codex uses the same matcher-group
 // envelope as Claude, but its command handler contract differs: async is required and the
 // timeout field is named timeoutSec.
-func writeCodexHooks(path string, o Options, remove bool) ([]Result, error) {
-	return writeHooksAt(path, o, remove, codexHookEntry)
+func writeCodexHooks(path, stop string, o Options, remove bool) ([]Result, error) {
+	return writeHooksAt(path, stop, o, remove, codexHookEntry)
 }
 
 type hookEntry func(command string) map[string]any
@@ -95,8 +95,8 @@ func codexHookEntry(command string) map[string]any {
 // writeHooksAt shares the matcher-group merge mechanics while allowing each agent to
 // encode command handlers according to its own schema. Only entries carrying
 // enolaHookMarker are ever replaced or removed.
-func writeHooksAt(path string, o Options, remove bool, makeEntry hookEntry) ([]Result, error) {
-	r, err := mutateJSON(path, func(doc map[string]any) {
+func writeHooksAt(path, stop string, o Options, remove bool, makeEntry hookEntry) ([]Result, error) {
+	r, err := mutateJSON(path, stop, func(doc map[string]any) {
 		hooks, _ := doc["hooks"].(map[string]any)
 		if hooks == nil {
 			if remove {

--- a/pkg/install/hooks_shape_test.go
+++ b/pkg/install/hooks_shape_test.go
@@ -19,7 +19,9 @@ import (
 // against the same belief that produced it. That job belongs to the end-to-end test
 // in hooks_e2e_test.go, which ends a real session and looks for the verdict.
 
-// settingsAfter runs an install (or uninstall) and returns the parsed hooks map.
+// settingsAfter runs an install (or uninstall) and returns the parsed hooks map. A
+// settings.json that is gone means no hooks, which is a legitimate outcome of an
+// uninstall: a file left holding nothing is removed rather than emptied.
 func settingsAfter(t *testing.T, o Options, remove bool) map[string]any {
 	t.Helper()
 	var err error
@@ -32,6 +34,9 @@ func settingsAfter(t *testing.T, o Options, remove bool) map[string]any {
 		t.Fatal(err)
 	}
 	raw, err := os.ReadFile(filepath.Join(o.RepoDir, ".claude", "settings.json"))
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		t.Fatalf("reading settings.json: %v", err)
 	}
@@ -199,14 +204,10 @@ func TestUninstall_RemovesTheLegacyFlatStopEntry(t *testing.T) {
 	if len(hooks) != 0 {
 		t.Errorf("uninstall left hooks behind:\n%#v", hooks)
 	}
-	if raw, err := os.ReadFile(path); err == nil && len(raw) > 0 {
-		var doc map[string]any
-		if err := json.Unmarshal(raw, &doc); err != nil {
-			t.Fatal(err)
-		}
-		if _, present := doc["hooks"]; present {
-			t.Errorf("an empty hooks object was left behind:\n%s", raw)
-		}
+	// These settings held nothing but enola's hooks, so the file goes with them rather
+	// than surviving as an empty `{}` scaffold.
+	if raw, err := os.ReadFile(path); err == nil {
+		t.Errorf("uninstall left a settings.json holding only enola's hooks behind:\n%s", raw)
 	}
 }
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -142,6 +142,16 @@ func codexDir(o Options) string {
 	return filepath.Join(o.RepoDir, ".codex")
 }
 
+// codexPruneStop keeps uninstall from removing `~/.codex` itself. Globally that directory
+// is Codex's, and enola only writes into it because it was already there; locally enola
+// creates `.codex/` in the repository, so an empty one goes with the files it held.
+func codexPruneStop(o Options) string {
+	if o.Scope == ScopeGlobal {
+		return codexDir(o)
+	}
+	return o.RepoDir
+}
+
 // codexTarget combines Codex's AGENTS.md block with its own hooks.json. Global scope
 // only writes hooks.json when ~/.codex already exists, same rule as globalAgentsTarget.
 func codexTarget(o Options, remove bool) ([]Result, error) {
@@ -163,7 +173,7 @@ func codexTarget(o Options, remove bool) ([]Result, error) {
 	if !remove && !o.Hooks {
 		return out, nil
 	}
-	hr, err := writeCodexHooks(path, o, remove)
+	hr, err := writeCodexHooks(path, codexPruneStop(o), o, remove)
 	if err != nil {
 		return nil, err
 	}
@@ -188,13 +198,14 @@ func globalAgentsTarget(o Options, remove bool, tool, rel string) ([]Result, err
 		}}, nil
 	}
 	path := filepath.Join(o.HomeDir, rel)
+	// filepath.Dir of ".pi/agent/AGENTS.md" is ".pi/agent"; require the tool's ROOT dir,
+	// which is the part that says the tool exists. It doubles as the pruning bound on the
+	// way out: `~/.pi/agent/` is enola's to remove, `~/.pi/` is not.
+	root := filepath.Join(o.HomeDir, strings.SplitN(rel, string(filepath.Separator), 2)[0])
 	if remove {
-		r, err := removeSection(path, o.DryRun)
+		r, err := removeSection(path, root, o.DryRun)
 		return []Result{r}, err
 	}
-	// filepath.Dir of ".pi/agent/AGENTS.md" is ".pi/agent"; require the tool's ROOT dir,
-	// which is the part that says the tool exists.
-	root := filepath.Join(o.HomeDir, strings.SplitN(rel, string(filepath.Separator), 2)[0])
 	if _, err := os.Stat(root); os.IsNotExist(err) {
 		return []Result{{
 			Path:   path,
@@ -224,7 +235,7 @@ func copilotTarget(o Options, remove bool) ([]Result, error) {
 	}
 	path := filepath.Join(o.RepoDir, ".github", "instructions", "enola.instructions.md")
 	if remove {
-		r, err := removeOwnedFile(path, o.DryRun)
+		r, err := removeOwnedFile(path, o.RepoDir, o.DryRun)
 		return []Result{r}, err
 	}
 	r, err := writeOwnedFile(path, copilotInstructions(o), o.DryRun)
@@ -249,7 +260,7 @@ func claudeTarget(o Options, remove bool) ([]Result, error) {
 	rule := filepath.Join(claudeDir(o), "rules", "enola.md")
 
 	if remove {
-		r, err := removeOwnedFile(rule, o.DryRun)
+		r, err := removeOwnedFile(rule, pruneStop(o), o.DryRun)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +302,7 @@ func cursorTarget(o Options, remove bool) ([]Result, error) {
 	}
 	path := filepath.Join(o.RepoDir, ".cursor", "rules", "enola.mdc")
 	if remove {
-		r, err := removeOwnedFile(path, o.DryRun)
+		r, err := removeOwnedFile(path, o.RepoDir, o.DryRun)
 		return []Result{r}, err
 	}
 	r, err := writeOwnedFile(path, cursorRule(o), o.DryRun)
@@ -314,7 +325,7 @@ func agentsTarget(o Options, remove bool) ([]Result, error) {
 	}
 	path := filepath.Join(o.RepoDir, "AGENTS.md")
 	if remove {
-		r, err := removeSection(path, o.DryRun)
+		r, err := removeSection(path, o.RepoDir, o.DryRun)
 		return []Result{r}, err
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -329,31 +340,12 @@ func agentsTarget(o Options, remove bool) ([]Result, error) {
 	return []Result{r}, err
 }
 
-func removeOwnedFile(path string, dryRun bool) (Result, error) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return Result{Path: path, Action: ActionUnchanged}, nil
+// pruneStop is the directory an uninstall's pruning must not climb past: the repository
+// for a local install, the home directory for a global one. Targets whose install is
+// gated on a directory it did not create pass that directory instead — see codexRoot.
+func pruneStop(o Options) string {
+	if o.Scope == ScopeGlobal {
+		return o.HomeDir
 	}
-	if dryRun {
-		return Result{Path: path, Action: ActionRemoved}, nil
-	}
-	if err := os.Remove(path); err != nil {
-		return Result{}, fmt.Errorf("removing %s: %w", path, err)
-	}
-	pruneEmptyDirs(filepath.Dir(path), 2)
-	return Result{Path: path, Action: ActionRemoved}, nil
-}
-
-// pruneEmptyDirs removes up to `levels` now-empty parent directories, so uninstalling
-// does not leave `.cursor/rules/` sitting there as the only trace of a tool that is gone.
-//
-// os.Remove is the guard as well as the mechanism: it refuses to delete a non-empty
-// directory, so a `.claude/` that still holds the user's settings.json survives without
-// needing an explicit check for it.
-func pruneEmptyDirs(dir string, levels int) {
-	for i := 0; i < levels; i++ {
-		if err := os.Remove(dir); err != nil {
-			return
-		}
-		dir = filepath.Dir(dir)
-	}
+	return o.RepoDir
 }

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -2,8 +2,11 @@ package install
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -399,22 +402,154 @@ func TestInstall_DryRunWritesNothing(t *testing.T) {
 	}
 }
 
-// TestUninstall_LeavesNoResidue — an installer that leaves empty directories behind
-// advertises a tool that is no longer there.
+// TestUninstall_LeavesNoResidue — an installer that leaves empty files and directories
+// behind advertises a tool that is no longer there.
+//
+// The hooks axis is the point. This test used to run without --hooks, so it never reached
+// the two JSON configs, and uninstall shipped leaving `.claude/settings.json` and
+// `.codex/hooks.json` behind as `{}` scaffolds — with their directories — while the test
+// named exactly the property they broke.
 func TestUninstall_LeavesNoResidue(t *testing.T) {
-	o := opts(t, false)
+	for _, hooks := range []bool{false, true} {
+		t.Run(fmt.Sprintf("hooks=%v", hooks), func(t *testing.T) {
+			o := opts(t, hooks)
+			if _, err := Install(o); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Uninstall(o); err != nil {
+				t.Fatal(err)
+			}
+			for _, path := range residue(t, o.RepoDir) {
+				t.Errorf("uninstall left %q behind", path)
+			}
+		})
+	}
+}
+
+// TestUninstall_GlobalLeavesNoResidueBeyondTheToolsOwnRoots — the same property in the
+// home directory, where the bound on reversal is different: `~/.codex` and `~/.pi` are
+// evidence those tools are installed, enola never creates them, and it gates its own
+// global install on finding them. It may empty them; it may not remove them.
+func TestUninstall_GlobalLeavesNoResidueBeyondTheToolsOwnRoots(t *testing.T) {
+	o := opts(t, true)
+	o.Scope = ScopeGlobal
+	for _, d := range []string{".codex", filepath.Join(".pi", "agent")} {
+		if err := os.MkdirAll(filepath.Join(o.HomeDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	if _, err := Install(o); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := Uninstall(o); err != nil {
 		t.Fatal(err)
 	}
-	entries, err := os.ReadDir(o.RepoDir)
+
+	for _, path := range residue(t, o.HomeDir) {
+		if path == ".codex" || path == ".pi" {
+			continue
+		}
+		t.Errorf("uninstall left %q behind in the home directory", path)
+	}
+	for _, root := range []string{".codex", ".pi"} {
+		if _, err := os.Stat(filepath.Join(o.HomeDir, root)); err != nil {
+			t.Errorf("uninstall removed %s, a directory enola never created: %v", root, err)
+		}
+	}
+}
+
+// residue lists every path left under root, relative and slash-separated.
+func residue(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	if err := filepath.WalkDir(root, func(path string, _ fs.DirEntry, err error) error {
+		if err != nil || path == root {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// TestUninstall_LeavesAnUntouchedEmptyConfigAlone — the removal of an emptied config is
+// bounded by having emptied it. A settings.json a user happens to have left at `{}` is
+// not enola's residue, and deleting it would be reversing something it never did.
+func TestUninstall_LeavesAnUntouchedEmptyConfigAlone(t *testing.T) {
+	o := opts(t, false)
+	settings := filepath.Join(o.RepoDir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settings, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rs, err := Uninstall(o)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, e := range entries {
-		t.Errorf("uninstall left %q behind", e.Name())
+	if a, _ := actionFor(rs, "settings.json"); a != ActionUnchanged {
+		t.Errorf("action = %q, want %q for a config enola never wrote to", a, ActionUnchanged)
+	}
+	if got := read(t, settings); got != "{}\n" {
+		t.Errorf("a hand-written empty settings.json was rewritten: %q", got)
+	}
+}
+
+// TestUninstall_KeepsAConfigStillHoldingTheUsersOwnSettings — the file is removed because
+// it is empty, never because enola is leaving.
+func TestUninstall_KeepsAConfigStillHoldingTheUsersOwnSettings(t *testing.T) {
+	o := opts(t, true)
+	settings := filepath.Join(o.RepoDir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settings, []byte(`{"permissions": {"allow": ["Bash(npm test)"]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Install(o); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Uninstall(o); err != nil {
+		t.Fatal(err)
+	}
+	got := read(t, settings)
+	if !strings.Contains(got, "Bash(npm test)") {
+		t.Errorf("uninstall removed a settings.json holding the user's own config:\n%s", got)
+	}
+}
+
+// TestUninstall_DryRunRemovesNothing — the preview must be a preview on the way out too,
+// and it must still report the removals it would make, or the confirmation prompt would
+// describe an uninstall that does less than it does.
+func TestUninstall_DryRunRemovesNothing(t *testing.T) {
+	o := opts(t, true)
+	if _, err := Install(o); err != nil {
+		t.Fatal(err)
+	}
+	before := residue(t, o.RepoDir)
+
+	o.DryRun = true
+	rs, err := Uninstall(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"settings.json", filepath.Join(".codex", "hooks.json")} {
+		if a, ok := actionFor(rs, name); !ok || a != ActionRemoved {
+			t.Errorf("%s action = %q, want %q", name, a, ActionRemoved)
+		}
+	}
+	if after := residue(t, o.RepoDir); !slices.Equal(before, after) {
+		t.Errorf("dry-run uninstall changed the tree:\nbefore %v\nafter  %v", before, after)
 	}
 }
 


### PR DESCRIPTION
Stripping enola's keys from a hook config left `{}` and its directory behind. A config the mutation empties is now removed, all three removal paths prune what they emptied, and the heartbeat's output directory goes with it when nothing else is in there.

Pruning stops at any directory whose existence gates the install: enola never creates those and reads them to decide whether the tool is present, so removing an empty one would reverse something it never did.