### PR TITLE
updatecheck: write the cache from any command, and notice on the fata…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ Copilot's `.vscode/mcp.json` uses `servers` as the top-level key instead of `mcp
 enola doctor
 ```
 
-Worth running once. A hook configuration is a contract with your agent, and one it quietly ignores looks exactly like one it honours - `doctor` reports whether the hooks *fired*, not whether they're configured.
+A report, not a gate - it always exits `0`. It is the fastest way to find out that something has gone quietly wrong:
+
+- **whether the hooks fired.** A hook configuration is a contract with your agent, and one it silently ignores looks exactly like one it honours, so `doctor` reports when each hook last ran rather than whether it is configured.
+- **whether your baseline still counts.** One pinned by a different enola version, or under different ignore rules, is not comparable - and nothing is graded against it until you re-pin.
+- **whether there is a newer release** - and specifically whether the **extractors** changed, which means your snapshots are missing facts a current build would find. `enola upgrade` installs it.
 
 ### Not using an agent?
 

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -179,6 +179,12 @@ func main() {
 			log.Fatalf("failed to resolve repo path: %v", err)
 		}
 
+		// `--generate` is not a subcommand, so it never passes through Dispatch and would
+		// otherwise be the one CLI path that reads the update cache (below) without ever
+		// writing it. Started before the snapshot rather than after, so the check has the
+		// whole run to complete and the notice can be current on this run, not the next.
+		command.SpawnUpdateRefresh()
+
 		var snapshot *facts.Snapshot
 		for i, repoPath := range repoPaths {
 			// The first repository resets the store; the rest append to it, which is

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -395,9 +395,9 @@ Every path argument follows the same rule: **a directory is a repository, a file
 
 enola releases often, so it tells you when you are behind — without ever making you wait on the network.
 
-A background check runs at most once every 12 hours and caches its answer in `~/.enola/update.json`. Every notice you see is a read of that file, so no command ever blocks on a request, and a machine with no network behaves exactly like one that is up to date. The check itself runs only where nothing is waiting on it: the detached session-start hook, and the MCP server's startup.
+A background check runs at most once every 12 hours and caches its answer in `~/.enola/update.json`. Every notice you see is a read of that file, so no command ever blocks on a request, and a machine with no network behaves exactly like one that is up to date. The check itself runs only where nothing is waiting on it: a detached child process any enola command starts when the cache is due, the session-start hook, and the MCP server's startup. The child is what makes the notice reach a shell-only install - one that has no agent hooks and never starts a server still gets told.
 
-When a newer release exists, `check`, `--generate` and `doctor` print one line on **stderr** (never stdout, so `--json` output stays a clean document), and `enola upgrade` installs it:
+When a newer release exists, `check`, `--generate` and `doctor` print one line on **stderr** (never stdout, so `--json` output stays a clean document), and `enola upgrade` installs it. A command that fails outright prints it too, after the error: when the extractors have moved, an old build detecting no language is not a fact about your repository, and `snapshot produced no facts` deserves the line that explains it.
 
 ```
 enola v0.3.12 is available (you have v0.3.2) — extractors changed since your build,

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -177,6 +177,27 @@ func Refresh(ctx context.Context) {
 	write(path, state{CheckedAt: time.Now().UTC().Truncate(time.Second), Manifest: m})
 }
 
+// Due reports whether a Refresh would do any work: notices are allowed here, and the
+// cache is missing or older than ttl.
+//
+// It exists so a command on the critical path can decide whether a background refresh is
+// worth spawning a process for, WITHOUT doing the refresh itself. It reads one small file
+// and never touches the network, so asking is free; the answer is true at most once per
+// ttl on a machine that keeps refreshing.
+//
+// Racing is harmless and deliberate: two commands started inside the same second both see
+// true and both spawn, and the loser of Refresh's non-blocking lock exits immediately.
+func Due() bool {
+	if Suppressed() {
+		return false
+	}
+	path, err := cachePath()
+	if err != nil {
+		return false
+	}
+	return !fresh(path)
+}
+
 // For reports what to tell a build running extractorVersion. It reads only the cache
 // and never blocks.
 //

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -328,8 +328,8 @@ func TestNewer(t *testing.T) {
 		current, latest string
 		want            bool
 	}{
-		{"0.3.2", "0.3.12", true},   // not a string comparison: "0.3.12" < "0.3.2" lexically
-		{"0.3.12", "0.3.2", false},  // and the reverse must not fire either
+		{"0.3.2", "0.3.12", true},  // not a string comparison: "0.3.12" < "0.3.2" lexically
+		{"0.3.12", "0.3.2", false}, // and the reverse must not fire either
 		{"0.3.12", "0.3.12", false},
 		{"0.9.9", "1.0.0", true},
 		{"1.0.0", "0.9.9", false},
@@ -424,4 +424,45 @@ func TestFprintWritesNothingWhenSilent(t *testing.T) {
 	if sb.String() != "" {
 		t.Errorf("Fprint wrote %q with nothing to report; callers rely on it being a no-op", sb.String())
 	}
+}
+
+// Due decides whether a command on the critical path spawns a process at all, so its
+// false answers matter as much as its true ones: too eager and every enola command pays
+// a fork, too shy and the cache is never written and every reading surface stays blank.
+func TestDue(t *testing.T) {
+	t.Run("no cache", func(t *testing.T) {
+		isolate(t, "0.3.2")
+		// The state a fresh install is in — and the one that made the notice unreachable
+		// for anyone without agent hooks or an MCP server.
+		if !Due() {
+			t.Error("Due() = false with no cache, so nothing would ever write the first one")
+		}
+	})
+
+	t.Run("fresh cache", func(t *testing.T) {
+		path := isolate(t, "0.3.2")
+		seed(t, path, state{CheckedAt: time.Now().UTC(), Manifest: Manifest{Version: "0.3.12"}})
+		if Due() {
+			t.Error("Due() = true inside the TTL; every command would spawn a refresh child")
+		}
+	})
+
+	t.Run("stale cache", func(t *testing.T) {
+		path := isolate(t, "0.3.2")
+		seed(t, path, state{CheckedAt: time.Now().UTC().Add(-ttl - time.Minute), Manifest: Manifest{Version: "0.3.12"}})
+		if !Due() {
+			t.Error("Due() = false past the TTL, so the notice would freeze at the first answer found")
+		}
+	})
+
+	// Suppression has to be answered HERE rather than only inside Refresh: the point of
+	// asking is to avoid the spawn, and a CI run that forks a process per enola command
+	// to reach a check it then declines to make has paid the cost for nothing.
+	t.Run("suppressed", func(t *testing.T) {
+		isolate(t, "0.3.2")
+		t.Setenv("CI", "true")
+		if Due() {
+			t.Error("Due() = true under CI, so the spawn happens for a check that cannot report")
+		}
+	})
 }

--- a/pkg/command/check.go
+++ b/pkg/command/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -290,8 +291,25 @@ func (r *Runner) checkFatal(format string, args ...any) { r.cmdFatal("check", fo
 // because the command did not run at all. The command name is a parameter so a shared
 // helper cannot misattribute an error to the wrong subcommand.
 func (r *Runner) cmdFatal(cmd, format string, args ...any) {
-	fmt.Fprintf(os.Stderr, r.name()+" "+cmd+": "+format+"\n", args...)
+	r.writeFatal(os.Stderr, cmd, format, args...)
 	os.Exit(check.StatusUsageError.ExitCode())
+}
+
+// writeFatal renders the failure. Split from cmdFatal only because cmdFatal ends in
+// os.Exit, which no test can call and return from.
+//
+// THE UPDATE NOTICE BELONGS ON THIS PATH, not only on the successful one. An operational
+// failure is the case where being behind the release stream is most likely to be the
+// CAUSE rather than a footnote: when the extractors have moved, an old build detects no
+// language where a current one detects several, and the run dies here with "snapshot
+// produced no facts" and a wall of "extractor X: not detected". Withholding the one line
+// that explains that — because the command failed — leaves someone debugging a
+// repository that is fine.
+//
+// After the error, never before it: what failed is what they need first.
+func (r *Runner) writeFatal(w io.Writer, cmd, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, r.name()+" "+cmd+": "+format+"\n", args...)
+	updatecheck.Fprint(w, engine.ExtractorVersion())
 }
 
 // runBaseline is `enola baseline pin|show|clear` — the CLI half of the loop, so the

--- a/pkg/command/check_fatal_test.go
+++ b/pkg/command/check_fatal_test.go
@@ -1,0 +1,52 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/pkg/cli"
+)
+
+// An operational failure is where the notice EARNS its place: a build whose extractors
+// are behind detects no language where a current one detects several, and the run dies
+// with "snapshot produced no facts" — an error about the repository, whose actual cause
+// is the binary. So the fatal path carries the notice too, and this test is what keeps it
+// there, because nothing about the code reads as though it should.
+func TestFatalCarriesTheUpdateNotice(t *testing.T) {
+	seedUpdateCache(t, "0.3.12", "v999")
+
+	var sb strings.Builder
+	New(cli.Binary{Name: "enola"}, "upgrade").
+		writeFatal(&sb, "check", "snapshot produced no facts for %s", "/repo")
+	out := sb.String()
+
+	if !strings.Contains(out, "enola check: snapshot produced no facts for /repo") {
+		t.Fatalf("the failure itself is missing:\n%s", out)
+	}
+	if !strings.Contains(out, "v0.3.12 is available") {
+		t.Fatalf("no update notice on the fatal path, which is the path most likely to be caused by one:\n%s", out)
+	}
+	if !strings.Contains(out, "extractors changed") {
+		t.Errorf("the extractor escalation is dropped here, and it is the half that explains a no-facts failure:\n%s", out)
+	}
+
+	// Order is load-bearing. What failed is what they came for; the notice is context for
+	// it, and a housekeeping line printed first reads as the error.
+	if strings.Index(out, "produced no facts") > strings.Index(out, "is available") {
+		t.Errorf("the update notice precedes the failure it annotates:\n%s", out)
+	}
+}
+
+// The other half of the contract: an unremarkable failure on an up-to-date build stays a
+// bare error. This is what stops the fatal path from growing a permanent second line.
+func TestFatalSaysNothingExtraWhenCurrent(t *testing.T) {
+	seedUpdateCache(t, "", "") // isolated HOME, no cache — an offline or fresh install
+
+	var sb strings.Builder
+	New(cli.Binary{Name: "enola"}, "upgrade").
+		writeFatal(&sb, "check", "%q is not a directory", "/nope")
+
+	if got := sb.String(); got != "enola check: \"/nope\" is not a directory\n" {
+		t.Errorf("fatal output = %q, want the error alone", got)
+	}
+}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/enola-labs/enola/internal/config"
@@ -119,6 +120,20 @@ func (r *Runner) Dispatch(ctx context.Context, args []string) bool {
 	if len(args) == 0 {
 		return false
 	}
+
+	// Refresh the update cache from here, because this is the one place every shared
+	// subcommand passes through: putting it in each command instead would make the notice
+	// depend on which command someone happens to run, which is how it came to depend on
+	// having agent hooks installed in the first place.
+	//
+	// Excluding `hook`: it refreshes inside the detached child it already starts, and its
+	// contract is to add nothing to session-start latency — not even one spawn. Excluding
+	// unrecognised arguments too, so a typo does not start a process before being told it
+	// was a typo.
+	if args[0] != "hook" && slices.Contains(Subcommands(), args[0]) {
+		SpawnUpdateRefresh()
+	}
+
 	switch args[0] {
 	case "check":
 		r.Check(ctx, args[1:]) // exits with the verdict's code

--- a/pkg/command/hook.go
+++ b/pkg/command/hook.go
@@ -54,6 +54,11 @@ func (r *Runner) Hook(ctx context.Context, args []string) {
 		r.runStopHook(ctx)
 	case "session-start":
 		r.runSessionStartHook(ctx, args[1:])
+	case updateRefreshEvent:
+		// The detached child SpawnUpdateRefresh starts. Nothing else: no engine, no
+		// repository, no output. It is a hook event only to inherit this dispatcher's
+		// silence and its unconditional exit 0.
+		updatecheck.Refresh(ctx)
 	default:
 		// An event this build does not know about is not an error: a newer install may
 		// have written config a older binary does not understand.

--- a/pkg/command/update.go
+++ b/pkg/command/update.go
@@ -1,0 +1,57 @@
+package command
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/enola-labs/enola/internal/updatecheck"
+)
+
+// updateRefreshEvent is the hook event that performs the refresh. It lives in the `hook`
+// namespace because that is where enola's unattended, silent, always-exit-0 work already
+// lives — the rules this needs are the rules that namespace already enforces.
+//
+// It is not documented as a command anyone types. `enola hook <unknown>` is a no-op by
+// design, so a future build that drops this event is not a build that breaks on it.
+const updateRefreshEvent = "update-check"
+
+// SpawnUpdateRefresh starts a detached child that refreshes the update cache, and returns
+// immediately. It is the WRITE side of the update check; every other surface only reads
+// the file this child writes.
+//
+// It exists because the two original writers do not cover the person most in need of the
+// notice. Refresh ran in exactly two places — the session-start hook's detached child and
+// the MCP server's boot goroutine — so someone who installs the binary and runs `enola
+// check` from a shell, with no agent hooks installed and no MCP server, never wrote a
+// cache and therefore was never told anything. Every reading surface was live and every
+// one of them read an empty file, indefinitely. That is the failure this closes: the
+// notice was not wrong, it was unreachable.
+//
+// The spawn, not a call: the package's founding rule is that no command a person waits on
+// may contain the network. A detached child costs one process spawn, is independent of
+// how slow the network is, and cannot delay or fail the command that started it. Due()
+// gates the spawn so the cost is paid at most once per ttl rather than on every command.
+//
+// Silent throughout, like everything else here — a caller invokes it for effect and has
+// nothing to do about a failure to check for updates.
+func SpawnUpdateRefresh() {
+	if !detachable || !updatecheck.Due() {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, "hook", updateRefreshEvent)
+	// No stdio. The child outlives this command, and an inherited stderr would let it
+	// write into a terminal that has already moved on to the next prompt.
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
+	detach(cmd)
+	// Start, never Wait: waiting is precisely what detaching exists to avoid.
+	_ = spawn(cmd)
+}
+
+// spawn is exec.Cmd.Start, indirected so a test can see the child that WOULD be started
+// without starting one — os.Executable() under `go test` is the test binary, and a test
+// that really forked it would re-enter the suite as `hook update-check`.
+var spawn = func(cmd *exec.Cmd) error { return cmd.Start() }

--- a/pkg/command/update_test.go
+++ b/pkg/command/update_test.go
@@ -1,0 +1,66 @@
+package command
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// captureSpawn swaps the process starter for one that records the argument lists it was
+// handed and starts nothing.
+func captureSpawn(t *testing.T) *[][]string {
+	t.Helper()
+	var got [][]string
+	prev := spawn
+	spawn = func(cmd *exec.Cmd) error {
+		got = append(got, cmd.Args[1:]) // args[0] is the executable path
+		return nil
+	}
+	t.Cleanup(func() { spawn = prev })
+	return &got
+}
+
+// The child must be started with the arguments the hook dispatcher actually routes.
+// Nothing else connects these two — a renamed event would leave the spawner starting a
+// process that this binary silently treats as an unknown hook and exits 0 from, which is
+// indistinguishable from the check simply never finding an update.
+func TestSpawnUpdateRefreshStartsTheRefreshChild(t *testing.T) {
+	got := captureSpawn(t)
+	seedUpdateCache(t, "", "") // isolated HOME, no cache: a refresh is due
+
+	SpawnUpdateRefresh()
+
+	if len(*got) != 1 {
+		t.Fatalf("started %d child processes with no cache present, want 1", len(*got))
+	}
+	if want := "hook " + updateRefreshEvent; strings.Join((*got)[0], " ") != want {
+		t.Errorf("child args = %q, want %q", (*got)[0], want)
+	}
+}
+
+// The gate is the whole reason this is affordable on the critical path. Without it every
+// enola command would fork a process to re-answer a question already answered on disk.
+func TestSpawnUpdateRefreshIsGated(t *testing.T) {
+	t.Run("cache is fresh", func(t *testing.T) {
+		got := captureSpawn(t)
+		seedUpdateCache(t, "0.3.12", "v999") // written just now, so inside the TTL
+
+		SpawnUpdateRefresh()
+
+		if len(*got) != 0 {
+			t.Errorf("started %d child processes with a fresh cache, want 0", len(*got))
+		}
+	})
+
+	t.Run("suppressed", func(t *testing.T) {
+		got := captureSpawn(t)
+		seedUpdateCache(t, "", "")
+		t.Setenv("CI", "true")
+
+		SpawnUpdateRefresh()
+
+		if len(*got) != 0 {
+			t.Errorf("started %d child processes under CI, where the result could not be reported anyway", len(*got))
+		}
+	})
+}


### PR DESCRIPTION
…l path

Refresh only ran in the session-start hook and the MCP server's boot, so an install with neither never wrote ~/.enola/update.json and every reading surface read an empty file forever. Commands now spawn a detached child to do it, so the network still never sits on a path anyone waits on.

cmdFatal prints the notice too: when the extractors have moved, an old build detecting no language is what produces "snapshot produced no facts", so the failure most likely to be caused by being behind was the one path staying silent.