### PR TITLE
fix(crossrepo): classify vendored OpenAPI specs as client routes

### DIFF
--- a/internal/facts/contract.go
+++ b/internal/facts/contract.go
@@ -205,6 +205,28 @@ var HandWrittenClientSources = map[string]bool{
 	RouteSourceDartHTTPClient:    true,
 }
 
+// NativeAppClientSources is the set of RouteSource values only a native application
+// emits — a mobile or desktop client that issues HTTP requests and cannot serve them.
+// The vendored-spec binder reads it as a POSITIVE marker: a repo containing one of
+// these ships an HTTP client, so an OpenAPI spec sitting in it describes an API the
+// repo CALLS, not one it serves.
+//
+// It lives here for the same reason HandWrittenClientSources does: membership is a
+// property of the source, so it is declared beside the constants extractors emit
+// rather than copied into the reader.
+//
+// The Java sources are deliberately absent. RouteSourceFeign and
+// RouteSourceJavaHTTPClient are emitted by Spring services that legitimately serve
+// endpoints while calling others, so their presence proves nothing about whether the
+// repo is a server — which is the entire question this set answers. Every member below
+// belongs to a platform that has no server story at all.
+var NativeAppClientSources = map[string]bool{
+	RouteSourceRetrofit:       true, // Kotlin/Java Retrofit service interface (Android)
+	RouteSourceURLSession:     true, // Swift URLSession (iOS/macOS)
+	RouteSourceSwiftEndpoint:  true, // Swift endpoint enum / protocol extension
+	RouteSourceDartHTTPClient: true, // Flutter package:http / dio / chopper / retrofit
+}
+
 // AllRouteSources is every registered RouteSource value. It exists for the conformance
 // test, which checks that no route fact in the golden corpus carries a source this file
 // does not know about — the check that catches a new extractor pass inventing a value

--- a/internal/linkers/binders/vendoredspecs/vendoredspecs.go
+++ b/internal/linkers/binders/vendoredspecs/vendoredspecs.go
@@ -1,0 +1,154 @@
+// Package vendoredspecs reclassifies OpenAPI specs that a client-only application
+// vendors for code generation: routes it CALLS, not routes it serves.
+//
+// THE BUG THIS FIXES. The OpenAPI extractor defaults every spec to role=server and
+// demotes to client only by directory convention (a "client" segment under an
+// "openapi" one). Backend repos follow that convention; mobile apps generally do not,
+// keeping each consumed service's spec in a per-feature openapi/ directory the code
+// generator reads. Every one of those was indexed as a SERVED endpoint, making the app
+// a match target for any repo calling the same paths: a mobile app that serves no HTTP
+// at all can collect inbound dependencies from most of the backends around it, plus a
+// crop of "endpoint no client calls" findings on routes it never served.
+//
+// WHY NOT A PATH RULE. The vendored specs sit in a bare openapi/ directory,
+// byte-identical in shape to a service's own spec directory; no path convention
+// separates them. And the tempting inverse — "a repo whose only server routes come
+// from OpenAPI is not a server" — is false: spec-first services exist whose entire
+// served surface is declared in api/openapi/*.yml and nowhere in code. Both shapes
+// occur in one estate, so the rule has to rest on positive evidence about the repo
+// rather than on the absence of evidence.
+package vendoredspecs
+
+import (
+	"context"
+	"log"
+
+	"github.com/enola-labs/enola/internal/facts"
+	"github.com/enola-labs/enola/pkg/plugin"
+)
+
+// PropVendoredSpec marks a route whose role this binder rewrote: an OpenAPI operation
+// that was extracted as server but belongs to a spec the repo vendors in order to CALL
+// it. Written rather than silently rewriting, so the change is auditable — the rewritten
+// set is query_facts(prop="vendored_spec"), and a prop appearing or disappearing shows up
+// in the snapshot diff. It is also what makes the rewrite reversible: see Bind.
+const PropVendoredSpec = "vendored_spec"
+
+// Binder demotes vendored OpenAPI server routes to client call sites in repos that
+// cannot serve HTTP.
+//
+// It is pre-link, and that is a correctness constraint rather than a preference. The
+// role it rewrites is read by routeindex.IndexServerRoutes, by both unmatched-route
+// passes and by the coverage counters; running after linking would leave every one of
+// them having already decided against a role this binder was about to change.
+type Binder struct{}
+
+func New() *Binder { return &Binder{} }
+
+func (b *Binder) Name() string { return "vendored-specs" }
+
+func (b *Binder) Stage() plugin.BindStage { return plugin.StagePreLink }
+
+// Bind rewrites the role of OpenAPI routes in client-only repos, and restores it in
+// repos that stop qualifying.
+//
+// Both directions are required by the Binder idempotency contract. Loading a repo that
+// later grows a real server (or re-extracting one under a corrected extractor) must not
+// leave the demotion behind, and PropVendoredSpec is what makes that possible: it marks
+// exactly the facts this binder rewrote, so restoring touches those and nothing else. A
+// genuine client spec — one the extractor itself classified from the openapi/client/
+// convention — carries no such mark and is therefore never "restored" into a server
+// route it never was.
+func (b *Binder) Bind(_ context.Context, store *facts.Store) error {
+	// FactsRef, not All: classify reads only, and finishes before UpdateWhere mutates
+	// anything. Copying the fact set here would duplicate every Props map on every
+	// snapshot, for a pass that writes to a few hundred facts at most.
+	clientOnly := clientOnlyRepos(store.FactsRef())
+
+	demoted, restored := 0, 0
+	store.UpdateWhere(func(f *facts.Fact) {
+		if f.Kind != facts.KindRoute || f.Repo == "" ||
+			f.PropString(facts.PropSource) != facts.RouteSourceOpenAPI {
+			return
+		}
+		wasRewritten, _ := f.Props[PropVendoredSpec].(bool)
+		// A spec the extractor already classified as a client spec is correct as it
+		// stands: leave it alone, and — crucially — do not let the restore branch below
+		// promote it to a server route it was never extracted as.
+		if !wasRewritten && f.PropString(facts.PropRole) == facts.RoleClient {
+			return
+		}
+		if clientOnly[f.Repo] {
+			if f.Props == nil {
+				f.Props = map[string]any{}
+			}
+			if !wasRewritten {
+				demoted++
+			}
+			f.Props[facts.PropRole] = facts.RoleClient
+			f.Props[PropVendoredSpec] = true
+			return
+		}
+		if wasRewritten {
+			f.Props[facts.PropRole] = facts.RoleServer
+			delete(f.Props, PropVendoredSpec)
+			restored++
+		}
+	})
+	if demoted > 0 || restored > 0 {
+		log.Printf("[binder:vendored-specs] reclassified %d vendored OpenAPI route(s) as client call sites, restored %d",
+			demoted, restored)
+	}
+	return nil
+}
+
+// clientOnlyRepos returns the repos whose OpenAPI specs must be vendored client
+// contracts, by the conjunction of two conditions:
+//
+//	∃ route{source ∈ facts.NativeAppClientSources}  — the repo ships a native-app
+//	                                                  HTTP client, so it is an app
+//	∄ route{role ≠ client, source ≠ openapi}        — and nothing outside a spec
+//	                                                  declares a served endpoint
+//
+// The first is positive evidence and does the real work: without it the second alone
+// would misclassify every spec-first backend, whose served surface is declared only in
+// its own OpenAPI files. The second is the guard that keeps a Kotlin or Swift repo that
+// genuinely serves something (a Ktor service, a Vapor app) out of the set.
+//
+// A route with no role counts as a server route, per the facts.RoleServer contract — an
+// extractor that found a declaration without a call site found a served endpoint. That
+// deliberately includes UI/page routes: a repo serving browser routes is a web app, and
+// leaving it untouched is the safe direction for a linker that everywhere prefers a
+// missing edge to a fabricated one.
+//
+// PropVendoredSpec needs no special handling here even though this runs over a store
+// that may already contain the binder's own output: only OpenAPI routes are ever
+// rewritten, and the second condition skips OpenAPI routes entirely. The classification
+// therefore reads the same before and after a demotion, which is what keeps the pass
+// stable across appends instead of self-reinforcing.
+func clientOnlyRepos(all []facts.Fact) map[string]bool {
+	nativeApp := map[string]bool{}
+	servesOutsideSpec := map[string]bool{}
+	for _, f := range all {
+		if f.Kind != facts.KindRoute || f.Repo == "" {
+			continue
+		}
+		src := f.PropString(facts.PropSource)
+		if facts.NativeAppClientSources[src] {
+			nativeApp[f.Repo] = true
+		}
+		if src == facts.RouteSourceOpenAPI {
+			continue
+		}
+		if f.PropString(facts.PropRole) != facts.RoleClient {
+			servesOutsideSpec[f.Repo] = true
+		}
+	}
+	out := map[string]bool{}
+	for repo := range nativeApp {
+		if !servesOutsideSpec[repo] {
+			out[repo] = true
+		}
+	}
+	return out
+}

--- a/internal/linkers/binders/vendoredspecs/vendoredspecs_test.go
+++ b/internal/linkers/binders/vendoredspecs/vendoredspecs_test.go
@@ -1,0 +1,192 @@
+package vendoredspecs
+
+// The binder answers one question per repo — can this repo serve HTTP at all? — and
+// rewrites its OpenAPI routes accordingly. The cases below are the two estates that
+// forced the rule's shape: a mobile app whose vendored specs must NOT be served
+// endpoints, and a spec-first backend whose identical-looking specs must stay served.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+func bind(t *testing.T, store *facts.Store) {
+	t.Helper()
+	if err := New().Bind(context.Background(), store); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+}
+
+func route(repo, name, source, role string) facts.Fact {
+	props := map[string]any{facts.PropSource: source, "method": "GET"}
+	if role != "" {
+		props[facts.PropRole] = role
+	}
+	return facts.Fact{Kind: facts.KindRoute, Name: name, Repo: repo, Props: props}
+}
+
+// roleOf returns the role and vendored-spec mark of the first route fact with the
+// given name, so a case can assert on the outcome without re-deriving indices.
+func roleOf(t *testing.T, store *facts.Store, name string) (string, bool) {
+	t.Helper()
+	for _, f := range store.All() {
+		if f.Name == name {
+			v, _ := f.Props[PropVendoredSpec].(bool)
+			return f.PropString(facts.PropRole), v
+		}
+	}
+	t.Fatalf("no fact named %q in store", name)
+	return "", false
+}
+
+// A mobile app vendors the specs of services it calls. Retrofit call sites are the
+// positive marker; nothing outside a spec declares a served endpoint.
+func TestDemotesVendoredSpecsInNativeApp(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("mobile-app", "/downstream/widgets", facts.RouteSourceRetrofit, facts.RoleClient),
+		route("mobile-app", "/widgets/{id}/details", facts.RouteSourceOpenAPI, facts.RoleServer),
+		route("mobile-app", "/sessions/{id}", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+
+	bind(t, store)
+
+	for _, name := range []string{"/widgets/{id}/details", "/sessions/{id}"} {
+		role, vendored := roleOf(t, store, name)
+		if role != facts.RoleClient {
+			t.Errorf("%s: role = %q, want %q", name, role, facts.RoleClient)
+		}
+		if !vendored {
+			t.Errorf("%s: %s not set — the rewrite must be auditable", name, PropVendoredSpec)
+		}
+	}
+}
+
+// The regression that matters most. A spec-first Go service declares its whole served
+// surface in api/openapi/*.yml and nothing in code, so it looks exactly like the mobile
+// case to any rule keyed on "server routes come only from OpenAPI". The native-app
+// marker is what tells them apart.
+func TestSpecFirstBackendUntouched(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("spec-first-svc", "/v1/query", facts.RouteSourceOpenAPI, facts.RoleServer),
+		route("spec-first-svc", "/v1/records", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+
+	bind(t, store)
+
+	for _, name := range []string{"/v1/query", "/v1/records"} {
+		role, vendored := roleOf(t, store, name)
+		if role != facts.RoleServer {
+			t.Errorf("%s: role = %q, want %q — a spec-first backend still serves its spec", name, role, facts.RoleServer)
+		}
+		if vendored {
+			t.Errorf("%s: %s was set on a repo with no native-app client", name, PropVendoredSpec)
+		}
+	}
+}
+
+// A Kotlin repo that both calls out via Retrofit and serves via Ktor is a server. The
+// second condition is what keeps it out of the set.
+func TestNativeClientThatAlsoServesUntouched(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("jvm-svc", "/downstream/items", facts.RouteSourceRetrofit, facts.RoleClient),
+		route("jvm-svc", "/internal/jobs", "ktor", facts.RoleServer),
+		route("jvm-svc", "/v1/orders", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+
+	bind(t, store)
+
+	if role, _ := roleOf(t, store, "/v1/orders"); role != facts.RoleServer {
+		t.Errorf("role = %q, want %q — the repo serves endpoints outside its spec", role, facts.RoleServer)
+	}
+}
+
+// A route with no role is a server route (see the facts.RoleServer contract), so a repo
+// whose only served declarations are role-less still counts as a server.
+func TestRoleLessRouteCountsAsServing(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("app", "/downstream/items", facts.RouteSourceRetrofit, facts.RoleClient),
+		route("app", "/pages/home", "rails", ""), // no role prop at all
+		route("app", "/v1/orders", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+
+	bind(t, store)
+
+	if role, _ := roleOf(t, store, "/v1/orders"); role != facts.RoleServer {
+		t.Errorf("role = %q, want %q — a role-less route means the repo serves something", role, facts.RoleServer)
+	}
+}
+
+// Every binder re-runs on every snapshot and append, so a second pass over its own
+// output must be a no-op rather than flipping the role back and forth.
+func TestIdempotentAcrossReruns(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("mobile-app", "/downstream/items", facts.RouteSourceRetrofit, facts.RoleClient),
+		route("mobile-app", "/v1/orders", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+
+	bind(t, store)
+	first, _ := roleOf(t, store, "/v1/orders")
+	bind(t, store)
+	bind(t, store)
+	second, vendored := roleOf(t, store, "/v1/orders")
+
+	if first != facts.RoleClient || second != first {
+		t.Errorf("role drifted across reruns: %q then %q", first, second)
+	}
+	if !vendored {
+		t.Errorf("%s cleared by a rerun that changed nothing", PropVendoredSpec)
+	}
+}
+
+// The reverse direction. A repo that grows a real server must not keep a demotion made
+// when it had none — the prop is what makes the rewrite reversible.
+func TestRestoresWhenRepoStartsServing(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("mobile-app", "/downstream/items", facts.RouteSourceRetrofit, facts.RoleClient),
+		route("mobile-app", "/v1/orders", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+	bind(t, store)
+	if role, _ := roleOf(t, store, "/v1/orders"); role != facts.RoleClient {
+		t.Fatalf("setup: role = %q, want the route demoted first", role)
+	}
+
+	store.Add(route("mobile-app", "/internal/jobs", "ktor", facts.RoleServer))
+	bind(t, store)
+
+	role, vendored := roleOf(t, store, "/v1/orders")
+	if role != facts.RoleServer {
+		t.Errorf("role = %q, want %q restored", role, facts.RoleServer)
+	}
+	if vendored {
+		t.Errorf("%s survived a restore", PropVendoredSpec)
+	}
+}
+
+// A spec the extractor itself classified as a client spec (the openapi/client/
+// convention) carries no vendored mark, and must never be "restored" into a server
+// route it was never extracted as.
+func TestGenuineClientSpecNeverPromoted(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		route("go-svc", "/v1/items", facts.RouteSourceOpenAPI, facts.RoleClient),
+		route("go-svc", "/v1/filters", facts.RouteSourceOpenAPI, facts.RoleServer),
+	)
+
+	bind(t, store)
+
+	role, vendored := roleOf(t, store, "/v1/items")
+	if role != facts.RoleClient {
+		t.Errorf("role = %q, want %q left alone", role, facts.RoleClient)
+	}
+	if vendored {
+		t.Errorf("%s set on a spec the extractor already classified as client", PropVendoredSpec)
+	}
+}

--- a/internal/linkers/crossrepo/routeindex/routeindex.go
+++ b/internal/linkers/crossrepo/routeindex/routeindex.go
@@ -155,9 +155,18 @@ func RoleOf(f facts.Fact) string { return f.PropString(facts.PropRole) }
 // — indexing one as a server route makes every page a candidate cross-repo
 // match and, worse, an "unused route no client calls" finding. Next.js App
 // Router API handlers carry type "route" and are deliberately NOT here.
+//
+// "loading" is a Suspense fallback component, as purely presentational as the
+// "error" boundary beside it, and its omission was not harmless: a loading.tsx
+// under a single dynamic segment (app/[slug]/loading.tsx) extracts as the server
+// route "/{}", which matches ANY one-segment client call with a path parameter —
+// enough for a frontend to collect inbound dependencies off that one route. The
+// set must therefore track every convention basename the Next.js branch of the TS
+// extractor emits (see tsextractor/ts.go, the App Router basename check) except
+// "route".
 var uiRouteTypes = map[string]bool{
-	"page": true, "layout": true, "error": true, "router_config": true,
-	"engine_mount": true,
+	"page": true, "layout": true, "error": true, "loading": true,
+	"router_config": true, "engine_mount": true,
 }
 
 // IsUIRoute reports whether a route fact is a client-side navigation route

--- a/internal/linkers/crossrepo/routeindex/routeindex_test.go
+++ b/internal/linkers/crossrepo/routeindex/routeindex_test.go
@@ -95,6 +95,18 @@ func TestIsUIRoute_PageRoutesExcludedFromServerIndex(t *testing.T) {
 	if IsUIRoute(api) || IsUIRoute(rails) {
 		t.Error("API and backend routes must stay server-indexable")
 	}
+	// Every Next.js App Router convention basename the TS extractor emits, except
+	// "route". "loading" was the one omission, and it was not cosmetic: a
+	// loading.tsx under a single dynamic segment extracts as "/{}", which matches
+	// any one-segment client call carrying a path parameter, handing a frontend
+	// inbound dependencies it has no endpoint for.
+	for _, typ := range []string{"page", "layout", "loading", "error"} {
+		f := facts.Fact{Kind: facts.KindRoute, Name: "/{}", Props: map[string]any{
+			"type": typ, "method": "GET", "framework": "nextjs"}}
+		if !IsUIRoute(f) {
+			t.Errorf("type %q must be a UI route — it renders, it does not serve", typ)
+		}
+	}
 	page.Repo = "web"
 	m := New(vocab.Default())
 	if got := m.IndexServerRoutes([]facts.Fact{page}); len(got) != 0 {

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -51,6 +51,7 @@ import (
 	"github.com/enola-labs/enola/internal/linkers/binders/grpcimpl"
 	"github.com/enola-labs/enola/internal/linkers/binders/httphandler"
 	"github.com/enola-labs/enola/internal/linkers/binders/unmatchedroutes"
+	"github.com/enola-labs/enola/internal/linkers/binders/vendoredspecs"
 	graphqlsignal "github.com/enola-labs/enola/internal/linkers/crossrepo/signals/graphqlsig"
 	httpsignal "github.com/enola-labs/enola/internal/linkers/crossrepo/signals/http"
 	importsignal "github.com/enola-labs/enola/internal/linkers/crossrepo/signals/imports"
@@ -411,6 +412,7 @@ func NewEngine(opts Options) (*Engine, *config.Config, error) {
 	eng.RegisterBinder(emberresolver.New())
 	eng.RegisterBinder(grpcimpl.New())
 	eng.RegisterBinder(httphandler.New())
+	eng.RegisterBinder(vendoredspecs.New())
 	eng.RegisterBinder(unmatchedroutes.New(linkVocab))
 
 	// Register all OSS cross-repo signals. Phase() decides when each runs, so the


### PR DESCRIPTION
The OpenAPI extractor defaults every spec to role=server, demoting to client only for the openapi/client/ directory convention. Mobile apps vendor the specs of services they call in a bare openapi/ dir, so those were indexed as served endpoints: an Android app acquired inbound edges from three backends and 28 unused-route findings.

Add a pre-link binder demoting a repo's OpenAPI routes to role=client when the repo ships a native-app HTTP client (retrofit/urlsession/swift-endpoint/ dart) and declares no server route outside a spec. The native-app marker is positive evidence, so spec-first backends serving only from api/openapi/*.yml are untouched. Rewritten facts carry vendored_spec=true, keeping the change auditable and reversible.

Also add "loading" to uiRouteTypes: a Next.js loading.tsx under a single dynamic segment extracts as "/{}", matching any one-segment client call with a path parameter.