### PR TITLE
ci: add dependabot for gomod and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What
Add Dependabot config to track weekly updates for:
- Go modules (`gomod`, repo root)
- GitHub Actions workflows

## Why
Keep dependencies and pinned action versions current automatically.

## Notes
Alternative would be to leverage Renovate which does offer more flexibility, but with additional setup cost. 