### PR TITLE
Feature/product dashboard - Improve dashboard architecture exploration, data trust, and change visibility

### DIFF
--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -310,7 +310,7 @@ func main() {
 			log.Printf("dashboard: not started: %v (continuing without it)", err)
 		} else {
 			tracker.SetDashboardPort(dash.Port())
-			fmt.Fprintf(os.Stderr, "Dashboard: %s (auto-refreshes every 30s)\n", dash.URL())
+			fmt.Fprintf(os.Stderr, "Dashboard: %s (refresh data explicitly)\n", dash.URL())
 			if opts.StablePort > 0 {
 				fmt.Fprintf(os.Stderr, "Shared URL: http://127.0.0.1:%d (whichever server holds it lists all the others)\n", opts.StablePort)
 			}

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -205,7 +205,7 @@ func dashboardSection() Section {
 		Title: "DASHBOARD",
 		Body: `  When the MCP server starts, a read-only HTTP dashboard is served on a free
   localhost port (127.0.0.1). It shows the same status data plus the snapshot and
-  graph receipts, and refreshes every 30 seconds. Run "--status" while the server
+  graph receipts. Refresh it explicitly when you want updated data. Run "--status" while the server
   is up to get its URL, or pass "--no-dashboard" to skip it entirely.
 `,
 	}

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -409,6 +409,8 @@ type pageData struct {
 	// EdgeDiagram is the node-link layout of CrossRepoEdges for the diagram view of
 	// the edges modal; nil when there are no edges (the modal shows the table only).
 	EdgeDiagram *diagramView
+	// ModuleGraph is the bounded, interactive module-level architecture map.
+	ModuleGraph *moduleGraphView
 
 	// Insights (grouped by explainer) back the clickable Insights card; the
 	// structural/candidate split is shown in the modal header.
@@ -515,6 +517,7 @@ func (s *Server) buildPage() pageData {
 	// counters. Empty (store not loaded) → the cards render as plain numbers.
 	data.Services, data.CrossRepoEdges = graphDetails(s.eng.Store())
 	data.EdgeDiagram = buildEdgeDiagram(data.Services, data.CrossRepoEdges)
+	data.ModuleGraph = buildModuleGraph(s.eng.Store())
 
 	// Insight list (grouped by explainer) backing the clickable Insights counter.
 	// Empty → the counter renders as a plain number.

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -559,7 +559,11 @@ func (s *Server) buildPageForModule(module string) pageData {
 	data.Services, data.CrossRepoEdges = graphDetails(s.eng.Store())
 	data.EdgeDiagram = buildEdgeDiagram(data.Services, data.CrossRepoEdges)
 	data.ModuleGraph = buildModuleGraphFocused(s.eng.Store(), module)
-	data.Changes = readChangeSummary(s.eng.ActiveRepo())
+	currentSnapshotID := ""
+	if data.Receipt != nil {
+		currentSnapshotID = data.Receipt.SnapshotID
+	}
+	data.Changes = readChangeSummary(s.eng.ActiveRepo(), currentSnapshotID)
 
 	// Insight list (grouped by explainer) backing the clickable Insights counter.
 	// Empty → the counter renders as a plain number.
@@ -579,8 +583,8 @@ func (s *Server) buildPageForModule(module string) pageData {
 	return data
 }
 
-func readChangeSummary(repoPath string) changeSummary {
-	if repoPath == "" {
+func readChangeSummary(repoPath, snapshotID string) changeSummary {
+	if repoPath == "" || snapshotID == "" {
 		return changeSummary{}
 	}
 	root, err := history.Root(repoPath, "")
@@ -591,7 +595,18 @@ func readChangeSummary(repoPath string) changeSummary {
 	if err != nil || len(entries) == 0 {
 		return changeSummary{}
 	}
-	entry := entries[len(entries)-1]
+	var entry history.Entry
+	found := false
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].ID == snapshotID {
+			entry = entries[i]
+			found = true
+			break
+		}
+	}
+	if !found {
+		return changeSummary{}
+	}
 	s := entry.Summary
 	return changeSummary{
 		Available: true, Incomparable: s.Incomparable, Initial: s.Initial,

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -358,6 +358,29 @@ type valueRow struct {
 	TokensSaved string
 }
 
+// snapshotSummary turns receipt provenance into the user-facing state shown at
+// the top of the Snapshots tab. The full receipt remains available below it.
+type snapshotSummary struct {
+	RepoName, Age, Generated, ShortID, ShortCommit, Status, StatusClass string
+}
+
+type qualityBlindSpot struct {
+	Kind, Reason string
+	Count        int
+}
+
+type qualityAssessment struct {
+	Status, StatusClass, Summary string
+	CoverageLabel                string
+	Potential                    []qualityBlindSpot
+	Expected                     []qualityBlindSpot
+	Inactive                     []facts.CensusCause
+	NoFacts                      []facts.CensusCause
+	ExpectedFiles, ExpectedKinds int
+	InactiveFiles, FilesWalked   int
+	InactiveShare                string
+}
+
 // pageData is the full template model.
 type pageData struct {
 	RefreshSeconds int
@@ -396,6 +419,7 @@ type pageData struct {
 
 	HasReceipt  bool
 	Receipt     *facts.Receipt
+	Snapshot    snapshotSummary
 	ReceiptNote string
 
 	HasGraph  bool
@@ -426,6 +450,7 @@ type pageData struct {
 	UnresolvedRoutes []routeRow
 	SkippedSample    []string
 	ParseErrors      []facts.ParseError
+	Quality          qualityAssessment
 
 	// Extra is whatever Options.Extra returned for this request — the data the
 	// overlay blocks render. Nil in a plain engine dashboard, and nil whenever a
@@ -495,9 +520,11 @@ func (s *Server) buildPage() pageData {
 	if rv := s.currentReceipt(); rv != nil {
 		data.HasReceipt = true
 		data.Receipt = rv
+		data.Snapshot = summarizeSnapshot(rv, now)
 		// Capped skip/parse-error samples back the clickable Extraction-quality cards.
 		data.SkippedSample = rv.Quality.SkippedSample
 		data.ParseErrors = rv.Quality.ParseErrorSample
+		data.Quality = assessQuality(rv)
 	} else {
 		data.ReceiptNote = "No snapshot loaded yet — run generate_snapshot to populate this."
 	}
@@ -535,6 +562,130 @@ func (s *Server) buildPage() pageData {
 	}
 
 	return data
+}
+
+var reviewableFileKinds = map[string]string{
+	".sql":   "Queries and transformations may encode data architecture.",
+	".toml":  "Project and dependency configuration may affect architecture.",
+	".html":  "Templates may contain routes, calls, or application structure.",
+	".j2":    "Templates may contain generated configuration or queries.",
+	".jinja": "Templates may contain generated configuration or queries.",
+	".pyi":   "Python type declarations may describe public interfaces.",
+	".sh":    "Scripts may describe build and operational dependencies.",
+	".ps1":   "Scripts may describe build and operational dependencies.",
+}
+
+func assessQuality(r *facts.Receipt) qualityAssessment {
+	q := qualityAssessment{Status: "Analysis complete", StatusClass: "on", Summary: "No parse failures or obvious extractor gaps were recorded."}
+	if census := r.Quality.Census; census != nil {
+		for kind, count := range census.ExcludedKinds {
+			if reason, review := reviewableFileKinds[kind]; review {
+				q.Potential = append(q.Potential, qualityBlindSpot{Kind: kind, Count: count, Reason: reason})
+			} else {
+				q.ExpectedFiles += count
+				q.ExpectedKinds++
+				q.Expected = append(q.Expected, qualityBlindSpot{Kind: kind, Count: count})
+			}
+		}
+		sort.Slice(q.Potential, func(i, j int) bool {
+			if q.Potential[i].Count != q.Potential[j].Count {
+				return q.Potential[i].Count > q.Potential[j].Count
+			}
+			return q.Potential[i].Kind < q.Potential[j].Kind
+		})
+		sort.Slice(q.Expected, func(i, j int) bool {
+			if q.Expected[i].Count != q.Expected[j].Count {
+				return q.Expected[i].Count > q.Expected[j].Count
+			}
+			return q.Expected[i].Kind < q.Expected[j].Kind
+		})
+		for _, cause := range census.TopSkipCauses {
+			if strings.Contains(cause.Cause, "did not run") {
+				q.Inactive = append(q.Inactive, cause)
+				q.InactiveFiles += cause.Count
+			} else {
+				q.NoFacts = append(q.NoFacts, cause)
+			}
+		}
+		q.FilesWalked = census.FilesWalked
+		q.InactiveShare = formatShare(q.InactiveFiles, census.FilesWalked)
+	}
+	if r.Quality.ParseErrors > 0 {
+		q.Status = "Analysis needs attention"
+		q.StatusClass = "off"
+		q.Summary = fmt.Sprintf("%d parse error(s) may leave gaps in the architecture map.", r.Quality.ParseErrors)
+	} else if q.InactiveFiles > 0 && materialCoverageGap(q.InactiveFiles, q.FilesWalked) {
+		q.Status = "Material extractor coverage gap"
+		q.StatusClass = "off"
+		q.CoverageLabel = "material gap"
+		q.Summary = fmt.Sprintf("%d of %d walked files (%s) belonged to an extractor that did not run.", q.InactiveFiles, q.FilesWalked, q.InactiveShare)
+	} else if q.InactiveFiles > 0 {
+		q.Status = "Coverage worth reviewing"
+		q.StatusClass = "warn"
+		q.CoverageLabel = "limited coverage"
+		q.Summary = fmt.Sprintf("Analysis completed without parse errors. %d of %d walked files (%s) belonged to an extractor that did not activate.", q.InactiveFiles, q.FilesWalked, q.InactiveShare)
+	} else if len(q.Potential) > 0 {
+		q.Status = "Coverage worth reviewing"
+		q.StatusClass = "warn"
+		q.Summary = "Analysis succeeded, but potentially architectural file types are outside the current graph."
+	}
+	return q
+}
+
+// materialCoverageGap deliberately requires meaningful corpus impact before the
+// dashboard uses red/error language. A handful of nested examples in a large
+// monorepo is transparent but not alarming; a missing language population is.
+func materialCoverageGap(files, walked int) bool {
+	if files <= 0 {
+		return false
+	}
+	return files >= 100 || walked > 0 && float64(files)/float64(walked) >= 0.05
+}
+
+func formatShare(part, total int) string {
+	if part <= 0 || total <= 0 {
+		return "unknown share"
+	}
+	pct := float64(part) / float64(total) * 100
+	if pct < 0.1 {
+		return "<0.1%"
+	}
+	return fmt.Sprintf("%.1f%%", pct)
+}
+
+func summarizeSnapshot(r *facts.Receipt, now time.Time) snapshotSummary {
+	s := snapshotSummary{
+		RepoName:    filepath.Base(r.RepoPath),
+		ShortID:     shortDigest(r.SnapshotID, 12),
+		Status:      "Snapshot ready",
+		StatusClass: "on",
+	}
+	if generated, err := time.Parse(time.RFC3339, r.GeneratedAt); err == nil {
+		s.Age = formatDuration(now.Sub(generated)) + " ago"
+		s.Generated = generated.Local().Format("2006-01-02 15:04:05 MST")
+	} else {
+		s.Generated = r.GeneratedAt
+	}
+	if r.Git != nil {
+		s.ShortCommit = shortDigest(r.Git.Commit, 8)
+		if r.Git.Dirty {
+			s.Status = "Captured with local changes"
+			s.StatusClass = "warn"
+		}
+	}
+	if r.Quality.ParseErrors > 0 {
+		s.Status = "Analysis needs attention"
+		s.StatusClass = "off"
+	}
+	return s
+}
+
+func shortDigest(value string, n int) string {
+	value = strings.TrimPrefix(value, "sha256:")
+	if len(value) > n {
+		return value[:n]
+	}
+	return value
 }
 
 // currentReceipt returns the receipt to display for the current snapshot, or nil

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -141,6 +141,10 @@ type Server struct {
 	changeCacheID string
 	changeCache   changeSummary
 
+	graphMu       sync.Mutex
+	graphCacheKey string
+	graphCache    *moduleGraphView
+
 	// frontDoor is set once this server claims the stable port. Read from every
 	// request handler and written by the claim goroutine, hence atomic.
 	frontDoor atomic.Bool
@@ -481,12 +485,9 @@ type pageData struct {
 	Extra any
 }
 
-// buildPage collects the status, current-snapshot receipt and graph-wide receipt
-// into the template model. Every source degrades gracefully to a note on error.
-func (s *Server) buildPage() pageData {
-	return s.buildPageForModule("")
-}
-
+// buildPageForModule collects the status, current-snapshot receipt and
+// graph-wide receipt into the template model, focusing the architecture map on
+// module if non-empty. Every source degrades gracefully to a note on error.
 func (s *Server) buildPageForModule(module string) pageData {
 	data := pageData{
 		RefreshSeconds: refreshSeconds,
@@ -570,11 +571,11 @@ func (s *Server) buildPageForModule(module string) pageData {
 	// counters. Empty (store not loaded) → the cards render as plain numbers.
 	data.Services, data.CrossRepoEdges = graphDetails(s.eng.Store())
 	data.EdgeDiagram = buildEdgeDiagram(data.Services, data.CrossRepoEdges)
-	data.ModuleGraph = buildModuleGraphFocused(s.eng.Store(), module)
 	currentSnapshotID := ""
 	if data.Receipt != nil {
 		currentSnapshotID = data.Receipt.SnapshotID
 	}
+	data.ModuleGraph = s.readModuleGraph(currentSnapshotID, module)
 	data.Changes = s.readChangeSummary(s.eng.ActiveRepo(), currentSnapshotID)
 
 	// Insight list (grouped by explainer) backing the clickable Insights counter.
@@ -593,6 +594,18 @@ func (s *Server) buildPageForModule(module string) pageData {
 	}
 
 	return data
+}
+
+func (s *Server) readModuleGraph(snapshotID, focus string) *moduleGraphView {
+	key := snapshotID + "\x00" + focus
+	s.graphMu.Lock()
+	defer s.graphMu.Unlock()
+	if snapshotID != "" && key == s.graphCacheKey {
+		return s.graphCache
+	}
+	result := buildModuleGraphFocused(s.eng.Store(), focus)
+	s.graphCacheKey, s.graphCache = key, result
+	return result
 }
 
 func (s *Server) readChangeSummary(repoPath, snapshotID string) changeSummary {

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/facts"
+	"github.com/enola-labs/enola/pkg/history"
 	"github.com/enola-labs/enola/pkg/status"
 )
 
@@ -271,7 +272,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := s.buildPage()
+	data := s.buildPageForModule(r.URL.Query().Get("module"))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.Execute(w, data); err != nil {
 		log.Printf("dashboard: render failed: %v", err)
@@ -381,6 +382,14 @@ type qualityAssessment struct {
 	InactiveShare                string
 }
 
+type changeSummary struct {
+	Available, Incomparable, Initial bool
+	Headline, ComparedTo             string
+	FactsAdded, FactsRemoved         int
+	EdgesAdded, EdgesRemoved         int
+	FindingsNew, FindingsResolved    int
+}
+
 // pageData is the full template model.
 type pageData struct {
 	RefreshSeconds int
@@ -451,6 +460,7 @@ type pageData struct {
 	SkippedSample    []string
 	ParseErrors      []facts.ParseError
 	Quality          qualityAssessment
+	Changes          changeSummary
 
 	// Extra is whatever Options.Extra returned for this request — the data the
 	// overlay blocks render. Nil in a plain engine dashboard, and nil whenever a
@@ -462,6 +472,10 @@ type pageData struct {
 // buildPage collects the status, current-snapshot receipt and graph-wide receipt
 // into the template model. Every source degrades gracefully to a note on error.
 func (s *Server) buildPage() pageData {
+	return s.buildPageForModule("")
+}
+
+func (s *Server) buildPageForModule(module string) pageData {
 	data := pageData{
 		RefreshSeconds: refreshSeconds,
 		Title:          s.title,
@@ -544,7 +558,8 @@ func (s *Server) buildPage() pageData {
 	// counters. Empty (store not loaded) → the cards render as plain numbers.
 	data.Services, data.CrossRepoEdges = graphDetails(s.eng.Store())
 	data.EdgeDiagram = buildEdgeDiagram(data.Services, data.CrossRepoEdges)
-	data.ModuleGraph = buildModuleGraph(s.eng.Store())
+	data.ModuleGraph = buildModuleGraphFocused(s.eng.Store(), module)
+	data.Changes = readChangeSummary(s.eng.ActiveRepo())
 
 	// Insight list (grouped by explainer) backing the clickable Insights counter.
 	// Empty → the counter renders as a plain number.
@@ -562,6 +577,29 @@ func (s *Server) buildPage() pageData {
 	}
 
 	return data
+}
+
+func readChangeSummary(repoPath string) changeSummary {
+	if repoPath == "" {
+		return changeSummary{}
+	}
+	root, err := history.Root(repoPath, "")
+	if err != nil {
+		return changeSummary{}
+	}
+	entries, err := history.Read(root)
+	if err != nil || len(entries) == 0 {
+		return changeSummary{}
+	}
+	entry := entries[len(entries)-1]
+	s := entry.Summary
+	return changeSummary{
+		Available: true, Incomparable: s.Incomparable, Initial: s.Initial,
+		Headline: s.Headline(), ComparedTo: "previous recorded snapshot",
+		FactsAdded: s.FactsAdded, FactsRemoved: s.FactsRemoved,
+		EdgesAdded: s.EdgesAdded, EdgesRemoved: s.EdgesRemoved,
+		FindingsNew: s.FindingsNew, FindingsResolved: s.FindingsResolved,
+	}
 }
 
 var reviewableFileKinds = map[string]string{

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -1,6 +1,6 @@
 // Package dashboard serves a read-only localhost HTTP dashboard alongside the
-// enola MCP server. It binds a free ephemeral port on 127.0.0.1 and renders —
-// refreshing every 30 seconds — the same activity data as --status plus the
+// enola MCP server. It binds a free ephemeral port on 127.0.0.1 and renders the
+// same activity data as --status plus the
 // contents of the current-snapshot and graph-wide receipt.json files, so a user
 // can visually inspect what the snapshot captured.
 //
@@ -37,9 +37,6 @@ import (
 	"github.com/enola-labs/enola/pkg/history"
 	"github.com/enola-labs/enola/pkg/status"
 )
-
-// refreshSeconds is the client-side auto-refresh interval, stated on the page.
-const refreshSeconds = 30
 
 //go:embed page.html.tmpl
 var pageTemplate string
@@ -408,8 +405,7 @@ type changeFinding struct {
 
 // pageData is the full template model.
 type pageData struct {
-	RefreshSeconds int
-	Title          string
+	Title string
 
 	// This server's own identity. Never sourced from the cross-process aggregate:
 	// with several agent terminals open, that would name a sibling process.
@@ -490,9 +486,8 @@ type pageData struct {
 // module if non-empty. Every source degrades gracefully to a note on error.
 func (s *Server) buildPageForModule(module string) pageData {
 	data := pageData{
-		RefreshSeconds: refreshSeconds,
-		Title:          s.title,
-		Port:           s.port,
+		Title: s.title,
+		Port:  s.port,
 	}
 
 	now := time.Now()

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -27,10 +27,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/enola-labs/enola/pkg/diff"
 	"github.com/enola-labs/enola/pkg/facts"
 	"github.com/enola-labs/enola/pkg/history"
 	"github.com/enola-labs/enola/pkg/status"
@@ -134,6 +136,10 @@ type Server struct {
 	labels map[string]string // insight-source allowlist + display labels
 	title  string            // product name in the page title/heading/footer
 	mux    *http.ServeMux
+
+	changeMu      sync.Mutex
+	changeCacheID string
+	changeCache   changeSummary
 
 	// frontDoor is set once this server claims the stable port. Read from every
 	// request handler and written by the claim goroutine, hence atomic.
@@ -388,6 +394,12 @@ type changeSummary struct {
 	FactsAdded, FactsRemoved         int
 	EdgesAdded, EdgesRemoved         int
 	FindingsNew, FindingsResolved    int
+	NewFindingDetails                []changeFinding
+}
+
+type changeFinding struct {
+	Source, Label, Title, Evidence string
+	Confidence                     int
 }
 
 // pageData is the full template model.
@@ -563,7 +575,7 @@ func (s *Server) buildPageForModule(module string) pageData {
 	if data.Receipt != nil {
 		currentSnapshotID = data.Receipt.SnapshotID
 	}
-	data.Changes = readChangeSummary(s.eng.ActiveRepo(), currentSnapshotID)
+	data.Changes = s.readChangeSummary(s.eng.ActiveRepo(), currentSnapshotID)
 
 	// Insight list (grouped by explainer) backing the clickable Insights counter.
 	// Empty → the counter renders as a plain number.
@@ -583,7 +595,18 @@ func (s *Server) buildPageForModule(module string) pageData {
 	return data
 }
 
-func readChangeSummary(repoPath, snapshotID string) changeSummary {
+func (s *Server) readChangeSummary(repoPath, snapshotID string) changeSummary {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	if snapshotID != "" && snapshotID == s.changeCacheID {
+		return s.changeCache
+	}
+	result := readChangeSummary(repoPath, snapshotID, s.labels)
+	s.changeCacheID, s.changeCache = snapshotID, result
+	return result
+}
+
+func readChangeSummary(repoPath, snapshotID string, labels map[string]string) changeSummary {
 	if repoPath == "" || snapshotID == "" {
 		return changeSummary{}
 	}
@@ -596,10 +619,12 @@ func readChangeSummary(repoPath, snapshotID string) changeSummary {
 		return changeSummary{}
 	}
 	var entry history.Entry
+	entryIndex := -1
 	found := false
 	for i := len(entries) - 1; i >= 0; i-- {
 		if entries[i].ID == snapshotID {
 			entry = entries[i]
+			entryIndex = i
 			found = true
 			break
 		}
@@ -608,13 +633,31 @@ func readChangeSummary(repoPath, snapshotID string) changeSummary {
 		return changeSummary{}
 	}
 	s := entry.Summary
-	return changeSummary{
+	result := changeSummary{
 		Available: true, Incomparable: s.Incomparable, Initial: s.Initial,
 		Headline: s.Headline(), ComparedTo: "previous recorded snapshot",
 		FactsAdded: s.FactsAdded, FactsRemoved: s.FactsRemoved,
 		EdgesAdded: s.EdgesAdded, EdgesRemoved: s.EdgesRemoved,
 		FindingsNew: s.FindingsNew, FindingsResolved: s.FindingsResolved,
 	}
+	if !s.Incomparable && !s.Initial && entryIndex > 0 && entry.Blob != nil && entries[entryIndex-1].Blob != nil {
+		previous, previousErr := history.Load(root, entries[entryIndex-1])
+		current, currentErr := history.Load(root, entry)
+		if previousErr == nil && currentErr == nil {
+			delta := diff.Compute(previous, current)
+			for _, finding := range delta.FindingsNew {
+				label := labels[finding.Source]
+				if label == "" {
+					label = finding.Source
+				}
+				result.NewFindingDetails = append(result.NewFindingDetails, changeFinding{
+					Source: finding.Source, Label: label, Title: finding.Title,
+					Confidence: int(finding.Confidence*100 + 0.5), Evidence: firstEvidence(finding.Evidence),
+				})
+			}
+		}
+	}
+	return result
 }
 
 var reviewableFileKinds = map[string]string{

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -104,12 +104,42 @@ func TestReadChangeSummaryMatchesLoadedSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := readChangeSummary(repo, "sha256:loaded")
+	got := readChangeSummary(repo, "sha256:loaded", mergedLabels(nil))
 	if !got.Available || got.FactsAdded != 2 || got.EdgesAdded != 7 || got.FactsRemoved != 0 {
 		t.Fatalf("summary = %+v, want loaded snapshot rather than newest history entry", got)
 	}
-	if got := readChangeSummary(repo, "sha256:missing"); got.Available {
+	if got := readChangeSummary(repo, "sha256:missing", mergedLabels(nil)); got.Available {
 		t.Fatalf("missing snapshot unexpectedly returned %+v", got)
+	}
+}
+
+func TestNewFindingsCardLinksToDrillDown(t *testing.T) {
+	tmpl, err := buildTemplate("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body strings.Builder
+	err = tmpl.Execute(&body, pageData{
+		Title: "enola",
+		Changes: changeSummary{
+			Available:   true,
+			FindingsNew: 1,
+			NewFindingDetails: []changeFinding{{
+				Label: "Dependency cycles", Title: "Cyclic dependency detected",
+				Confidence: 100, Evidence: "src/core",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`onclick="openModal('new-findings-modal')"`, `id="new-findings-modal"`,
+		"Cyclic dependency detected", "src/core",
+	} {
+		if !strings.Contains(body.String(), want) {
+			t.Errorf("page missing new-finding drill-down content %q", want)
+		}
 	}
 }
 

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -216,7 +216,7 @@ func TestHandlerDegradesGracefully(t *testing.T) {
 	}
 	body := rec.Body.String()
 	wantContains := []string{
-		"location.reload()",              // JS-driven auto-refresh mechanism
+		"Refresh data",                   // explicit refresh; investigations are never interrupted
 		"Ready to map this repository.",  // product-facing empty state
 		"No snapshot loaded yet",         // degraded current receipt
 		"No graph loaded in this server", // degraded graph receipt
@@ -225,6 +225,9 @@ func TestHandlerDegradesGracefully(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}
+	}
+	if strings.Contains(body, "setTimeout(function () { location.reload()") || strings.Contains(body, "updates every") {
+		t.Error("dashboard still contains automatic refresh behavior")
 	}
 }
 

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/enola-labs/enola/pkg/facts"
+	"github.com/enola-labs/enola/pkg/history"
 )
 
 func TestSummarizeSnapshotExplainsFreshnessAndDirtyCapture(t *testing.T) {
@@ -74,6 +75,41 @@ func TestAssessQualityEscalatesOnlyMaterialExtractorGaps(t *testing.T) {
 				t.Fatalf("status = %q, want %q (%+v)", got.Status, tt.want, got)
 			}
 		})
+	}
+}
+
+func TestReadChangeSummaryMatchesLoadedSnapshot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := t.TempDir()
+	root, err := history.Root(repo, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entries := []history.Entry{
+		{ID: "sha256:loaded", Summary: history.Summary{FactsAdded: 2, EdgesAdded: 7}},
+		{ID: "sha256:newer", Summary: history.Summary{FactsRemoved: 99}},
+	}
+	var lines []byte
+	for _, entry := range entries {
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, append(line, '\n')...)
+	}
+	if err := os.WriteFile(filepath.Join(root, history.LogFileName), lines, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readChangeSummary(repo, "sha256:loaded")
+	if !got.Available || got.FactsAdded != 2 || got.EdgesAdded != 7 || got.FactsRemoved != 0 {
+		t.Fatalf("summary = %+v, want loaded snapshot rather than newest history entry", got)
+	}
+	if got := readChangeSummary(repo, "sha256:missing"); got.Available {
+		t.Fatalf("missing snapshot unexpectedly returned %+v", got)
 	}
 }
 

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -87,11 +87,10 @@ func TestHandlerDegradesGracefully(t *testing.T) {
 	}
 	body := rec.Body.String()
 	wantContains := []string{
-		"location.reload()",                // JS-driven auto-refresh mechanism
-		"refreshes automatically every 30", // stated on the page
-		"127.0.0.1:54321",                  // the dashboard port/URL
-		"No snapshot loaded yet",           // degraded current receipt
-		"No graph loaded in this server",   // degraded graph receipt
+		"location.reload()",              // JS-driven auto-refresh mechanism
+		"Ready to map this repository.",  // product-facing empty state
+		"No snapshot loaded yet",         // degraded current receipt
+		"No graph loaded in this server", // degraded graph receipt
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(body, want) {
@@ -144,8 +143,8 @@ func TestHandlerRendersReceipts(t *testing.T) {
 
 	body := rec.Body.String()
 	for _, want := range []string{
-		"snap-abc123", "goextractor", "tsextractor", "4242", // current receipt
-		"graph-xyz", "backend", "/x/backend", // graph receipt + repos table
+		"4242",                         // fact summary
+		"Your architecture is mapped.", // product-facing populated state
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
@@ -720,7 +719,7 @@ func TestTitleDefaultsAndOverrides(t *testing.T) {
 	rec = httptest.NewRecorder()
 	newTestServer(1, fakeArtifacts{err: errors.New("none")}, Options{Title: "wrapper build"}).handleIndex(rec, req())
 	body := rec.Body.String()
-	for _, want := range []string{"<title>wrapper build — dashboard</title>", "<h1>wrapper build</h1>"} {
+	for _, want := range []string{"<title>wrapper build — dashboard</title>", `<h1>wrapper build<span class="brand-dot">.</span></h1>`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -10,9 +10,72 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/enola-labs/enola/pkg/facts"
 )
+
+func TestSummarizeSnapshotExplainsFreshnessAndDirtyCapture(t *testing.T) {
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	r := &facts.Receipt{
+		SnapshotID:  "sha256:b3640f5cdab13ea7",
+		GeneratedAt: "2026-08-22T09:55:00Z",
+		RepoPath:    "/work/dbt-core",
+		Git:         &facts.GitInfo{Commit: "f5a3aa5b1d5b0f7d", Dirty: true},
+	}
+	got := summarizeSnapshot(r, now)
+	if got.RepoName != "dbt-core" || got.Age != "5m 0s ago" || got.ShortID != "b3640f5cdab1" || got.ShortCommit != "f5a3aa5b" {
+		t.Fatalf("summary = %+v", got)
+	}
+	if got.Status != "Captured with local changes" || got.StatusClass != "warn" {
+		t.Fatalf("status = %q/%q, want dirty warning", got.Status, got.StatusClass)
+	}
+}
+
+func TestAssessQualityPrioritizesActionableBlindSpots(t *testing.T) {
+	r := &facts.Receipt{Quality: facts.ReceiptQuality{Census: &facts.FileCensus{
+		FilesWalked:   1000,
+		ExcludedKinds: map[string]int{".sql": 40, ".png": 10, ".toml": 5},
+		TopSkipCauses: []facts.CensusCause{
+			{Cause: "claimed by cpp, which did not run this snapshot", Count: 2},
+			{Cause: "claimed by rust, no facts emitted", Count: 3},
+		},
+	}}}
+	got := assessQuality(r)
+	if got.Status != "Coverage worth reviewing" || got.StatusClass != "warn" || got.CoverageLabel != "limited coverage" {
+		t.Fatalf("status = %q/%q", got.Status, got.StatusClass)
+	}
+	if len(got.Potential) != 2 || got.Potential[0].Kind != ".sql" || got.Potential[1].Kind != ".toml" {
+		t.Fatalf("potential = %+v, want SQL then TOML", got.Potential)
+	}
+	if got.ExpectedFiles != 10 || got.ExpectedKinds != 1 || len(got.Inactive) != 1 || len(got.NoFacts) != 1 || got.InactiveShare != "0.2%" {
+		t.Fatalf("assessment buckets = %+v", got)
+	}
+}
+
+func TestAssessQualityEscalatesOnlyMaterialExtractorGaps(t *testing.T) {
+	for _, tt := range []struct {
+		name, want string
+		files      int
+		walked     int
+	}{
+		{name: "small nested population", files: 2, walked: 2987, want: "Coverage worth reviewing"},
+		{name: "five percent of corpus", files: 50, walked: 1000, want: "Material extractor coverage gap"},
+		{name: "large absolute population", files: 100, walked: 10000, want: "Material extractor coverage gap"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &facts.Receipt{Quality: facts.ReceiptQuality{Census: &facts.FileCensus{
+				FilesWalked: tt.walked,
+				TopSkipCauses: []facts.CensusCause{{
+					Cause: "claimed by cpp, which did not run this snapshot", Count: tt.files,
+				}},
+			}}}
+			if got := assessQuality(r); got.Status != tt.want {
+				t.Fatalf("status = %q, want %q (%+v)", got.Status, tt.want, got)
+			}
+		})
+	}
+}
 
 // fakeArtifacts is a stub engineView for handler tests. activeRepo/outputDir
 // drive the on-disk receipt fallback (empty by default → no fallback). store is
@@ -413,6 +476,25 @@ func TestInsightDetailsFiltersUnknownSources(t *testing.T) {
 	}
 }
 
+func TestInsightDetailsAdmitsEveryCurrentBuiltInSource(t *testing.T) {
+	sources := []string{
+		"hotspots", "god-class", "exported-surface", "complexity-outliers",
+		"dependency-depth", "cycles", "layers", "crossrepo", "coverage",
+		"unused-routes", "domain", "query-loops", "entry-points",
+		"messaging-coverage", "intent", "constraints",
+	}
+	ins := make([]facts.Insight, 0, len(sources))
+	for _, source := range sources {
+		ins = append(ins, facts.Insight{Source: source, Title: source, Confidence: 1})
+	}
+
+	groups, structural, candidate := insightDetails(ins, mergedLabels(nil))
+	if len(groups) != len(sources) || structural != len(sources) || candidate != 0 {
+		t.Fatalf("built-in insights = %d groups, %d/%d split; want %d groups, %d/0 split",
+			len(groups), structural, candidate, len(sources), len(sources))
+	}
+}
+
 // mergedLabels must copy, so one dashboard's wrapper labels never bleed into the
 // package map (and thus into another dashboard in the same process).
 func TestMergedLabelsDoesNotMutatePackageMap(t *testing.T) {
@@ -524,12 +606,23 @@ func TestHandlerRendersQualityModals(t *testing.T) {
 	receipt := facts.Receipt{
 		SnapshotID: "snap-q",
 		Quality: facts.ReceiptQuality{
+			FilesSeen:        80,
+			FilesParsed:      60,
 			FilesSkipped:     0,
 			DirsSkipped:      1,
 			SkippedSample:    []string{".git/ (glob: .git/**)"},
 			ParseErrors:      1,
 			ParseErrorSample: []facts.ParseError{{Extractor: "goextractor", File: "bad.go", Msg: "syntax error near EOF"}},
 			Coverage:         &facts.CoverageSummary{ServicesTotal: 1, UnresolvedEdges: 1},
+			Census: &facts.FileCensus{
+				FilesWalked:      100,
+				Parsed:           60,
+				ExcludedByIgnore: 10,
+				ExcludedByKind:   25,
+				ExcludedKinds:    map[string]int{".sql": 25},
+				SkippedWithCause: 5,
+				TopSkipCauses:    []facts.CensusCause{{Cause: "claimed by go, no facts emitted", Count: 5}},
+			},
 		},
 	}
 	rb, err := json.Marshal(receipt)
@@ -551,6 +644,8 @@ func TestHandlerRendersQualityModals(t *testing.T) {
 	body := rec.Body.String()
 	for _, want := range []string{
 		`id="coverage-modal"`, `id="coverage-unresolved-modal"`, `id="skipped-modal"`, `id="parse-errors-modal"`,
+		`Files walked`, `Intentionally ignored`, `Non-source / unsupported`, `No facts emitted`,
+		`Ignored and non-source files are not parse failures`, `.sql`, `claimed by go, no facts emitted`,
 		`onclick="openModal('coverage-modal')"`,
 		`onclick="openModal('coverage-unresolved-modal')"`,
 		`onclick="openModal('skipped-modal')"`,

--- a/pkg/dashboard/identity_test.go
+++ b/pkg/dashboard/identity_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/enola-labs/enola/pkg/status"
 )
 
-// TestPageDescribesItsOwnServer guards the simplified product surface: runtime
-// identity is still collected for --status, but no longer crowds repository results.
+// TestPageDescribesItsOwnServer guards the Activity tab: runtime identity comes
+// from the tracker for this process, never from a sibling server.
 func TestPageDescribesItsOwnServer(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -43,15 +43,15 @@ func TestPageDescribesItsOwnServer(t *testing.T) {
 	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	body := rec.Body.String()
 
-	for _, operational := range []string{"enola-enterprise 4.2.0", "/tmp/my-workspace", "my-repo"} {
-		if strings.Contains(body, operational) {
-			t.Errorf("body contains operational detail %q — the product dashboard should stay focused on repository results", operational)
+	for _, operational := range []string{"panel-activity", "enola-enterprise 4.2.0", "/tmp/my-workspace", "my-repo"} {
+		if !strings.Contains(body, operational) {
+			t.Errorf("Activity tab missing this server's operational detail %q", operational)
 		}
 	}
 }
 
-// TestPageListsLiveInstances confirms sibling-server bookkeeping stays out of the
-// product dashboard. It remains available through --status.
+// TestPageListsLiveInstances confirms the Activity tab provides the original
+// server switcher alongside the product-focused Overview and Architecture tabs.
 func TestPageListsLiveInstances(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -82,8 +82,8 @@ func TestPageListsLiveInstances(t *testing.T) {
 	body := rec.Body.String()
 
 	for _, operational := range []string{"Servers running", "http://127.0.0.1:54545", "other-repo", "this page"} {
-		if strings.Contains(body, operational) {
-			t.Errorf("body contains server-switcher detail %q", operational)
+		if !strings.Contains(body, operational) {
+			t.Errorf("Activity tab missing server-switcher detail %q", operational)
 		}
 	}
 }
@@ -103,6 +103,12 @@ func TestPageWithoutTrackerStillRenders(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "Your architecture is mapped.") {
 		t.Error("body missing the populated architecture state")
+	}
+	for _, tab := range []string{"overview", "architecture", "snapshots", "activity", "quality"} {
+		if !strings.Contains(rec.Body.String(), `id="tab-`+tab+`"`) ||
+			!strings.Contains(rec.Body.String(), `id="panel-`+tab+`"`) {
+			t.Errorf("body missing %q tab or panel", tab)
+		}
 	}
 }
 

--- a/pkg/dashboard/identity_test.go
+++ b/pkg/dashboard/identity_test.go
@@ -110,6 +110,10 @@ func TestPageWithoutTrackerStillRenders(t *testing.T) {
 			t.Errorf("body missing %q tab or panel", tab)
 		}
 	}
+	if body := rec.Body.String(); !strings.Contains(body, `href="https://github.com/enola-labs/enola"`) ||
+		!strings.Contains(body, "Open source on GitHub · Star Enola") {
+		t.Error("body missing the subtle open-source project link")
+	}
 }
 
 func TestResolveStablePort(t *testing.T) {

--- a/pkg/dashboard/identity_test.go
+++ b/pkg/dashboard/identity_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -16,14 +15,8 @@ import (
 	"github.com/enola-labs/enola/pkg/status"
 )
 
-// TestPageDescribesItsOwnServer is the regression test for the complaint that
-// started this work: with one enola server per agent terminal, the dashboard used
-// to fill its Server/PID/uptime cards from the cross-process aggregate, which
-// picks whichever process started last. A page served by this process would then
-// announce a sibling's PID.
-//
-// Here a foreign instance is registered with a NEWER start time — exactly the
-// case that used to win — and the page must still describe this process.
+// TestPageDescribesItsOwnServer guards the simplified product surface: runtime
+// identity is still collected for --status, but no longer crowds repository results.
 func TestPageDescribesItsOwnServer(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -50,24 +43,15 @@ func TestPageDescribesItsOwnServer(t *testing.T) {
 	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	body := rec.Body.String()
 
-	for _, want := range []string{
-		"PID " + strconv.Itoa(os.Getpid()), // this process, not the newer sibling
-		"enola-enterprise 4.2.0",           // which binary is serving the page
-		"/tmp/my-workspace",                // which terminal launched it
-		"my-repo",                          // what THIS server has loaded
-	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("body missing %q — the page must describe the process serving it", want)
+	for _, operational := range []string{"enola-enterprise 4.2.0", "/tmp/my-workspace", "my-repo"} {
+		if strings.Contains(body, operational) {
+			t.Errorf("body contains operational detail %q — the product dashboard should stay focused on repository results", operational)
 		}
-	}
-	if strings.Contains(body, "PID "+strconv.Itoa(foreignPID)) {
-		t.Error("body names another server's PID as its own")
 	}
 }
 
-// TestPageListsLiveInstances covers the switcher: a user with several agent
-// terminals open must be able to reach every other server's dashboard from any
-// one of them, and see at a glance which page they are on.
+// TestPageListsLiveInstances confirms sibling-server bookkeeping stays out of the
+// product dashboard. It remains available through --status.
 func TestPageListsLiveInstances(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -97,14 +81,9 @@ func TestPageListsLiveInstances(t *testing.T) {
 	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	body := rec.Body.String()
 
-	for _, want := range []string{
-		"Servers running",
-		"http://127.0.0.1:54545", // a clickable link to the sibling's dashboard
-		"other-repo",             // what the sibling has loaded
-		"this page",              // the row marking the current dashboard
-	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("body missing %q", want)
+	for _, operational := range []string{"Servers running", "http://127.0.0.1:54545", "other-repo", "this page"} {
+		if strings.Contains(body, operational) {
+			t.Errorf("body contains server-switcher detail %q", operational)
 		}
 	}
 }
@@ -122,8 +101,8 @@ func TestPageWithoutTrackerStillRenders(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "g1") {
-		t.Error("body missing the graph receipt")
+	if !strings.Contains(rec.Body.String(), "Your architecture is mapped.") {
+		t.Error("body missing the populated architecture state")
 	}
 }
 

--- a/pkg/dashboard/insights.go
+++ b/pkg/dashboard/insights.go
@@ -45,6 +45,12 @@ var insightLabels = map[string]string{
 	"crossrepo":           "Cross-repo dependencies",
 	"coverage":            "Coverage gaps",
 	"unused-routes":       "Unused routes",
+	"domain":              "Domain boundaries",
+	"query-loops":         "Query loops",
+	"entry-points":        "Entry points",
+	"messaging-coverage":  "Messaging coverage",
+	"intent":              "Intent",
+	"constraints":         "Constraint violations",
 }
 
 // mergedLabels returns the engine's label map widened by a wrapper's extra

--- a/pkg/dashboard/modulegraph.go
+++ b/pkg/dashboard/modulegraph.go
@@ -26,14 +26,21 @@ type moduleGraphView struct {
 	Width, Height int
 	Nodes         []moduleNode
 	Edges         []moduleEdge
+	AllModules    []string
 	Total         int
 	Limited       bool
+	Focused       bool
+	FocusName     string
 }
 
 // buildModuleGraph produces a deliberately bounded architecture map. It ranks
 // production modules by connectedness, keeps the most structurally relevant
 // ones, and renders only imports whose endpoints are both visible.
 func buildModuleGraph(store *facts.Store) *moduleGraphView {
+	return buildModuleGraphFocused(store, "")
+}
+
+func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView {
 	if store == nil {
 		return nil
 	}
@@ -101,13 +108,37 @@ func buildModuleGraph(store *facts.Store) *moduleGraphView {
 		return nil
 	}
 	total := len(ranked)
+	allModules := make([]string, 0, len(ranked))
+	for _, r := range ranked {
+		allModules = append(allModules, r.name)
+	}
+	focused := false
+	if center := byName[focus]; focus != "" && center != nil {
+		neighborhood := map[string]bool{focus: true}
+		for target := range center.out {
+			neighborhood[target] = true
+		}
+		for _, r := range ranked {
+			if r.out[focus] {
+				neighborhood[r.name] = true
+			}
+		}
+		selected := []*raw{center}
+		for _, r := range ranked {
+			if r.name != focus && neighborhood[r.name] {
+				selected = append(selected, r)
+			}
+		}
+		ranked = selected
+		focused = true
+	}
 	if len(ranked) > moduleGraphLimit {
 		ranked = ranked[:moduleGraphLimit]
 	}
 
 	const cols, nodeW, nodeH, gapX, gapY, margin = 4, 154, 36, 34, 34, 28
 	rows := (len(ranked) + cols - 1) / cols
-	view := &moduleGraphView{Width: margin*2 + cols*nodeW + (cols-1)*gapX, Height: margin*2 + rows*nodeH + (rows-1)*gapY, Total: total, Limited: total > len(ranked)}
+	view := &moduleGraphView{Width: margin*2 + cols*nodeW + (cols-1)*gapX, Height: margin*2 + rows*nodeH + (rows-1)*gapY, AllModules: allModules, Total: total, Limited: total > len(ranked), Focused: focused, FocusName: focus}
 	index := make(map[string]int, len(ranked))
 	for i, r := range ranked {
 		x := margin + (i%cols)*(nodeW+gapX)
@@ -117,6 +148,9 @@ func buildModuleGraph(store *facts.Store) *moduleGraphView {
 	}
 	for i, r := range ranked {
 		for target := range r.out {
+			if focused && r.name != focus && target != focus {
+				continue
+			}
 			j, ok := index[target]
 			if !ok {
 				continue

--- a/pkg/dashboard/modulegraph.go
+++ b/pkg/dashboard/modulegraph.go
@@ -7,30 +7,47 @@ import (
 	"github.com/enola-labs/enola/pkg/facts"
 )
 
-const moduleGraphLimit = 36
+const (
+	moduleGraphLimit         = 36
+	moduleGraphOverviewLimit = 18
+	moduleGraphOverviewEdges = 30
+	moduleSearchLimit        = 500
+)
 
 type moduleNode struct {
 	ID                        int
 	Name, Display, File, Repo string
+	Role                      string
 	X, Y                      int
 	FanIn, FanOut             int
 	Degree                    int
 }
 
 type moduleEdge struct {
-	Source, Target int
-	X1, Y1, X2, Y2 int
+	Source, Target         int
+	X1, Y1, X2, Y2         int
+	SourceName, TargetName string
+	SourceFile, TargetFile string
+	Kind                   string
 }
 
 type moduleGraphView struct {
-	Width, Height int
-	Nodes         []moduleNode
-	Edges         []moduleEdge
-	AllModules    []string
-	Total         int
-	Limited       bool
-	Focused       bool
-	FocusName     string
+	Width, Height       int
+	Nodes               []moduleNode
+	Edges               []moduleEdge
+	AllModules          []string
+	AllModulesTruncated bool
+	Total               int
+	Limited             bool
+	Focused             bool
+	FocusName           string
+	OmittedEdges        int
+}
+
+type moduleRaw struct {
+	name, file, repo string
+	out              map[string]bool
+	in               int
 }
 
 // buildModuleGraph produces a deliberately bounded architecture map. It ranks
@@ -49,18 +66,13 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 		return nil
 	}
 
-	type raw struct {
-		name, file, repo string
-		out              map[string]bool
-		in               int
-	}
-	byName := make(map[string]*raw, len(mods))
+	byName := make(map[string]*moduleRaw, len(mods))
 	for _, m := range mods {
 		if role, _ := m.Props[facts.PropModuleRole].(string); role == facts.ModuleRoleTest {
 			continue
 		}
 		if _, exists := byName[m.Name]; !exists {
-			byName[m.Name] = &raw{name: m.Name, file: m.File, repo: m.Repo, out: map[string]bool{}}
+			byName[m.Name] = &moduleRaw{name: m.Name, file: m.File, repo: m.Repo, out: map[string]bool{}}
 		}
 	}
 	for _, m := range mods {
@@ -91,7 +103,7 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 		}
 	}
 
-	ranked := make([]*raw, 0, len(byName))
+	ranked := make([]*moduleRaw, 0, len(byName))
 	for _, r := range byName {
 		if r.in+len(r.out) > 0 {
 			ranked = append(ranked, r)
@@ -108,8 +120,14 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 		return nil
 	}
 	total := len(ranked)
-	allModules := make([]string, 0, len(ranked))
-	for _, r := range ranked {
+	searchable := ranked
+	truncated := false
+	if len(searchable) > moduleSearchLimit {
+		searchable = searchable[:moduleSearchLimit]
+		truncated = true
+	}
+	allModules := make([]string, 0, len(searchable))
+	for _, r := range searchable {
 		allModules = append(allModules, r.name)
 	}
 	focused := false
@@ -123,7 +141,7 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 				neighborhood[r.name] = true
 			}
 		}
-		selected := []*raw{center}
+		selected := []*moduleRaw{center}
 		for _, r := range ranked {
 			if r.name != focus && neighborhood[r.name] {
 				selected = append(selected, r)
@@ -132,40 +150,140 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 		ranked = selected
 		focused = true
 	}
-	if len(ranked) > moduleGraphLimit {
-		ranked = ranked[:moduleGraphLimit]
+	limit := moduleGraphOverviewLimit
+	if focused {
+		limit = moduleGraphLimit
+	}
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
 	}
 
-	const cols, nodeW, nodeH, gapX, gapY, margin = 4, 154, 36, 34, 34, 28
-	rows := (len(ranked) + cols - 1) / cols
-	view := &moduleGraphView{Width: margin*2 + cols*nodeW + (cols-1)*gapX, Height: margin*2 + rows*nodeH + (rows-1)*gapY, AllModules: allModules, Total: total, Limited: total > len(ranked), Focused: focused, FocusName: focus}
-	index := make(map[string]int, len(ranked))
-	for i, r := range ranked {
-		x := margin + (i%cols)*(nodeW+gapX)
-		y := margin + (i/cols)*(nodeH+gapY)
-		view.Nodes = append(view.Nodes, moduleNode{ID: i, Name: r.name, Display: moduleLabel(r.name), File: r.file, Repo: r.repo, X: x, Y: y, FanIn: r.in, FanOut: len(r.out), Degree: r.in + len(r.out)})
-		index[r.name] = i
-	}
-	for i, r := range ranked {
-		for target := range r.out {
-			if focused && r.name != focus && target != focus {
-				continue
+	const nodeW, nodeH, gapX, gapY, margin = 154, 36, 72, 34, 28
+	layers := make(map[string]int, len(ranked))
+	roles := make(map[string]string, len(ranked))
+	if focused {
+		for _, r := range ranked {
+			switch {
+			case r.name == focus:
+				layers[r.name], roles[r.name] = 1, "selected"
+			case r.out[focus]:
+				layers[r.name], roles[r.name] = 0, "consumer"
+			default:
+				layers[r.name], roles[r.name] = 2, "dependency"
 			}
+		}
+	} else {
+		layers = dependencyLayers(ranked)
+		for _, r := range ranked {
+			roles[r.name] = "module"
+		}
+	}
+	byLayer := map[int][]*moduleRaw{}
+	maxLayer, maxRows := 0, 0
+	for _, r := range ranked {
+		layer := layers[r.name]
+		byLayer[layer] = append(byLayer[layer], r)
+		if layer > maxLayer {
+			maxLayer = layer
+		}
+	}
+	for _, rs := range byLayer {
+		if len(rs) > maxRows {
+			maxRows = len(rs)
+		}
+	}
+	view := &moduleGraphView{Width: margin*2 + (maxLayer+1)*nodeW + maxLayer*gapX, Height: margin*2 + maxRows*nodeH + (maxRows-1)*gapY, AllModules: allModules, AllModulesTruncated: truncated, Total: total, Limited: total > len(ranked), Focused: focused, FocusName: focus}
+	index := make(map[string]int, len(ranked))
+	for layer := 0; layer <= maxLayer; layer++ {
+		for row, r := range byLayer[layer] {
+			i := len(view.Nodes)
+			x := margin + layer*(nodeW+gapX)
+			y := margin + row*(nodeH+gapY)
+			view.Nodes = append(view.Nodes, moduleNode{ID: i, Name: r.name, Display: moduleLabel(r.name), File: r.file, Repo: r.repo, Role: roles[r.name], X: x, Y: y, FanIn: r.in, FanOut: len(r.out), Degree: r.in + len(r.out)})
+			index[r.name] = i
+		}
+	}
+	for _, r := range ranked {
+		for target := range r.out {
 			j, ok := index[target]
 			if !ok {
 				continue
 			}
+			i := index[r.name]
 			a, b := view.Nodes[i], view.Nodes[j]
-			view.Edges = append(view.Edges, moduleEdge{Source: i, Target: j, X1: a.X + nodeW/2, Y1: a.Y + nodeH/2, X2: b.X + nodeW/2, Y2: b.Y + nodeH/2})
+			view.Edges = append(view.Edges, moduleEdge{Source: i, Target: j, X1: a.X + nodeW, Y1: a.Y + nodeH/2, X2: b.X, Y2: b.Y + nodeH/2, SourceName: a.Name, TargetName: b.Name, SourceFile: a.File, TargetFile: b.File, Kind: facts.RelImports})
 		}
 	}
-	sort.Slice(view.Edges, func(i, j int) bool {
-		if view.Edges[i].Source != view.Edges[j].Source {
-			return view.Edges[i].Source < view.Edges[j].Source
-		}
-		return view.Edges[i].Target < view.Edges[j].Target
-	})
+	sortEdgesByEndpoints(view.Edges)
+	if !focused && len(view.Edges) > moduleGraphOverviewEdges {
+		view.OmittedEdges = len(view.Edges) - moduleGraphOverviewEdges
+		// Keep the edges between the most-connected endpoints rather than an
+		// arbitrary source/target-ordered prefix, so the truncated overview still
+		// shows the structurally significant dependency backbone.
+		sort.SliceStable(view.Edges, func(i, j int) bool {
+			di := view.Nodes[view.Edges[i].Source].Degree + view.Nodes[view.Edges[i].Target].Degree
+			dj := view.Nodes[view.Edges[j].Source].Degree + view.Nodes[view.Edges[j].Target].Degree
+			return di > dj
+		})
+		view.Edges = view.Edges[:moduleGraphOverviewEdges]
+		sortEdgesByEndpoints(view.Edges)
+	}
 	return view
+}
+
+func sortEdgesByEndpoints(edges []moduleEdge) {
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Source != edges[j].Source {
+			return edges[i].Source < edges[j].Source
+		}
+		return edges[i].Target < edges[j].Target
+	})
+}
+
+// dependencyLayers places consumers before the modules they depend on. Kahn's
+// algorithm gives acyclic regions stable layers; cycle members remain together
+// in the first layer, which truthfully exposes that no ordering exists for them.
+func dependencyLayers(ranked []*moduleRaw) map[string]int {
+	layers := make(map[string]int, len(ranked))
+	indegree := make(map[string]int, len(ranked))
+	visible := make(map[string]bool, len(ranked))
+	for _, r := range ranked {
+		visible[r.name] = true
+	}
+	for _, r := range ranked {
+		for target := range r.out {
+			if visible[target] {
+				indegree[target]++
+			}
+		}
+	}
+	queue := make([]string, 0, len(ranked))
+	for _, r := range ranked {
+		if indegree[r.name] == 0 {
+			queue = append(queue, r.name)
+		}
+	}
+	byName := make(map[string]*moduleRaw, len(ranked))
+	for _, r := range ranked {
+		byName[r.name] = r
+	}
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		for target := range byName[name].out {
+			if !visible[target] {
+				continue
+			}
+			if layers[target] < layers[name]+1 {
+				layers[target] = layers[name] + 1
+			}
+			indegree[target]--
+			if indegree[target] == 0 {
+				queue = append(queue, target)
+			}
+		}
+	}
+	return layers
 }
 
 func moduleLabel(name string) string {

--- a/pkg/dashboard/modulegraph.go
+++ b/pkg/dashboard/modulegraph.go
@@ -1,0 +1,150 @@
+package dashboard
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+const moduleGraphLimit = 36
+
+type moduleNode struct {
+	ID                        int
+	Name, Display, File, Repo string
+	X, Y                      int
+	FanIn, FanOut             int
+	Degree                    int
+}
+
+type moduleEdge struct {
+	Source, Target int
+	X1, Y1, X2, Y2 int
+}
+
+type moduleGraphView struct {
+	Width, Height int
+	Nodes         []moduleNode
+	Edges         []moduleEdge
+	Total         int
+	Limited       bool
+}
+
+// buildModuleGraph produces a deliberately bounded architecture map. It ranks
+// production modules by connectedness, keeps the most structurally relevant
+// ones, and renders only imports whose endpoints are both visible.
+func buildModuleGraph(store *facts.Store) *moduleGraphView {
+	if store == nil {
+		return nil
+	}
+	mods := store.ByKind(facts.KindModule)
+	if len(mods) == 0 {
+		return nil
+	}
+
+	type raw struct {
+		name, file, repo string
+		out              map[string]bool
+		in               int
+	}
+	byName := make(map[string]*raw, len(mods))
+	for _, m := range mods {
+		if role, _ := m.Props[facts.PropModuleRole].(string); role == facts.ModuleRoleTest {
+			continue
+		}
+		if _, exists := byName[m.Name]; !exists {
+			byName[m.Name] = &raw{name: m.Name, file: m.File, repo: m.Repo, out: map[string]bool{}}
+		}
+	}
+	for _, m := range mods {
+		r := byName[m.Name]
+		if r == nil {
+			continue
+		}
+		// Snapshot stores publish a built graph whose module→module import edges are
+		// synthesized from dependency facts. A small test/embedder store may not have
+		// built that index yet, so fall back to relations carried directly by modules.
+		type importEdge struct{ kind, target string }
+		edges := make([]importEdge, 0)
+		if graph := store.Graph(); graph != nil {
+			for _, edge := range graph.ForwardEdges(m.Name) {
+				edges = append(edges, importEdge{kind: edge.RelKind, target: edge.Target})
+			}
+		} else {
+			for _, rel := range m.Relations {
+				edges = append(edges, importEdge{kind: rel.Kind, target: rel.Target})
+			}
+		}
+		for _, edge := range edges {
+			if edge.kind != facts.RelImports || edge.target == m.Name || byName[edge.target] == nil || r.out[edge.target] {
+				continue
+			}
+			r.out[edge.target] = true
+			byName[edge.target].in++
+		}
+	}
+
+	ranked := make([]*raw, 0, len(byName))
+	for _, r := range byName {
+		if r.in+len(r.out) > 0 {
+			ranked = append(ranked, r)
+		}
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		di, dj := ranked[i].in+len(ranked[i].out), ranked[j].in+len(ranked[j].out)
+		if di != dj {
+			return di > dj
+		}
+		return ranked[i].name < ranked[j].name
+	})
+	if len(ranked) == 0 {
+		return nil
+	}
+	total := len(ranked)
+	if len(ranked) > moduleGraphLimit {
+		ranked = ranked[:moduleGraphLimit]
+	}
+
+	const cols, nodeW, nodeH, gapX, gapY, margin = 4, 154, 36, 34, 34, 28
+	rows := (len(ranked) + cols - 1) / cols
+	view := &moduleGraphView{Width: margin*2 + cols*nodeW + (cols-1)*gapX, Height: margin*2 + rows*nodeH + (rows-1)*gapY, Total: total, Limited: total > len(ranked)}
+	index := make(map[string]int, len(ranked))
+	for i, r := range ranked {
+		x := margin + (i%cols)*(nodeW+gapX)
+		y := margin + (i/cols)*(nodeH+gapY)
+		view.Nodes = append(view.Nodes, moduleNode{ID: i, Name: r.name, Display: moduleLabel(r.name), File: r.file, Repo: r.repo, X: x, Y: y, FanIn: r.in, FanOut: len(r.out), Degree: r.in + len(r.out)})
+		index[r.name] = i
+	}
+	for i, r := range ranked {
+		for target := range r.out {
+			j, ok := index[target]
+			if !ok {
+				continue
+			}
+			a, b := view.Nodes[i], view.Nodes[j]
+			view.Edges = append(view.Edges, moduleEdge{Source: i, Target: j, X1: a.X + nodeW/2, Y1: a.Y + nodeH/2, X2: b.X + nodeW/2, Y2: b.Y + nodeH/2})
+		}
+	}
+	sort.Slice(view.Edges, func(i, j int) bool {
+		if view.Edges[i].Source != view.Edges[j].Source {
+			return view.Edges[i].Source < view.Edges[j].Source
+		}
+		return view.Edges[i].Target < view.Edges[j].Target
+	})
+	return view
+}
+
+func moduleLabel(name string) string {
+	const limit = 25
+	if len(name) <= limit {
+		return name
+	}
+	parts := strings.Split(name, "/")
+	if len(parts) > 1 {
+		tail := parts[len(parts)-2] + "/" + parts[len(parts)-1]
+		if len(tail) <= limit {
+			return tail
+		}
+	}
+	return "…" + name[len(name)-(limit-1):]
+}

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -42,11 +42,37 @@ func TestModuleGraphPageExplainsScopeAndProvidesModuleTable(t *testing.T) {
 	for _, want := range []string{
 		"Showing 2 of 2 connected modules", "1 visible dependencies",
 		"Most-connected modules in this view", "Used by", "Depends on",
-		`onclick="focusModule('`, "Filter visible modules",
+		`onclick="focusModule('`, "Search every module",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("module graph page missing %q", want)
 		}
+	}
+}
+
+func TestBuildModuleGraphFocusesOnImmediateNeighborhood(t *testing.T) {
+	st := facts.NewStore()
+	st.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "core", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "api"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "api", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "storage"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "storage"},
+		facts.Fact{Kind: facts.KindModule, Name: "unrelated", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "other"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "other"},
+	)
+	view := buildModuleGraphFocused(st, "api")
+	if view == nil || !view.Focused || view.FocusName != "api" || len(view.Nodes) != 3 {
+		t.Fatalf("focused view = %+v, want api plus core/storage", view)
+	}
+	if len(view.Edges) != 2 {
+		t.Fatalf("focused edges = %+v, want only edges incident to api", view.Edges)
+	}
+	for _, node := range view.Nodes {
+		if node.Name == "unrelated" || node.Name == "other" {
+			t.Fatalf("focused view contains unrelated node %+v", node)
+		}
+	}
+	if len(view.AllModules) != 5 {
+		t.Fatalf("search index = %d modules, want all 5", len(view.AllModules))
 	}
 }
 

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -42,7 +42,8 @@ func TestModuleGraphPageExplainsScopeAndProvidesModuleTable(t *testing.T) {
 	for _, want := range []string{
 		"Showing 2 of 2 connected modules", "1 visible dependencies",
 		"Most-connected modules in this view", "Used by", "Depends on",
-		`onclick="focusModule('`, "Search every module",
+		`onclick="focusModule('`, "Search every module", "Layered by dependency direction",
+		"selectDependency(this)", "module-level evidence", "window.location.assign('/?module='",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("module graph page missing %q", want)
@@ -66,13 +67,64 @@ func TestBuildModuleGraphFocusesOnImmediateNeighborhood(t *testing.T) {
 	if len(view.Edges) != 2 {
 		t.Fatalf("focused edges = %+v, want only edges incident to api", view.Edges)
 	}
+	roles := map[string]string{}
+	positions := map[string]int{}
 	for _, node := range view.Nodes {
 		if node.Name == "unrelated" || node.Name == "other" {
 			t.Fatalf("focused view contains unrelated node %+v", node)
 		}
+		roles[node.Name], positions[node.Name] = node.Role, node.X
+	}
+	if roles["core"] != "consumer" || roles["api"] != "selected" || roles["storage"] != "dependency" {
+		t.Fatalf("focused roles = %+v", roles)
+	}
+	if !(positions["core"] < positions["api"] && positions["api"] < positions["storage"]) {
+		t.Fatalf("focused x positions = %+v, want consumer < selected < dependency", positions)
+	}
+	if view.Edges[0].Kind != facts.RelImports || view.Edges[0].SourceName == "" || view.Edges[0].TargetName == "" {
+		t.Fatalf("edge lacks inspectable evidence: %+v", view.Edges[0])
 	}
 	if len(view.AllModules) != 5 {
 		t.Fatalf("search index = %d modules, want all 5", len(view.AllModules))
+	}
+}
+
+func TestBuildModuleGraphFocusedIncludesNeighborhoodEdges(t *testing.T) {
+	st := facts.NewStore()
+	st.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "core", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "api"}, {Kind: facts.RelImports, Target: "storage"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "api", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "storage"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "storage"},
+	)
+	view := buildModuleGraphFocused(st, "api")
+	if view == nil || len(view.Edges) != 3 {
+		t.Fatalf("focused edges = %+v, want core->api, api->storage, and core->storage (both endpoints in the neighborhood)", view.Edges)
+	}
+	found := false
+	for _, e := range view.Edges {
+		if e.SourceName == "core" && e.TargetName == "storage" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("focused edges = %+v, want core->storage even though neither endpoint is the focus module", view.Edges)
+	}
+}
+
+func TestBuildModuleGraphLayersConsumersBeforeDependencies(t *testing.T) {
+	st := facts.NewStore()
+	st.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "web", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "service"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "service", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "storage"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "storage"},
+	)
+	view := buildModuleGraph(st)
+	positions := map[string]int{}
+	for _, node := range view.Nodes {
+		positions[node.Name] = node.X
+	}
+	if !(positions["web"] < positions["service"] && positions["service"] < positions["storage"]) {
+		t.Fatalf("layer positions = %+v, want web < service < storage", positions)
 	}
 }
 
@@ -84,7 +136,24 @@ func TestBuildModuleGraphCapsLargeRepositories(t *testing.T) {
 		st.Add(facts.Fact{Kind: facts.KindModule, Name: name, Relations: []facts.Relation{{Kind: facts.RelImports, Target: target}}})
 	}
 	view := buildModuleGraph(st)
-	if view == nil || len(view.Nodes) != moduleGraphLimit || !view.Limited || view.Total != moduleGraphLimit+10 {
-		t.Fatalf("view = %+v, want %d of %d modules", view, moduleGraphLimit, moduleGraphLimit+10)
+	if view == nil || len(view.Nodes) != moduleGraphOverviewLimit || !view.Limited || view.Total != moduleGraphLimit+10 {
+		t.Fatalf("view = %+v, want %d of %d modules", view, moduleGraphOverviewLimit, moduleGraphLimit+10)
+	}
+}
+
+func TestBuildModuleGraphCapsOverviewEdges(t *testing.T) {
+	st := facts.NewStore()
+	for i := 0; i < moduleGraphOverviewLimit; i++ {
+		relations := make([]facts.Relation, 0, moduleGraphOverviewLimit-1)
+		for j := 0; j < moduleGraphOverviewLimit; j++ {
+			if i != j {
+				relations = append(relations, facts.Relation{Kind: facts.RelImports, Target: fmt.Sprintf("m%02d", j)})
+			}
+		}
+		st.Add(facts.Fact{Kind: facts.KindModule, Name: fmt.Sprintf("m%02d", i), Relations: relations})
+	}
+	view := buildModuleGraph(st)
+	if len(view.Edges) != moduleGraphOverviewEdges || view.OmittedEdges == 0 {
+		t.Fatalf("overview edges = %d, omitted = %d", len(view.Edges), view.OmittedEdges)
 	}
 }

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -2,6 +2,9 @@ package dashboard
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/enola-labs/enola/pkg/facts"
@@ -22,6 +25,28 @@ func TestBuildModuleGraphRanksBoundsAndLinks(t *testing.T) {
 	}
 	if view.Nodes[0].Name != "core" || view.Nodes[0].FanIn != 1 || view.Nodes[0].FanOut != 2 {
 		t.Errorf("top node = %+v, want core with fan-in 1 / fan-out 2", view.Nodes[0])
+	}
+}
+
+func TestModuleGraphPageExplainsScopeAndProvidesModuleTable(t *testing.T) {
+	st := facts.NewStore()
+	st.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "core", File: "src/core", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "api"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "api", File: "src/api"},
+	)
+	s := newTestServer(8080, fakeArtifacts{store: st})
+	rec := httptest.NewRecorder()
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"Showing 2 of 2 connected modules", "1 visible dependencies",
+		"Most-connected modules in this view", "Used by", "Depends on",
+		`onclick="focusModule('`, "Filter visible modules",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("module graph page missing %q", want)
+		}
 	}
 }
 

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -1,0 +1,39 @@
+package dashboard
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/enola-labs/enola/pkg/facts"
+)
+
+func TestBuildModuleGraphRanksBoundsAndLinks(t *testing.T) {
+	st := facts.NewStore()
+	st.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "core", File: "src/core", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "api"}, {Kind: facts.RelImports, Target: "storage"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "api", File: "src/api", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "core"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "storage", File: "src/storage"},
+		facts.Fact{Kind: facts.KindModule, Name: "core_test", File: "tests/core", Props: map[string]any{facts.PropModuleRole: facts.ModuleRoleTest}, Relations: []facts.Relation{{Kind: facts.RelImports, Target: "core"}}},
+	)
+
+	view := buildModuleGraph(st)
+	if view == nil || len(view.Nodes) != 3 || len(view.Edges) != 3 {
+		t.Fatalf("view = %+v, want 3 production nodes and 3 directed edges", view)
+	}
+	if view.Nodes[0].Name != "core" || view.Nodes[0].FanIn != 1 || view.Nodes[0].FanOut != 2 {
+		t.Errorf("top node = %+v, want core with fan-in 1 / fan-out 2", view.Nodes[0])
+	}
+}
+
+func TestBuildModuleGraphCapsLargeRepositories(t *testing.T) {
+	st := facts.NewStore()
+	for i := 0; i < moduleGraphLimit+10; i++ {
+		name := fmt.Sprintf("m%02d", i)
+		target := fmt.Sprintf("m%02d", (i+1)%(moduleGraphLimit+10))
+		st.Add(facts.Fact{Kind: facts.KindModule, Name: name, Relations: []facts.Relation{{Kind: facts.RelImports, Target: target}}})
+	}
+	view := buildModuleGraph(st)
+	if view == nil || len(view.Nodes) != moduleGraphLimit || !view.Limited || view.Total != moduleGraphLimit+10 {
+		t.Fatalf("view = %+v, want %d of %d modules", view, moduleGraphLimit, moduleGraphLimit+10)
+	}
+}

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -80,7 +80,7 @@ func TestBuildModuleGraphFocusesOnImmediateNeighborhood(t *testing.T) {
 	if roles["core"] != "consumer" || roles["api"] != "selected" || roles["storage"] != "dependency" {
 		t.Fatalf("focused roles = %+v", roles)
 	}
-	if !(positions["core"] < positions["api"] && positions["api"] < positions["storage"]) {
+	if positions["core"] >= positions["api"] || positions["api"] >= positions["storage"] {
 		t.Fatalf("focused x positions = %+v, want consumer < selected < dependency", positions)
 	}
 	if view.Edges[0].Kind != facts.RelImports || view.Edges[0].SourceName == "" || view.Edges[0].TargetName == "" {
@@ -125,7 +125,7 @@ func TestBuildModuleGraphLayersConsumersBeforeDependencies(t *testing.T) {
 	for _, node := range view.Nodes {
 		positions[node.Name] = node.X
 	}
-	if !(positions["web"] < positions["service"] && positions["service"] < positions["storage"]) {
+	if positions["web"] >= positions["service"] || positions["service"] >= positions["storage"] {
 		t.Fatalf("layer positions = %+v, want web < service < storage", positions)
 	}
 }

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -40,10 +40,12 @@ func TestModuleGraphPageExplainsScopeAndProvidesModuleTable(t *testing.T) {
 	body := rec.Body.String()
 
 	for _, want := range []string{
-		"Showing 2 of 2 connected modules", "1 visible dependencies",
-		"Most-connected modules in this view", "Used by", "Depends on",
+		"Showing 2 of 2 connected modules", "1 visible module dependencies",
+		"Most-connected modules in this view", "Consumer modules", "Dependency modules",
 		`onclick="focusModule('`, "Search every module", "Layered by dependency direction",
 		"selectDependency(this)", "module-level evidence", "window.location.assign('/?module='",
+		"Architecture inspector", "Nothing selected", "Fit view", "toggleGraphFit(this)",
+		"Map shows module imports", "symbol-level finding", "enola-selected-finding",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("module graph page missing %q", want)

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -16,7 +16,7 @@
       margin: 0; padding: 1.5rem 1.25rem 3rem; background: var(--bg); color: var(--fg);
       font: 14px/1.55 "Instrument Sans", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
-    .wrap { max-width: 1000px; margin: 0 auto; }
+    .wrap { max-width: 1180px; margin: 0 auto; }
     header { display: flex; flex-wrap: wrap; align-items: baseline; gap: .75rem; margin-bottom: .25rem; }
     h1, h2, h3 { font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     h1 { font-size: 1.4rem; margin: 0; }
@@ -47,6 +47,7 @@
     .project-link svg { width: 13px; height: 13px; fill: currentColor; }
     code { background: var(--th); padding: .05rem .3rem; border-radius: 4px; }
     .topbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
+    .top-actions { display: flex; align-items: center; gap: .55rem; }
     .brand { display: flex; align-items: center; font-size: 1.15rem; font-weight: 750; letter-spacing: -.04em; }
     .brand h1 { font: inherit; margin: 0; }
     .brand-dot { color: var(--violet); }
@@ -94,10 +95,15 @@
     .graph-search:focus { border-color: #6f8fff; box-shadow: 0 0 0 2px rgba(111,143,255,.14); }
     .graph-search-form { display: flex; gap: .4rem; }
     .secondary-action { border: 1px solid var(--border); border-radius: 8px; padding: .5rem .7rem; background: var(--card); color: var(--fg); cursor: pointer; font: inherit; font-weight: 600; }
-    .explorer { display: flex; flex-direction: column; min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
-    .findings-pane { border-top: 1px solid var(--border); background: #08112b; padding: .85rem 1rem; }
+    .explorer { display: grid; grid-template-columns: minmax(0, 1fr) 300px; min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
+    .inspector-pane { min-width: 0; border-left: 1px solid var(--border); background: #08112b; }
+    .inspector-head { padding: .85rem 1rem; border-bottom: 1px solid var(--border); }
+    .inspector-head h3 { margin: 0; font-size: .88rem; }
+    .inspector-head p { margin: .2rem 0 0; color: #7180aa; font-size: .68rem; }
+    .inspector-empty { padding: .9rem 1rem; color: var(--muted); font-size: .75rem; }
+    .findings-pane { border-top: 1px solid var(--border); padding: .85rem 1rem; }
     .findings-pane h3 { margin: .2rem .35rem .7rem; font-size: .82rem; }
-    .findings-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0 .9rem; max-height: 230px; overflow: auto; }
+    .findings-groups { max-height: 390px; overflow: auto; }
     .finding-group { border-top: 1px solid var(--border); }
     .finding-group:first-of-type { border-top: 0; }
     .finding-group > summary { display: flex; justify-content: space-between; gap: .5rem; cursor: pointer; padding: .65rem .35rem; color: #cbd3eb; font-size: .76rem; font-weight: 600; list-style: none; }
@@ -109,6 +115,7 @@
     .graph-pane { position: relative; display: flex; flex-direction: column; min-width: 0; }
     .graph-canvas { flex: 1; min-height: 420px; overflow: auto; padding: .5rem; background-image: radial-gradient(rgba(139,165,255,.13) .7px, transparent .7px); background-size: 18px 18px; }
     .module-graph { display: block; width: auto; min-width: 100%; height: auto; }
+    .graph-canvas.fit .module-graph { width: 100%; min-width: 100%; }
     .module-edge { stroke: #536a9f; stroke-width: 1.2; opacity: .34; transition: opacity .18s, stroke .18s; pointer-events: none; }
     .module-edge-hit { stroke: transparent; stroke-width: 12; cursor: pointer; }
     .module-edge-hit:hover + .module-edge { opacity: 1; stroke: #9b75e8; stroke-width: 2; }
@@ -119,11 +126,11 @@
     .module-node[data-role="selected"] rect { fill: #23336b; stroke: #9b75e8; stroke-width: 2; }
     .module-node.dim, .module-edge.dim { opacity: .12; }
     .module-edge.active { opacity: .9; stroke: #9b75e8; stroke-width: 1.8; }
-    .module-detail { display: none; border-top: 1px solid var(--border); padding: .8rem 1rem; background: #0a1432; }
-    .module-detail.open { display: flex; align-items: start; justify-content: space-between; gap: 1rem; }
+    .module-detail { display: none; padding: .9rem 1rem; background: #0a1432; }
+    .module-detail.open { display: block; }
     .module-detail b { display: block; font-size: .82rem; }
     .module-detail span { color: #8f9bbb; font-size: .7rem; }
-    .module-stats { display: flex; gap: 1rem; white-space: nowrap; font: .65rem ui-monospace, SFMono-Regular, Menlo, monospace; color: #9bb4f5; }
+    .module-stats { display: flex; flex-wrap: wrap; gap: .35rem .8rem; margin-top: .65rem; font: .65rem ui-monospace, SFMono-Regular, Menlo, monospace; color: #9bb4f5; }
     .graph-columns { display: grid; grid-template-columns: repeat(3, 1fr); gap: 72px; padding: .55rem 28px 0; color: #8294c8; font: .62rem ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .08em; }
     .graph-columns span:nth-child(2) { text-align: center; }
     .graph-columns span:last-child { text-align: right; }
@@ -133,7 +140,7 @@
     .quality-disclosure { margin-top: 1.5rem; border-top: 1px solid var(--border); }
     .quality-disclosure > summary { cursor: pointer; padding: .9rem 0; color: #aeb8d4; font-size: .78rem; }
     .quality-disclosure[open] > summary { color: #fff; }
-    @media (max-width: 760px) { body { padding: 1rem; } .topbar { align-items: flex-start; } .graph-canvas { min-height: 300px; } .findings-groups { max-height: 180px; } .quality-row { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 860px) { body { padding: 1rem; } .topbar { align-items: flex-start; } .explorer { grid-template-columns: 1fr; } .inspector-pane { border-left: 0; border-top: 1px solid var(--border); } .graph-canvas { min-height: 300px; } .findings-groups { max-height: 220px; } .quality-row { grid-template-columns: repeat(2, 1fr); } }
     .count-link {
       background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
       color: var(--accent); font: inherit; font-weight: 600; text-decoration: underline;
@@ -204,7 +211,10 @@
 <div class="wrap">
   <div class="topbar">
     <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span></h1></div>
-    {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
+    <div class="top-actions">
+      {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
+      <button class="secondary-action" type="button" onclick="location.reload()" title="Reload the dashboard from the currently loaded snapshot">Refresh data</button>
+    </div>
   </div>
 
   <nav class="tabs" role="tablist" aria-label="Dashboard sections">
@@ -271,12 +281,14 @@
       <input id="module-search" class="graph-search" name="module" type="search" list="all-modules" value="{{.ModuleGraph.FocusName}}" placeholder="Search every module…" aria-label="Search every module">
       <datalist id="all-modules">{{range .ModuleGraph.AllModules}}<option value="{{.}}">{{end}}</datalist>
       <button class="secondary-action" type="submit">Explore</button>
+      <button class="secondary-action" type="button" id="graph-fit" aria-pressed="false" onclick="toggleGraphFit(this)">Fit view</button>
     </form>
   </div>
   {{$graph := .ModuleGraph}}
   <div class="graph-summary">
+    <span class="chip">Module graph</span>
     {{if $graph.Focused}}<span class="chip">Neighborhood of {{$graph.FocusName}}</span>{{else}}<span class="chip">Showing {{len $graph.Nodes}} of {{$graph.Total}} connected modules</span>{{end}}
-    <span class="chip">{{len $graph.Edges}} visible dependencies{{if $graph.OmittedEdges}} · {{$graph.OmittedEdges}} hidden for clarity{{end}}</span>
+    <span class="chip">{{len $graph.Edges}} visible module dependencies{{if $graph.OmittedEdges}} · {{$graph.OmittedEdges}} hidden for clarity{{end}}</span>
     {{if not $graph.Focused}}<span class="chip">Layered by dependency direction</span>{{end}}
   </div>
   <p class="note">Search covers {{if $graph.AllModulesTruncated}}the {{len $graph.AllModules}} most-connected of {{$graph.Total}}{{else}}all {{$graph.Total}}{{end}} connected modules. {{if $graph.Focused}}This view contains the selected module, its immediate incoming and outgoing dependencies, and the dependencies between them. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}</p>
@@ -290,24 +302,28 @@
           {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-role="{{.Role}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" onclick="selectModule(this)"><title>{{.Name}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
         </svg>
       </div>
-      <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div></div>
       {{if $graph.Limited}}<div class="graph-note">{{if $graph.Focused}}This neighborhood is bounded to keep individual relationships inspectable.{{else}}This overview shows the most-connected modules and a representative dependency backbone. Search for any module to inspect its complete immediate neighborhood.{{end}}</div>{{end}}
     </div>
-    {{if .Insights}}<aside class="findings-pane">
+    <aside class="inspector-pane" aria-label="Architecture inspector">
+      <div class="inspector-head"><h3>Inspector</h3><p>Select a module, dependency, or finding to inspect it.</p></div>
+      <div id="inspector-empty" class="inspector-empty">Nothing selected. Choose a node or edge on the map.</div>
+      <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div></div>
+      {{if .Insights}}<div class="findings-pane">
       <h3>Findings <span class="note">({{.InsightTotal}})</span> <button type="button" class="count-link" onclick="openModal('insights-modal')">review all</button></h3>
       <div class="findings-groups">{{range .Insights}}
       <details class="finding-group">
         <summary><span>{{.Label}}</span><span class="finding-count">{{.Count}}</span></summary>
-        {{range .Items}}<button type="button" class="finding-button" data-evidence="{{.Evidence}}" onclick="selectFinding(this)">{{.Title}}<span class="finding-meta">{{.Confidence}}%{{if .Evidence}} · {{.Evidence}}{{end}}</span></button>{{end}}
+        {{range .Items}}<button type="button" class="finding-button" data-title="{{.Title}}" data-confidence="{{.Confidence}}" data-evidence="{{.Evidence}}" onclick="selectFinding(this)">{{.Title}}<span class="finding-meta">{{.Confidence}}%{{if .Evidence}} · {{.Evidence}}{{end}}</span></button>{{end}}
       </details>
       {{end}}</div>
-    </aside>{{end}}
+      </div>{{end}}
+    </aside>
   </section>
 
   <div class="data-section"><h2>Most-connected modules in this view</h2>
-  <p class="note">Select a row to isolate its incoming and outgoing dependencies on the map.</p>
+  <p class="note">These counts describe module imports. Symbol-level finding counts may be larger because many call sites can live inside one module.</p>
   <div class="table-scroll"><table class="module-table">
-    <thead><tr><th>Module</th><th>File</th><th class="num">Used by</th><th class="num">Depends on</th><th class="num">Connections</th></tr></thead>
+    <thead><tr><th>Module</th><th>File</th><th class="num">Consumer modules</th><th class="num">Dependency modules</th><th class="num">Connections</th></tr></thead>
     <tbody>{{range $graph.Nodes}}<tr><td><button type="button" class="count-link" onclick="focusModule('{{.ID}}')">{{.Name}}</button></td><td>{{.File}}</td><td class="num">{{.FanIn}}</td><td class="num">{{.FanOut}}</td><td class="num">{{.Degree}}</td></tr>{{end}}</tbody>
   </table></div></div>
   {{else}}<p class="note">No module dependencies loaded yet.</p>{{end}}
@@ -478,7 +494,7 @@
   </main>
 
   <footer>
-    <span>{{.Title}} · read-only · updates every {{.RefreshSeconds}} seconds</span>
+    <span>Read-only dashboard</span>
     <a class="project-link" href="https://github.com/enola-labs/enola" target="_blank" rel="noopener noreferrer" aria-label="Star Enola on GitHub">
       <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.2l2.05 4.15 4.58.67-3.31 3.22.78 4.56L8 11.65 3.9 13.8l.78-4.56L1.37 6.02l4.58-.67L8 1.2z"/></svg>
       Open source on GitHub · Star Enola
@@ -689,16 +705,9 @@
     selectTab(name, false);
   }
 
-  // JS-driven auto-refresh (replaces the old <meta refresh>) so it can be paused
-  // while a modal is open — otherwise a reload would close the modal mid-read.
-  var refreshMs = {{.RefreshSeconds}} * 1000;
-  var reloadTimer = null;
-  function startRefresh() { stopRefresh(); reloadTimer = setTimeout(function () { location.reload(); }, refreshMs); }
-  function stopRefresh() { if (reloadTimer !== null) { clearTimeout(reloadTimer); reloadTimer = null; } }
   function openModal(id) {
     var m = document.getElementById(id);
     if (!m) return;
-    stopRefresh();
     m.classList.add('open');
     if (id === 'insights-modal') {
       var sel = document.getElementById('insight-band');
@@ -772,6 +781,20 @@
     graphNodes().forEach(function(n) { n.classList.remove('active', 'dim'); });
     graphEdges().forEach(function(e) { e.classList.remove('active', 'dim'); });
   }
+  function openInspector() {
+    var empty = document.getElementById('inspector-empty');
+    var detail = document.getElementById('module-detail');
+    if (empty) empty.hidden = true;
+    if (detail) detail.classList.add('open');
+    return detail;
+  }
+  function toggleGraphFit(button) {
+    var canvas = document.querySelector('.graph-canvas');
+    if (!canvas) return;
+    var fit = canvas.classList.toggle('fit');
+    button.setAttribute('aria-pressed', fit ? 'true' : 'false');
+    button.textContent = fit ? 'Readable size' : 'Fit view';
+  }
   function selectModule(node) {
     clearGraphFocus();
     var id = node.getAttribute('data-id');
@@ -787,13 +810,12 @@
       n.classList.toggle('active', n === node);
       n.classList.toggle('dim', !related[n.getAttribute('data-id')]);
     });
-    var detail = document.getElementById('module-detail');
+    var detail = openInspector();
     if (detail) {
-      detail.classList.add('open');
       document.getElementById('module-detail-name').textContent = node.getAttribute('data-name');
       document.getElementById('module-detail-file').textContent = node.getAttribute('data-file') || '';
-      document.getElementById('module-detail-in').textContent = 'used by ' + node.getAttribute('data-in');
-      document.getElementById('module-detail-out').textContent = 'depends on ' + node.getAttribute('data-out');
+      document.getElementById('module-detail-in').textContent = node.getAttribute('data-in') + ' consumer modules';
+      document.getElementById('module-detail-out').textContent = node.getAttribute('data-out') + ' dependency modules';
     }
   }
   function selectDependency(hit) {
@@ -810,9 +832,8 @@
       e.classList.toggle('active', selected);
       e.classList.toggle('dim', !selected);
     });
-    var detail = document.getElementById('module-detail');
+    var detail = openInspector();
     if (!detail) return;
-    detail.classList.add('open');
     document.getElementById('module-detail-name').textContent = hit.getAttribute('data-source-name') + ' → ' + hit.getAttribute('data-target-name');
     var sourceFile = hit.getAttribute('data-source-file') || 'source file unavailable';
     var targetFile = hit.getAttribute('data-target-file') || 'target file unavailable';
@@ -840,6 +861,7 @@
     document.querySelectorAll('.finding-button').forEach(function(b) { b.classList.toggle('active', b === button); });
     clearGraphFocus();
     var evidence = (button.getAttribute('data-evidence') || '').toLowerCase();
+	showFindingInspector(button);
     if (!evidence) return;
     var matches = {};
     graphNodes().forEach(function(n) {
@@ -859,6 +881,13 @@
 	    if (belongsToModule && moduleName.length > bestModule.length) bestModule = option.value;
 	  });
 	  if (bestModule) {
+	    try {
+	      sessionStorage.setItem('enola-selected-finding', JSON.stringify({
+	        title: button.getAttribute('data-title') || '',
+	        confidence: button.getAttribute('data-confidence') || '',
+	        evidence: button.getAttribute('data-evidence') || ''
+	      }));
+	    } catch (_) {}
 	    window.location.assign('/?module=' + encodeURIComponent(bestModule) + '#architecture');
 	    return;
 	  }
@@ -869,12 +898,35 @@
       e.classList.toggle('dim', !active);
     });
   }
+  function showFindingInspector(button) {
+    showFindingDetails({
+      title: button.getAttribute('data-title') || button.textContent.trim(),
+      confidence: button.getAttribute('data-confidence') || '',
+      evidence: button.getAttribute('data-evidence') || ''
+    });
+  }
+  function showFindingDetails(finding) {
+    var detail = openInspector();
+    if (!detail) return;
+    var symbolLevel = (finding.title || '').toLowerCase().indexOf('symbol') !== -1;
+    document.getElementById('module-detail-name').textContent = finding.title || 'Selected finding';
+    document.getElementById('module-detail-file').textContent = finding.evidence || 'No file evidence';
+    document.getElementById('module-detail-in').textContent = (finding.confidence ? finding.confidence + '% · ' : '') + (symbolLevel ? 'symbol-level finding' : 'finding');
+    document.getElementById('module-detail-out').textContent = 'Map shows module imports';
+  }
+  function restoreFindingInspector() {
+    try {
+      var raw = sessionStorage.getItem('enola-selected-finding');
+      if (!raw) return;
+      sessionStorage.removeItem('enola-selected-finding');
+      showFindingDetails(JSON.parse(raw));
+    } catch (_) {}
+  }
   {{/* extra-scripts: extension slot — see pkg/dashboard.Options.Overlay */}}
   {{block "extra-scripts" $}}{{end}}
   function closeModal(el) {
     var m = el && el.closest ? el.closest('.modal') : el;
     if (m && m.classList) m.classList.remove('open');
-    startRefresh();
   }
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
@@ -891,7 +943,7 @@
   });
   window.addEventListener('hashchange', initialTab);
   initialTab();
-  startRefresh();
+  restoreFindingInspector();
 </script>
 </body>
 </html>

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -41,7 +41,10 @@
     .note { color: var(--muted); font-style: italic; }
     .chips { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .2rem; }
     .chip { background: var(--th); border: 1px solid var(--border); border-radius: 6px; padding: .05rem .45rem; font-size: .8rem; }
-    footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: #7784a4; font-size: .72rem; }
+    footer { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .75rem; margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: #7784a4; font-size: .72rem; }
+    .project-link { display: inline-flex; align-items: center; gap: .35rem; color: #8996b8; text-decoration: none; }
+    .project-link:hover { color: var(--fg); }
+    .project-link svg { width: 13px; height: 13px; fill: currentColor; }
     code { background: var(--th); padding: .05rem .3rem; border-radius: 4px; }
     .topbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
     .brand { display: flex; align-items: center; font-size: 1.15rem; font-weight: 750; letter-spacing: -.04em; }
@@ -442,7 +445,13 @@
   </section>
   </main>
 
-  <footer>{{.Title}} · read-only · updates every {{.RefreshSeconds}} seconds</footer>
+  <footer>
+    <span>{{.Title}} · read-only · updates every {{.RefreshSeconds}} seconds</span>
+    <a class="project-link" href="https://github.com/enola-labs/enola" target="_blank" rel="noopener noreferrer" aria-label="Star Enola on GitHub">
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.2l2.05 4.15 4.58.67-3.31 3.22.78 4.56L8 11.65 3.9 13.8l.78-4.56L1.37 6.02l4.58-.67L8 1.2z"/></svg>
+      Open source on GitHub · Star Enola
+    </a>
+  </footer>
 </div>
 
 {{if .Services}}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -108,12 +108,15 @@
     .finding-meta { display: block; color: #7180aa; margin-top: .2rem; font: .6rem ui-monospace, SFMono-Regular, Menlo, monospace; }
     .graph-pane { position: relative; display: flex; flex-direction: column; min-width: 0; }
     .graph-canvas { flex: 1; min-height: 420px; overflow: auto; padding: .5rem; background-image: radial-gradient(rgba(139,165,255,.13) .7px, transparent .7px); background-size: 18px 18px; }
-    .module-graph { display: block; width: 100%; height: auto; }
-    .module-edge { stroke: #33446f; stroke-width: 1; opacity: .07; transition: opacity .18s, stroke .18s; }
+    .module-graph { display: block; width: auto; min-width: 100%; height: auto; }
+    .module-edge { stroke: #536a9f; stroke-width: 1.2; opacity: .34; transition: opacity .18s, stroke .18s; pointer-events: none; }
+    .module-edge-hit { stroke: transparent; stroke-width: 12; cursor: pointer; }
+    .module-edge-hit:hover + .module-edge { opacity: 1; stroke: #9b75e8; stroke-width: 2; }
     .module-node { cursor: pointer; transition: opacity .18s; }
     .module-node rect { fill: #0d193b; stroke: #33456f; rx: 7; transition: fill .18s, stroke .18s; }
-    .module-node text { fill: #cbd3eb; font: 8px ui-monospace, SFMono-Regular, Menlo, monospace; pointer-events: none; }
+    .module-node text { fill: #cbd3eb; font: 10px ui-monospace, SFMono-Regular, Menlo, monospace; pointer-events: none; }
     .module-node:hover rect, .module-node.active rect { fill: #172657; stroke: #7d92e4; }
+    .module-node[data-role="selected"] rect { fill: #23336b; stroke: #9b75e8; stroke-width: 2; }
     .module-node.dim, .module-edge.dim { opacity: .12; }
     .module-edge.active { opacity: .9; stroke: #9b75e8; stroke-width: 1.8; }
     .module-detail { display: none; border-top: 1px solid var(--border); padding: .8rem 1rem; background: #0a1432; }
@@ -121,6 +124,9 @@
     .module-detail b { display: block; font-size: .82rem; }
     .module-detail span { color: #8f9bbb; font-size: .7rem; }
     .module-stats { display: flex; gap: 1rem; white-space: nowrap; font: .65rem ui-monospace, SFMono-Regular, Menlo, monospace; color: #9bb4f5; }
+    .graph-columns { display: grid; grid-template-columns: repeat(3, 1fr); gap: 72px; padding: .55rem 28px 0; color: #8294c8; font: .62rem ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .08em; }
+    .graph-columns span:nth-child(2) { text-align: center; }
+    .graph-columns span:last-child { text-align: right; }
     .graph-note { padding: .55rem .8rem; border-top: 1px solid var(--border); color: #7180aa; font-size: .65rem; }
     .graph-summary { display: flex; flex-wrap: wrap; gap: .45rem; margin: .65rem 0; }
     .module-table button { max-width: 36rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left; }
@@ -270,21 +276,22 @@
   {{$graph := .ModuleGraph}}
   <div class="graph-summary">
     {{if $graph.Focused}}<span class="chip">Neighborhood of {{$graph.FocusName}}</span>{{else}}<span class="chip">Showing {{len $graph.Nodes}} of {{$graph.Total}} connected modules</span>{{end}}
-    <span class="chip">{{len $graph.Edges}} visible dependencies</span>
-    {{if not $graph.Focused}}<span class="chip">Ranked by connectedness</span>{{end}}
+    <span class="chip">{{len $graph.Edges}} visible dependencies{{if $graph.OmittedEdges}} · {{$graph.OmittedEdges}} hidden for clarity{{end}}</span>
+    {{if not $graph.Focused}}<span class="chip">Layered by dependency direction</span>{{end}}
   </div>
-  <p class="note">Search covers all {{$graph.Total}} connected modules. {{if $graph.Focused}}This view contains the selected module and its immediate incoming and outgoing dependencies. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}</p>
+  <p class="note">Search covers {{if $graph.AllModulesTruncated}}the {{len $graph.AllModules}} most-connected of {{$graph.Total}}{{else}}all {{$graph.Total}}{{end}} connected modules. {{if $graph.Focused}}This view contains the selected module, its immediate incoming and outgoing dependencies, and the dependencies between them. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}</p>
   <section class="explorer" aria-label="Architecture explorer">
     <div class="graph-pane">
+      {{if $graph.Focused}}<div class="graph-columns"><span>Consumers</span><span>Selected module</span><span>Dependencies</span></div>{{end}}
       <div class="graph-canvas">
-        <svg class="module-graph" viewBox="0 0 {{$graph.Width}} {{$graph.Height}}" role="img" aria-label="Module dependency graph">
+        <svg class="module-graph" width="{{$graph.Width}}" height="{{$graph.Height}}" viewBox="0 0 {{$graph.Width}} {{$graph.Height}}" role="img" aria-label="Module dependency graph">
           <defs><marker id="module-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#536a9f"/></marker></defs>
-          {{range $graph.Edges}}<line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}
-          {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" onclick="selectModule(this)"><title>{{.Name}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
+          {{range $graph.Edges}}<line class="module-edge-hit" data-source="{{.Source}}" data-target="{{.Target}}" data-source-name="{{.SourceName}}" data-target-name="{{.TargetName}}" data-source-file="{{.SourceFile}}" data-target-file="{{.TargetFile}}" data-kind="{{.Kind}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" onclick="selectDependency(this)"/><line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}
+          {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-role="{{.Role}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" onclick="selectModule(this)"><title>{{.Name}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
         </svg>
       </div>
       <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div></div>
-      {{if $graph.Limited}}<div class="graph-note">This is a focused map, not the complete repository graph. It keeps the most-connected modules so individual relationships remain inspectable.</div>{{end}}
+      {{if $graph.Limited}}<div class="graph-note">{{if $graph.Focused}}This neighborhood is bounded to keep individual relationships inspectable.{{else}}This overview shows the most-connected modules and a representative dependency backbone. Search for any module to inspect its complete immediate neighborhood.{{end}}</div>{{end}}
     </div>
     {{if .Insights}}<aside class="findings-pane">
       <h3>Findings <span class="note">({{.InsightTotal}})</span> <button type="button" class="count-link" onclick="openModal('insights-modal')">review all</button></h3>
@@ -789,6 +796,30 @@
       document.getElementById('module-detail-out').textContent = 'depends on ' + node.getAttribute('data-out');
     }
   }
+  function selectDependency(hit) {
+    clearGraphFocus();
+    var source = hit.getAttribute('data-source');
+    var target = hit.getAttribute('data-target');
+    graphNodes().forEach(function(n) {
+      var connected = n.getAttribute('data-id') === source || n.getAttribute('data-id') === target;
+      n.classList.toggle('active', connected);
+      n.classList.toggle('dim', !connected);
+    });
+    graphEdges().forEach(function(e) {
+      var selected = e.getAttribute('data-source') === source && e.getAttribute('data-target') === target;
+      e.classList.toggle('active', selected);
+      e.classList.toggle('dim', !selected);
+    });
+    var detail = document.getElementById('module-detail');
+    if (!detail) return;
+    detail.classList.add('open');
+    document.getElementById('module-detail-name').textContent = hit.getAttribute('data-source-name') + ' → ' + hit.getAttribute('data-target-name');
+    var sourceFile = hit.getAttribute('data-source-file') || 'source file unavailable';
+    var targetFile = hit.getAttribute('data-target-file') || 'target file unavailable';
+    document.getElementById('module-detail-file').textContent = sourceFile + ' → ' + targetFile;
+    document.getElementById('module-detail-in').textContent = hit.getAttribute('data-kind');
+    document.getElementById('module-detail-out').textContent = 'module-level evidence';
+  }
   function focusModule(id) {
     var node = document.querySelector('.module-node[data-id="' + id + '"]');
     if (!node) return;
@@ -819,6 +850,19 @@
       n.classList.toggle('dim', !match);
       if (match) matches[n.getAttribute('data-id')] = true;
     });
+	var matchedVisible = Object.keys(matches).length > 0;
+	if (!matchedVisible) {
+	  var bestModule = '';
+	  document.querySelectorAll('#all-modules option').forEach(function(option) {
+	    var moduleName = (option.value || '').toLowerCase();
+	    var belongsToModule = evidence === moduleName || evidence.indexOf(moduleName + '/') === 0;
+	    if (belongsToModule && moduleName.length > bestModule.length) bestModule = option.value;
+	  });
+	  if (bestModule) {
+	    window.location.assign('/?module=' + encodeURIComponent(bestModule) + '#architecture');
+	    return;
+	  }
+	}
     graphEdges().forEach(function(e) {
       var active = matches[e.getAttribute('data-source')] || matches[e.getAttribute('data-target')];
       e.classList.toggle('active', !!active);

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -6,38 +6,33 @@
   <title>{{.Title}} — dashboard</title>
   <style>
     :root {
-      --bg: #ffffff; --fg: #1a1a1a; --muted: #666; --border: #e2e2e2;
-      --card: #f7f7f8; --accent: #2563eb; --ok: #16a34a; --off: #b91c1c;
-      --warn: #b45309; --th: #efeff1;
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg: #16181d; --fg: #e6e6e6; --muted: #9aa0aa; --border: #2c2f36;
-        --card: #1e2127; --accent: #6ea8fe; --ok: #4ade80; --off: #f87171;
-        --warn: #fbbf24; --th: #242832;
-      }
+      --bg: #041031; --fg: #f5f3fb; --muted: #a9b1ce;
+      --border: rgba(139, 165, 255, .16); --card: #0b1432;
+      --accent: #6f8fff; --violet: #8b4fe0; --lilac: #b87bea;
+      --ok: #68c49a; --off: #e27a63; --warn: #e4b968; --th: #111b3b;
     }
     * { box-sizing: border-box; }
     body {
-      margin: 0; padding: 2rem 1.25rem; background: var(--bg); color: var(--fg);
-      font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      margin: 0; padding: 1.5rem 1.25rem 3rem; background: var(--bg); color: var(--fg);
+      font: 14px/1.55 "Instrument Sans", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
-    .wrap { max-width: 960px; margin: 0 auto; }
+    .wrap { max-width: 1000px; margin: 0 auto; }
     header { display: flex; flex-wrap: wrap; align-items: baseline; gap: .75rem; margin-bottom: .25rem; }
+    h1, h2, h3 { font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     h1 { font-size: 1.4rem; margin: 0; }
-    h2 { font-size: 1.05rem; margin: 2rem 0 .6rem; border-bottom: 1px solid var(--border); padding-bottom: .35rem; }
+    h2 { font-size: 1.05rem; letter-spacing: -.015em; margin: 1.75rem 0 .65rem; }
     .refresh { color: var(--muted); font-size: .85rem; margin-bottom: 1.25rem; }
     .badge { font-size: .8rem; font-weight: 600; padding: .1rem .5rem; border-radius: 999px; }
     .badge.on { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
     .badge.off { background: color-mix(in srgb, var(--off) 18%, transparent); color: var(--off); }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .75rem; }
-    .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: .75rem .9rem; }
-    .card .k { color: var(--muted); font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; }
-    .card .v { font-size: 1.15rem; font-weight: 600; margin-top: .15rem; word-break: break-word; }
+    .card { background: linear-gradient(180deg, #0b1432, #08112b); border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
+    .card .k { color: #8fa0c5; font: 500 .64rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .08em; }
+    .card .v { font-size: 1.25rem; font-weight: 650; margin-top: .25rem; word-break: break-word; }
     .table-scroll { overflow-x: auto; }
     table { border-collapse: collapse; width: 100%; font-variant-numeric: tabular-nums; }
     th, td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--border); white-space: nowrap; }
-    th { background: var(--th); font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; color: var(--muted); }
+    th { background: var(--th); font: 500 .68rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .06em; color: #8fa0c5; }
     td.num, th.num { text-align: right; }
     tr.total td { font-weight: 700; border-top: 2px solid var(--border); }
     tr.self-row td { background: color-mix(in srgb, var(--accent) 10%, transparent); }
@@ -45,8 +40,61 @@
     .note { color: var(--muted); font-style: italic; }
     .chips { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .2rem; }
     .chip { background: var(--th); border: 1px solid var(--border); border-radius: 6px; padding: .05rem .45rem; font-size: .8rem; }
-    footer { margin-top: 2.5rem; color: var(--muted); font-size: .8rem; }
+    footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: #7784a4; font-size: .72rem; }
     code { background: var(--th); padding: .05rem .3rem; border-radius: 4px; }
+    .topbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
+    .brand { display: flex; align-items: center; font-size: 1.15rem; font-weight: 750; letter-spacing: -.04em; }
+    .brand h1 { font: inherit; margin: 0; }
+    .brand-dot { color: var(--violet); }
+    .nav { display: flex; flex-wrap: wrap; gap: .25rem; }
+    .nav a { color: var(--muted); text-decoration: none; padding: .35rem .6rem; border-radius: 7px; }
+    .nav a:hover { color: var(--fg); background: var(--card); }
+    .hero { position: relative; overflow: hidden; border: 1px solid var(--border); border-radius: 14px; padding: 1.35rem 1.5rem; background: radial-gradient(circle at 88% 8%, rgba(139,79,224,.13), transparent 32%), linear-gradient(135deg, #0b173b, #08112b); margin-bottom: 1.25rem; }
+    .hero h1 { font-size: clamp(1.55rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -.035em; margin-bottom: .4rem; }
+    .hero p { color: var(--muted); max-width: 650px; margin: 0; font-size: .9rem; }
+    .hero-meta { display: flex; flex-wrap: wrap; align-items: center; gap: .45rem; margin-top: 1rem; }
+    .primary-action { display: inline-flex; align-items: center; border: 0; border-radius: 8px; padding: .55rem .85rem; background: linear-gradient(135deg, #3e6fe0, var(--violet)); color: #fff; cursor: pointer; font: inherit; font-weight: 650; box-shadow: 0 12px 35px rgba(119,75,211,.25); }
+    .section-kicker { color: #9bb4f5; font: 500 .64rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .11em; margin-bottom: .45rem; }
+    .quality-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; background: #08112b; }
+    .quality-item { min-width: 0; padding: .9rem 1rem; border-right: 1px solid var(--border); }
+    .quality-item:last-child { border-right: 0; }
+    .quality-item .k { display: block; color: #8fa0c5; font: 500 .62rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .07em; }
+    .quality-item .v { display: block; margin-top: .25rem; font-size: 1rem; font-weight: 650; }
+    .explorer-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin: 1.8rem 0 .7rem; }
+    .explorer-head h2 { margin: 0; }
+    .graph-search { width: min(260px, 45vw); border: 1px solid var(--border); border-radius: 8px; background: #08112b; color: var(--fg); padding: .5rem .65rem; font: inherit; outline: none; }
+    .graph-search:focus { border-color: #6f8fff; box-shadow: 0 0 0 2px rgba(111,143,255,.14); }
+    .explorer { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
+    .findings-pane { border-right: 1px solid var(--border); background: #08112b; padding: .75rem; overflow: auto; max-height: 620px; }
+    .findings-pane h3 { margin: .2rem .35rem .7rem; font-size: .82rem; }
+    .finding-group { border-top: 1px solid var(--border); }
+    .finding-group:first-of-type { border-top: 0; }
+    .finding-group > summary { display: flex; justify-content: space-between; gap: .5rem; cursor: pointer; padding: .65rem .35rem; color: #cbd3eb; font-size: .76rem; font-weight: 600; list-style: none; }
+    .finding-group > summary::-webkit-details-marker { display: none; }
+    .finding-count { color: #8294c8; font: .66rem ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .finding-button { width: 100%; border: 0; border-radius: 7px; background: transparent; color: #9faaca; padding: .5rem .55rem; text-align: left; cursor: pointer; font: inherit; font-size: .72rem; line-height: 1.4; }
+    .finding-button:hover, .finding-button.active { color: #fff; background: rgba(111,143,255,.1); }
+    .finding-meta { display: block; color: #7180aa; margin-top: .2rem; font: .6rem ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .graph-pane { position: relative; display: flex; flex-direction: column; min-width: 0; }
+    .graph-canvas { flex: 1; overflow: auto; padding: .5rem; background-image: radial-gradient(rgba(139,165,255,.13) .7px, transparent .7px); background-size: 18px 18px; }
+    .module-graph { display: block; min-width: 720px; width: 100%; height: auto; }
+    .module-edge { stroke: #33446f; stroke-width: 1; opacity: .38; transition: opacity .18s, stroke .18s; }
+    .module-node { cursor: pointer; transition: opacity .18s; }
+    .module-node rect { fill: #0d193b; stroke: #33456f; rx: 7; transition: fill .18s, stroke .18s; }
+    .module-node text { fill: #cbd3eb; font: 8px ui-monospace, SFMono-Regular, Menlo, monospace; pointer-events: none; }
+    .module-node:hover rect, .module-node.active rect { fill: #172657; stroke: #7d92e4; }
+    .module-node.dim, .module-edge.dim { opacity: .12; }
+    .module-edge.active { opacity: .9; stroke: #9b75e8; stroke-width: 1.8; }
+    .module-detail { display: none; border-top: 1px solid var(--border); padding: .8rem 1rem; background: #0a1432; }
+    .module-detail.open { display: flex; align-items: start; justify-content: space-between; gap: 1rem; }
+    .module-detail b { display: block; font-size: .82rem; }
+    .module-detail span { color: #8f9bbb; font-size: .7rem; }
+    .module-stats { display: flex; gap: 1rem; white-space: nowrap; font: .65rem ui-monospace, SFMono-Regular, Menlo, monospace; color: #9bb4f5; }
+    .graph-note { padding: .55rem .8rem; border-top: 1px solid var(--border); color: #7180aa; font-size: .65rem; }
+    .quality-disclosure { margin-top: 1.5rem; border-top: 1px solid var(--border); }
+    .quality-disclosure > summary { cursor: pointer; padding: .9rem 0; color: #aeb8d4; font-size: .78rem; }
+    .quality-disclosure[open] > summary { color: #fff; }
+    @media (max-width: 760px) { body { padding: 1rem; } .topbar { align-items: flex-start; } .explorer { grid-template-columns: 1fr; } .findings-pane { border-right: 0; border-bottom: 1px solid var(--border); max-height: 230px; } .quality-row { grid-template-columns: repeat(2, 1fr); } }
     .count-link {
       background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
       color: var(--accent); font: inherit; font-weight: 600; text-decoration: underline;
@@ -115,123 +163,80 @@
 </head>
 <body>
 <div class="wrap">
-  <header>
-    <h1>{{.Title}}</h1>
-    {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
-  </header>
-  <div class="refresh">This page refreshes automatically every {{.RefreshSeconds}} seconds. Served on <code>http://127.0.0.1:{{.Port}}</code>{{if .FrontDoor}} and on the shared URL <code>{{.StableURL}}</code>{{end}}.</div>
-
-  <h2>This server</h2>
-  <p class="note">Everything on this page describes this one process and the graph it holds. Other servers are listed below.</p>
-  <div class="grid">
-    <div class="card"><div class="k">Process</div><div class="v">PID {{.PID}}</div></div>
-    {{if .Binary}}<div class="card"><div class="k">Binary</div><div class="v">{{.Binary}}</div></div>{{end}}
-    {{if .Uptime}}<div class="card"><div class="k">Uptime</div><div class="v">{{.Uptime}}</div></div>{{end}}
-    {{if .StartedAt}}<div class="card"><div class="k">Started</div><div class="v">{{.StartedAt}}</div></div>{{end}}
-    {{if .ReposLoaded}}<div class="card"><div class="k">Repos loaded</div><div class="v">{{.ReposLoaded}}</div></div>{{end}}
-    <div class="card"><div class="k">Calls served</div><div class="v">{{.SessionCalls}}</div></div>
-    <div class="card"><div class="k">Dashboard port</div><div class="v">{{.Port}}{{if .FrontDoor}} <span class="badge on">shared URL</span>{{end}}</div></div>
+  <div class="topbar">
+    <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span></h1></div>
   </div>
-  {{if .WorkDir}}<div class="card" style="margin-top:.75rem"><div class="k">Launched from</div><div class="v">{{.WorkDir}}{{if .ConfigPath}} <span class="note" style="font-size:.85rem;font-weight:400">(config: {{.ConfigPath}})</span>{{end}}</div></div>{{end}}
 
-  {{if .Instances}}
-  <h2>Servers running <span class="note">({{len .Instances}})</span></h2>
-  <p class="note">One enola server runs per agent session, each with its own graph. Follow a link to inspect another one.</p>
-  <div class="table-scroll"><table>
-    <thead><tr><th>PID</th><th>Binary</th><th>Repos</th><th class="num">Uptime</th><th class="num">Calls</th><th>Dashboard</th></tr></thead>
-    <tbody>
-      {{range .Instances}}<tr{{if .Self}} class="self-row"{{end}}>
-        <td>{{.PID}}{{if .Self}} <span class="badge on">this page</span>{{end}}</td>
-        <td>{{.Binary}}</td>
-        <td>{{.Repos}}</td>
-        <td class="num">{{.Uptime}}</td>
-        <td class="num">{{.Calls}}</td>
-        <td>{{if .URL}}<a href="{{.URL}}">{{.URL}}</a>{{if .FrontDoor}} <span class="chip">shared</span>{{end}}{{else}}<span class="note">none</span>{{end}}</td>
-      </tr>{{end}}
-    </tbody>
-  </table></div>
+  <section class="hero" id="overview">
+    <div class="section-kicker">Repository intelligence</div>
+    <h1>{{if .HasGraph}}Your architecture is mapped.{{else}}Ready to map this repository.{{end}}</h1>
+    <p>{{if .HasGraph}}See what Enola found and whether the analysis is complete enough to trust.{{else}}Generate a snapshot from your coding agent to reveal dependencies, hotspots, routes, and structural findings.{{end}}</p>
+    <div class="hero-meta">
+      {{if .HasReceipt}}{{with .Receipt}}<span class="chip">{{.FactCount}} facts</span><span class="chip">{{.InsightCount}} findings</span>{{end}}{{end}}
+      {{if .Insights}}<button type="button" class="primary-action" onclick="openModal('insights-modal')">Review findings</button>{{end}}
+    </div>
+  </section>
+
+  {{if .ModuleGraph}}
+  <div class="explorer-head">
+    <div><div class="section-kicker">Explore</div><h2>Architecture map</h2></div>
+    <input id="module-search" class="graph-search" type="search" placeholder="Find a module…" oninput="filterModules(this.value)" aria-label="Find a module">
+  </div>
+  <section class="explorer" aria-label="Architecture explorer">
+    <aside class="findings-pane">
+      <h3>Findings <span class="note">({{.InsightTotal}})</span></h3>
+      {{range .Insights}}
+      <details class="finding-group">
+        <summary><span>{{.Label}}</span><span class="finding-count">{{.Count}}</span></summary>
+        {{range .Items}}<button type="button" class="finding-button" data-evidence="{{.Evidence}}" onclick="selectFinding(this)">{{.Title}}<span class="finding-meta">{{.Confidence}}%{{if .Evidence}} · {{.Evidence}}{{end}}</span></button>{{end}}
+      </details>
+      {{end}}
+    </aside>
+    <div class="graph-pane">
+      <div class="graph-canvas">
+        {{$graph := .ModuleGraph}}
+        <svg class="module-graph" viewBox="0 0 {{$graph.Width}} {{$graph.Height}}" role="img" aria-label="Module dependency graph">
+          <defs><marker id="module-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#536a9f"/></marker></defs>
+          {{range $graph.Edges}}<line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}
+          {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" onclick="selectModule(this)"><title>{{.Name}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
+        </svg>
+      </div>
+      <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div></div>
+      {{if $graph.Limited}}<div class="graph-note">Focused on 36 of {{$graph.Total}} connected modules. Search filters this view.</div>{{end}}
+    </div>
+  </section>
   {{end}}
 
-  <h2>Tool usage</h2>
-  {{if .Tools}}
-  <div class="table-scroll"><table>
-    <thead><tr><th>Tool</th><th class="num">This server</th><th class="num">All servers, lifetime</th></tr></thead>
-    <tbody>
-      {{range .Tools}}<tr><td>{{.Name}}</td><td class="num">{{.Session}}</td><td class="num">{{.Total}}</td></tr>{{end}}
-    </tbody>
-  </table></div>
-  <p class="note">
-    "This server" counts only the calls this process has served{{if .TrackingSince}}; the lifetime column sums every repo on this machine since {{.TrackingSince}}{{end}}{{if .ReposTracked}} ({{.ReposTracked}} repo(s) tracked){{end}}.
-  </p>
-  {{else}}<p class="note">No tool calls recorded yet.</p>{{end}}
-
-  <h2>Value estimate <span class="note">(approximate)</span></h2>
-  {{if .Values}}
-  <div class="table-scroll"><table>
-    <thead><tr><th>Tool</th><th class="num">Calls</th><th class="num">~Time saved</th><th class="num">~Tokens saved</th></tr></thead>
-    <tbody>
-      {{range .Values}}<tr><td>{{.Label}}</td><td class="num">{{.Calls}}</td><td class="num">{{.TimeSaved}}</td><td class="num">{{.TokensSaved}}</td></tr>{{end}}
-      <tr class="total"><td>{{.ValueTotal.Label}}</td><td class="num">{{.ValueTotal.Calls}}</td><td class="num">{{.ValueTotal.TimeSaved}}</td><td class="num">{{.ValueTotal.TokensSaved}}{{if .BeyondContext}}&#8224;{{end}}</td></tr>
-    </tbody>
-  </table></div>
-  {{if .BeyondContext}}<p class="note">&#8224; Some indexed corpus exceeds a single context window &mdash; that part is not reproducible by re-reading files at any budget, so the token figure understates it.</p>{{end}}
-  {{else}}<p class="note">No value recorded yet.</p>{{end}}
-
-  <h2>Current snapshot receipt</h2>
-  {{if .HasReceipt}}{{with .Receipt}}
+  {{if .HasGraph}}{{with .Graph}}{{if or (gt (len .Repos) 1) .ServiceCount .CrossRepoEdgeCount}}
+  <h2 id="architecture">Architecture</h2>
   <div class="grid">
-    <div class="card"><div class="k">Snapshot ID</div><div class="v">{{.SnapshotID}}</div></div>
-    <div class="card"><div class="k">enola version</div><div class="v">{{.EnolaVersion}}</div></div>
-    <div class="card"><div class="k">Generated at</div><div class="v">{{.GeneratedAt}}</div></div>
-    <div class="card"><div class="k">Duration</div><div class="v">{{.Duration}}</div></div>
-    <div class="card"><div class="k">Facts</div><div class="v">{{.FactCount}}</div></div>
-    <div class="card"><div class="k">Insights</div><div class="v">{{if $.Insights}}<button type="button" class="count-link" onclick="openModal('insights-modal')">{{$.InsightTotal}}</button>{{else}}{{.InsightCount}}{{end}}</div></div>
+    {{if gt (len .Repos) 1}}<div class="card"><div class="k">Repositories</div><div class="v">{{len .Repos}}</div></div>{{end}}
+    {{if .ServiceCount}}<div class="card"><div class="k">Services</div><div class="v">{{if $.Services}}<button type="button" class="count-link" onclick="openModal('services-modal')">{{.ServiceCount}}</button>{{else}}{{.ServiceCount}}{{end}}</div></div>{{end}}
+    {{if .CrossRepoEdgeCount}}<div class="card"><div class="k">Cross-repo edges</div><div class="v">{{if $.CrossRepoEdges}}<button type="button" class="count-link" onclick="openModal('edges-modal')">{{.CrossRepoEdgeCount}}</button>{{else}}{{.CrossRepoEdgeCount}}{{end}}</div></div>{{end}}
+  </div>
+  {{end}}{{end}}{{else}}<p class="note">{{.GraphNote}}</p>{{end}}
+  <div class="grid">
     {{/* extra-cards: extension slot — see pkg/dashboard.Options.Overlay */}}
     {{block "extra-cards" $}}{{end}}
-    {{if .Git}}<div class="card"><div class="k">Git</div><div class="v">{{.Git.Ref}}{{if .Git.Commit}} @ {{.Git.Commit}}{{end}}{{if .Git.Dirty}} (dirty){{end}}</div></div>{{end}}
   </div>
-  <div class="card" style="margin-top:.75rem"><div class="k">Repo path</div><div class="v">{{.RepoPath}}</div></div>
-  {{if .Extractors}}<div style="margin-top:.75rem"><div class="k">Extractors</div><div class="chips">{{range .Extractors}}<span class="chip">{{.}}</span>{{end}}</div></div>{{end}}
-  {{if .Explainers}}<div style="margin-top:.6rem"><div class="k">Explainers</div><div class="chips">{{range .Explainers}}<span class="chip">{{.}}</span>{{end}}</div></div>{{end}}
 
-  <h3 style="margin:1.25rem 0 .5rem;font-size:.95rem">Extraction quality</h3>
-  <div class="grid">
-    <div class="card"><div class="k">Files seen</div><div class="v">{{.Quality.FilesSeen}}</div></div>
-    <div class="card"><div class="k">Files parsed</div><div class="v">{{.Quality.FilesParsed}}</div></div>
-    <div class="card"><div class="k">Files skipped</div><div class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.FilesSkipped}}</button>{{else}}{{.Quality.FilesSkipped}}{{end}}</div></div>
-    <div class="card"><div class="k">Dirs skipped</div><div class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.DirsSkipped}}</button>{{else}}{{.Quality.DirsSkipped}}{{end}}</div></div>
-    <div class="card"><div class="k">Parse errors</div><div class="v">{{if $.ParseErrors}}<button type="button" class="count-link" onclick="openModal('parse-errors-modal')">{{.Quality.ParseErrors}}</button>{{else}}{{.Quality.ParseErrors}}{{end}}</div></div>
+  {{if .HasReceipt}}{{with .Receipt}}
+  <details class="quality-disclosure" id="quality">
+  <summary>{{if .Quality.ParseErrors}}Analysis quality needs attention · {{.Quality.ParseErrors}} parse error(s){{else}}Analysis complete · no parse errors{{end}}</summary>
+  <div class="quality-row">
+    <div class="quality-item"><span class="k">Files seen</span><span class="v">{{.Quality.FilesSeen}}</span></div>
+    <div class="quality-item"><span class="k">Files parsed</span><span class="v">{{.Quality.FilesParsed}}</span></div>
+    <div class="quality-item"><span class="k">Skipped</span><span class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.FilesSkipped}}</button>{{else}}{{.Quality.FilesSkipped}}{{end}}</span></div>
+    <div class="quality-item"><span class="k">Parse errors</span><span class="v">{{if $.ParseErrors}}<button type="button" class="count-link" onclick="openModal('parse-errors-modal')">{{.Quality.ParseErrors}}</button>{{else}}{{.Quality.ParseErrors}}{{end}}</span></div>
     {{if .Quality.Coverage}}{{with .Quality.Coverage}}
-    <div class="card"><div class="k">Services</div><div class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.ServicesTotal}}</button>{{else}}{{.ServicesTotal}}{{end}}</div></div>
-    <div class="card"><div class="k">Coverage gaps</div><div class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.CoverageGaps}}</button>{{else}}{{.CoverageGaps}}{{end}}</div></div>
-    <div class="card"><div class="k">Unresolved edges</div><div class="v">{{if $.UnresolvedRoutes}}<button type="button" class="count-link" onclick="openModal('coverage-unresolved-modal')">{{.UnresolvedEdges}}</button>{{else}}{{.UnresolvedEdges}}{{end}}</div></div>
+    <div class="quality-item"><span class="k">Coverage gaps</span><span class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.CoverageGaps}}</button>{{else}}{{.CoverageGaps}}{{end}}</span></div>
+    <div class="quality-item"><span class="k">Unresolved edges</span><span class="v">{{if $.UnresolvedRoutes}}<button type="button" class="count-link" onclick="openModal('coverage-unresolved-modal')">{{.UnresolvedEdges}}</button>{{else}}{{.UnresolvedEdges}}{{end}}</span></div>
     {{end}}{{end}}
   </div>
+  </details>
   {{end}}{{else}}<p class="note">{{.ReceiptNote}}</p>{{end}}
 
-  <h2>Graph receipt <span class="note">(this server's graph)</span></h2>
-  {{if .HasGraph}}{{with .Graph}}
-  <div class="grid">
-    <div class="card"><div class="k">Snapshot ID</div><div class="v">{{.SnapshotID}}</div></div>
-    <div class="card"><div class="k">enola version</div><div class="v">{{.EnolaVersion}}</div></div>
-    <div class="card"><div class="k">Generated at</div><div class="v">{{.GeneratedAt}}</div></div>
-    <div class="card"><div class="k">Facts</div><div class="v">{{.FactCount}}</div></div>
-    <div class="card"><div class="k">Insights</div><div class="v">{{if $.Insights}}<button type="button" class="count-link" onclick="openModal('insights-modal')">{{$.InsightTotal}}</button>{{else}}{{.InsightCount}}{{end}}</div></div>
-    <div class="card"><div class="k">Services</div><div class="v">{{if $.Services}}<button type="button" class="count-link" onclick="openModal('services-modal')">{{.ServiceCount}}</button>{{else}}{{.ServiceCount}}{{end}}</div></div>
-    <div class="card"><div class="k">Cross-repo edges</div><div class="v">{{if $.CrossRepoEdges}}<button type="button" class="count-link" onclick="openModal('edges-modal')">{{.CrossRepoEdgeCount}}</button>{{else}}{{.CrossRepoEdgeCount}}{{end}}</div></div>
-  </div>
-  {{if .Repos}}
-  <h3 style="margin:1.25rem 0 .5rem;font-size:.95rem">Repos in graph</h3>
-  <div class="table-scroll"><table>
-    <thead><tr><th>Label</th><th>Path</th><th>Added</th><th>In graph for</th><th class="num">Facts</th></tr></thead>
-    <tbody>
-      {{range .Repos}}<tr><td>{{.Label}}</td><td>{{.Path}}</td><td>{{.AddedAt}}</td><td>{{.InGraphFor}}</td><td class="num">{{.FactCount}}</td></tr>{{end}}
-    </tbody>
-  </table></div>
-  {{end}}
-  {{end}}{{else}}<p class="note">{{.GraphNote}}</p>{{end}}
-
-  <footer>{{.Title}} dashboard · read-only · localhost only</footer>
+  <footer>{{.Title}} · read-only · updates every {{.RefreshSeconds}} seconds</footer>
 </div>
 
 {{if .Services}}
@@ -474,6 +479,65 @@
       if (toTable) toTable.hidden = showTable;
       if (toDiagram) toDiagram.hidden = !showTable;
     }
+  }
+  function graphNodes() { return Array.prototype.slice.call(document.querySelectorAll('.module-node')); }
+  function graphEdges() { return Array.prototype.slice.call(document.querySelectorAll('.module-edge')); }
+  function clearGraphFocus() {
+    graphNodes().forEach(function(n) { n.classList.remove('active', 'dim'); });
+    graphEdges().forEach(function(e) { e.classList.remove('active', 'dim'); });
+  }
+  function selectModule(node) {
+    clearGraphFocus();
+    var id = node.getAttribute('data-id');
+    var related = {};
+    related[id] = true;
+    graphEdges().forEach(function(e) {
+      var connected = e.getAttribute('data-source') === id || e.getAttribute('data-target') === id;
+      e.classList.toggle('active', connected);
+      e.classList.toggle('dim', !connected);
+      if (connected) { related[e.getAttribute('data-source')] = true; related[e.getAttribute('data-target')] = true; }
+    });
+    graphNodes().forEach(function(n) {
+      n.classList.toggle('active', n === node);
+      n.classList.toggle('dim', !related[n.getAttribute('data-id')]);
+    });
+    var detail = document.getElementById('module-detail');
+    if (detail) {
+      detail.classList.add('open');
+      document.getElementById('module-detail-name').textContent = node.getAttribute('data-name');
+      document.getElementById('module-detail-file').textContent = node.getAttribute('data-file') || '';
+      document.getElementById('module-detail-in').textContent = 'used by ' + node.getAttribute('data-in');
+      document.getElementById('module-detail-out').textContent = 'depends on ' + node.getAttribute('data-out');
+    }
+  }
+  function filterModules(query) {
+    clearGraphFocus();
+    query = (query || '').trim().toLowerCase();
+    graphNodes().forEach(function(n) {
+      var match = !query || (n.getAttribute('data-name') || '').toLowerCase().indexOf(query) !== -1 || (n.getAttribute('data-file') || '').toLowerCase().indexOf(query) !== -1;
+      n.classList.toggle('dim', !match);
+    });
+    if (query) graphEdges().forEach(function(e) { e.classList.add('dim'); });
+  }
+  function selectFinding(button) {
+    document.querySelectorAll('.finding-button').forEach(function(b) { b.classList.toggle('active', b === button); });
+    clearGraphFocus();
+    var evidence = (button.getAttribute('data-evidence') || '').toLowerCase();
+    if (!evidence) return;
+    var matches = {};
+    graphNodes().forEach(function(n) {
+      var name = (n.getAttribute('data-name') || '').toLowerCase();
+      var file = (n.getAttribute('data-file') || '').toLowerCase();
+      var match = (name && evidence.indexOf(name) !== -1) || (file && evidence.indexOf(file) !== -1) || (file && file.indexOf(evidence) !== -1);
+      n.classList.toggle('active', match);
+      n.classList.toggle('dim', !match);
+      if (match) matches[n.getAttribute('data-id')] = true;
+    });
+    graphEdges().forEach(function(e) {
+      var active = matches[e.getAttribute('data-source')] || matches[e.getAttribute('data-target')];
+      e.classList.toggle('active', !!active);
+      e.classList.toggle('dim', !active);
+    });
   }
   {{/* extra-scripts: extension slot — see pkg/dashboard.Options.Overlay */}}
   {{block "extra-scripts" $}}{{end}}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -231,7 +231,7 @@
       {{else}}
       <p class="note">Compared with the {{.Changes.ComparedTo}} · {{.Changes.Headline}}</p>
       <div class="grid">
-        <div class="card"><div class="k">New findings</div><div class="v">{{.Changes.FindingsNew}}</div></div>
+        <div class="card"><div class="k">New findings</div><div class="v">{{if .Changes.NewFindingDetails}}<button type="button" class="count-link" onclick="openModal('new-findings-modal')">{{.Changes.FindingsNew}}</button>{{else}}{{.Changes.FindingsNew}}{{end}}</div></div>
         <div class="card"><div class="k">Resolved findings</div><div class="v">{{.Changes.FindingsResolved}}</div></div>
         <div class="card"><div class="k">Facts added / removed</div><div class="v">+{{.Changes.FactsAdded}} / −{{.Changes.FactsRemoved}}</div></div>
         <div class="card"><div class="k">Dependencies added / removed</div><div class="v">+{{.Changes.EdgesAdded}} / −{{.Changes.EdgesRemoved}}</div></div>
@@ -570,6 +570,22 @@
       </table></div>
     </details>
     {{end}}
+  </div>
+</div>
+{{end}}
+
+{{if .Changes.NewFindingDetails}}
+<div class="modal" id="new-findings-modal" onclick="if(event.target===this)closeModal(this)">
+  <div class="modal-panel wide" role="dialog" aria-modal="true" aria-label="New findings since previous snapshot">
+    <div class="modal-head">
+      <h3>New findings <span class="note">({{len .Changes.NewFindingDetails}})</span></h3>
+      <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
+    </div>
+    <div class="insight-summary">Structurally introduced since the previous recorded snapshot.</div>
+    <div class="table-scroll"><table>
+      <thead><tr><th>Category</th><th>Finding</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
+      <tbody>{{range .Changes.NewFindingDetails}}<tr><td>{{.Label}}</td><td class="title">{{.Title}}</td><td class="num">{{.Confidence}}%</td><td>{{.Evidence}}</td></tr>{{end}}</tbody>
+    </table></div>
   </div>
 </div>
 {{end}}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -92,6 +92,8 @@
     .explorer-head h2 { margin: 0; }
     .graph-search { width: min(260px, 45vw); border: 1px solid var(--border); border-radius: 8px; background: #08112b; color: var(--fg); padding: .5rem .65rem; font: inherit; outline: none; }
     .graph-search:focus { border-color: #6f8fff; box-shadow: 0 0 0 2px rgba(111,143,255,.14); }
+    .graph-search-form { display: flex; gap: .4rem; }
+    .secondary-action { border: 1px solid var(--border); border-radius: 8px; padding: .5rem .7rem; background: var(--card); color: var(--fg); cursor: pointer; font: inherit; font-weight: 600; }
     .explorer { display: flex; flex-direction: column; min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
     .findings-pane { border-top: 1px solid var(--border); background: #08112b; padding: .85rem 1rem; }
     .findings-pane h3 { margin: .2rem .35rem .7rem; font-size: .82rem; }
@@ -219,6 +221,25 @@
     </div>
   </section>
 
+  <div class="data-section">
+    <div class="section-kicker">Development feedback</div><h2>What changed?</h2>
+    {{if .Changes.Available}}
+      {{if .Changes.Incomparable}}
+      <div class="snapshot-alert"><b>Comparison unavailable.</b> The current and previous snapshots used different extraction inputs, so their raw deltas would describe rebuild noise rather than a trustworthy code change.</div>
+      {{else if .Changes.Initial}}
+      <p class="note">This is the first recorded architecture snapshot. The next snapshot will provide a change comparison.</p>
+      {{else}}
+      <p class="note">Compared with the {{.Changes.ComparedTo}} · {{.Changes.Headline}}</p>
+      <div class="grid">
+        <div class="card"><div class="k">New findings</div><div class="v">{{.Changes.FindingsNew}}</div></div>
+        <div class="card"><div class="k">Resolved findings</div><div class="v">{{.Changes.FindingsResolved}}</div></div>
+        <div class="card"><div class="k">Facts added / removed</div><div class="v">+{{.Changes.FactsAdded}} / −{{.Changes.FactsRemoved}}</div></div>
+        <div class="card"><div class="k">Dependencies added / removed</div><div class="v">+{{.Changes.EdgesAdded}} / −{{.Changes.EdgesRemoved}}</div></div>
+      </div>
+      {{end}}
+    {{else}}<p class="note">No earlier architecture snapshot is available yet. Generate another snapshot after a change to start tracking deltas.</p>{{end}}
+  </div>
+
   <div class="grid">
     {{if .HasReceipt}}{{with .Receipt}}
     <div class="card"><div class="k">Current facts</div><div class="v">{{.FactCount}}</div></div>
@@ -240,15 +261,19 @@
   {{if .ModuleGraph}}
   <div class="explorer-head">
     <div><h2>Architecture map</h2></div>
-    <input id="module-search" class="graph-search" type="search" placeholder="Filter visible modules…" oninput="filterModules(this.value)" aria-label="Filter visible modules">
+    <form class="graph-search-form" action="/#architecture" method="get">
+      <input id="module-search" class="graph-search" name="module" type="search" list="all-modules" value="{{.ModuleGraph.FocusName}}" placeholder="Search every module…" aria-label="Search every module">
+      <datalist id="all-modules">{{range .ModuleGraph.AllModules}}<option value="{{.}}">{{end}}</datalist>
+      <button class="secondary-action" type="submit">Explore</button>
+    </form>
   </div>
   {{$graph := .ModuleGraph}}
   <div class="graph-summary">
-    <span class="chip">Showing {{len $graph.Nodes}} of {{$graph.Total}} connected modules</span>
+    {{if $graph.Focused}}<span class="chip">Neighborhood of {{$graph.FocusName}}</span>{{else}}<span class="chip">Showing {{len $graph.Nodes}} of {{$graph.Total}} connected modules</span>{{end}}
     <span class="chip">{{len $graph.Edges}} visible dependencies</span>
-    <span class="chip">Ranked by connectedness</span>
+    {{if not $graph.Focused}}<span class="chip">Ranked by connectedness</span>{{end}}
   </div>
-  <p class="note">Select a node or table row to highlight its immediate dependency neighborhood; the full edge set stays faint until focused.</p>
+  <p class="note">Search covers all {{$graph.Total}} connected modules. {{if $graph.Focused}}This view contains the selected module and its immediate incoming and outgoing dependencies. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}</p>
   <section class="explorer" aria-label="Architecture explorer">
     <div class="graph-pane">
       <div class="graph-canvas">

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -25,6 +25,7 @@
     .badge { font-size: .8rem; font-weight: 600; padding: .1rem .5rem; border-radius: 999px; }
     .badge.on { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
     .badge.off { background: color-mix(in srgb, var(--off) 18%, transparent); color: var(--off); }
+    .badge.warn { background: color-mix(in srgb, var(--warn) 18%, transparent); color: var(--warn); }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .75rem; }
     .card { background: linear-gradient(180deg, #0b1432, #08112b); border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
     .card .k { color: #8fa0c5; font: 500 .64rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .08em; }
@@ -46,9 +47,30 @@
     .brand { display: flex; align-items: center; font-size: 1.15rem; font-weight: 750; letter-spacing: -.04em; }
     .brand h1 { font: inherit; margin: 0; }
     .brand-dot { color: var(--violet); }
-    .nav { display: flex; flex-wrap: wrap; gap: .25rem; }
-    .nav a { color: var(--muted); text-decoration: none; padding: .35rem .6rem; border-radius: 7px; }
-    .nav a:hover { color: var(--fg); background: var(--card); }
+    .tabs { display: flex; gap: .25rem; overflow-x: auto; padding: .25rem; margin-bottom: 1.25rem; border: 1px solid var(--border); border-radius: 10px; background: #07112d; scrollbar-width: thin; }
+    .tab { flex: 0 0 auto; border: 0; border-radius: 7px; padding: .5rem .8rem; background: transparent; color: var(--muted); cursor: pointer; font: inherit; font-size: .8rem; font-weight: 600; }
+    .tab:hover { color: var(--fg); background: var(--card); }
+    .tab.active { color: #fff; background: linear-gradient(135deg, rgba(62,111,224,.55), rgba(139,79,224,.55)); box-shadow: inset 0 0 0 1px rgba(139,165,255,.18); }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+    .panel-intro { margin-bottom: 1rem; }
+    .panel-intro h2 { margin: 0 0 .25rem; font-size: 1.25rem; }
+    .panel-intro p { margin: 0; color: var(--muted); }
+    .data-section { margin-top: 1.75rem; }
+    .data-section:first-child { margin-top: 0; }
+    .data-section h2 { margin-bottom: .7rem; }
+    .path-card .v { font-size: .9rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .snapshot-head { display: flex; flex-wrap: wrap; align-items: start; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+    .snapshot-head h2 { margin: 0 0 .2rem; font-size: 1.35rem; }
+    .snapshot-head p { margin: 0; color: var(--muted); }
+    .snapshot-alert { margin: .8rem 0 0; padding: .7rem .85rem; border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent); border-radius: 9px; background: color-mix(in srgb, var(--warn) 8%, transparent); color: #e5c98e; font-size: .8rem; }
+    .technical-receipt { margin-top: 1.8rem; border-top: 1px solid var(--border); }
+    .technical-receipt > summary { cursor: pointer; padding: 1rem 0; color: var(--muted); font-weight: 600; }
+    .technical-receipt[open] > summary { color: var(--fg); }
+    .technical-grid { display: grid; grid-template-columns: minmax(150px, .35fr) minmax(0, 1fr); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+    .technical-grid dt, .technical-grid dd { margin: 0; padding: .55rem .7rem; border-bottom: 1px solid var(--border); }
+    .technical-grid dt { color: #8fa0c5; background: var(--th); font: 500 .66rem/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .05em; }
+    .technical-grid dd { min-width: 0; overflow-wrap: anywhere; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .75rem; }
     .hero { position: relative; overflow: hidden; border: 1px solid var(--border); border-radius: 14px; padding: 1.35rem 1.5rem; background: radial-gradient(circle at 88% 8%, rgba(139,79,224,.13), transparent 32%), linear-gradient(135deg, #0b173b, #08112b); margin-bottom: 1.25rem; }
     .hero h1 { font-size: clamp(1.55rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -.035em; margin-bottom: .4rem; }
     .hero p { color: var(--muted); max-width: 650px; margin: 0; font-size: .9rem; }
@@ -60,13 +82,17 @@
     .quality-item:last-child { border-right: 0; }
     .quality-item .k { display: block; color: #8fa0c5; font: 500 .62rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: .07em; }
     .quality-item .v { display: block; margin-top: .25rem; font-size: 1rem; font-weight: 650; }
+    .quality-item .why { display: block; margin-top: .3rem; color: #7f8bac; font-size: .68rem; line-height: 1.35; }
+    .accounting-note { margin: .75rem 0 0; color: var(--muted); font-size: .78rem; }
+    .accounting-note.ok::before { content: "✓"; margin-right: .4rem; color: var(--ok); }
     .explorer-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin: 1.8rem 0 .7rem; }
     .explorer-head h2 { margin: 0; }
     .graph-search { width: min(260px, 45vw); border: 1px solid var(--border); border-radius: 8px; background: #08112b; color: var(--fg); padding: .5rem .65rem; font: inherit; outline: none; }
     .graph-search:focus { border-color: #6f8fff; box-shadow: 0 0 0 2px rgba(111,143,255,.14); }
-    .explorer { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
-    .findings-pane { border-right: 1px solid var(--border); background: #08112b; padding: .75rem; overflow: auto; max-height: 620px; }
+    .explorer { display: flex; flex-direction: column; min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
+    .findings-pane { border-top: 1px solid var(--border); background: #08112b; padding: .85rem 1rem; }
     .findings-pane h3 { margin: .2rem .35rem .7rem; font-size: .82rem; }
+    .findings-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0 .9rem; max-height: 230px; overflow: auto; }
     .finding-group { border-top: 1px solid var(--border); }
     .finding-group:first-of-type { border-top: 0; }
     .finding-group > summary { display: flex; justify-content: space-between; gap: .5rem; cursor: pointer; padding: .65rem .35rem; color: #cbd3eb; font-size: .76rem; font-weight: 600; list-style: none; }
@@ -76,9 +102,9 @@
     .finding-button:hover, .finding-button.active { color: #fff; background: rgba(111,143,255,.1); }
     .finding-meta { display: block; color: #7180aa; margin-top: .2rem; font: .6rem ui-monospace, SFMono-Regular, Menlo, monospace; }
     .graph-pane { position: relative; display: flex; flex-direction: column; min-width: 0; }
-    .graph-canvas { flex: 1; overflow: auto; padding: .5rem; background-image: radial-gradient(rgba(139,165,255,.13) .7px, transparent .7px); background-size: 18px 18px; }
-    .module-graph { display: block; min-width: 720px; width: 100%; height: auto; }
-    .module-edge { stroke: #33446f; stroke-width: 1; opacity: .38; transition: opacity .18s, stroke .18s; }
+    .graph-canvas { flex: 1; min-height: 420px; overflow: auto; padding: .5rem; background-image: radial-gradient(rgba(139,165,255,.13) .7px, transparent .7px); background-size: 18px 18px; }
+    .module-graph { display: block; width: 100%; height: auto; }
+    .module-edge { stroke: #33446f; stroke-width: 1; opacity: .07; transition: opacity .18s, stroke .18s; }
     .module-node { cursor: pointer; transition: opacity .18s; }
     .module-node rect { fill: #0d193b; stroke: #33456f; rx: 7; transition: fill .18s, stroke .18s; }
     .module-node text { fill: #cbd3eb; font: 8px ui-monospace, SFMono-Regular, Menlo, monospace; pointer-events: none; }
@@ -91,10 +117,12 @@
     .module-detail span { color: #8f9bbb; font-size: .7rem; }
     .module-stats { display: flex; gap: 1rem; white-space: nowrap; font: .65rem ui-monospace, SFMono-Regular, Menlo, monospace; color: #9bb4f5; }
     .graph-note { padding: .55rem .8rem; border-top: 1px solid var(--border); color: #7180aa; font-size: .65rem; }
+    .graph-summary { display: flex; flex-wrap: wrap; gap: .45rem; margin: .65rem 0; }
+    .module-table button { max-width: 36rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left; }
     .quality-disclosure { margin-top: 1.5rem; border-top: 1px solid var(--border); }
     .quality-disclosure > summary { cursor: pointer; padding: .9rem 0; color: #aeb8d4; font-size: .78rem; }
     .quality-disclosure[open] > summary { color: #fff; }
-    @media (max-width: 760px) { body { padding: 1rem; } .topbar { align-items: flex-start; } .explorer { grid-template-columns: 1fr; } .findings-pane { border-right: 0; border-bottom: 1px solid var(--border); max-height: 230px; } .quality-row { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 760px) { body { padding: 1rem; } .topbar { align-items: flex-start; } .graph-canvas { min-height: 300px; } .findings-groups { max-height: 180px; } .quality-row { grid-template-columns: repeat(2, 1fr); } }
     .count-link {
       background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
       color: var(--accent); font: inherit; font-weight: 600; text-decoration: underline;
@@ -165,9 +193,20 @@
 <div class="wrap">
   <div class="topbar">
     <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span></h1></div>
+    {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
   </div>
 
-  <section class="hero" id="overview">
+  <nav class="tabs" role="tablist" aria-label="Dashboard sections">
+    <button class="tab active" id="tab-overview" role="tab" aria-selected="true" aria-controls="panel-overview" data-tab="overview" onclick="selectTab('overview')">Overview</button>
+    <button class="tab" id="tab-architecture" role="tab" aria-selected="false" aria-controls="panel-architecture" data-tab="architecture" onclick="selectTab('architecture')">Architecture</button>
+    <button class="tab" id="tab-snapshots" role="tab" aria-selected="false" aria-controls="panel-snapshots" data-tab="snapshots" onclick="selectTab('snapshots')">Snapshots</button>
+    <button class="tab" id="tab-activity" role="tab" aria-selected="false" aria-controls="panel-activity" data-tab="activity" onclick="selectTab('activity')">Activity</button>
+    <button class="tab" id="tab-quality" role="tab" aria-selected="false" aria-controls="panel-quality" data-tab="quality" onclick="selectTab('quality')">Quality</button>
+  </nav>
+
+  <main>
+  <section class="tab-panel active" id="panel-overview" role="tabpanel" aria-labelledby="tab-overview">
+  <section class="hero">
     <div class="section-kicker">Repository intelligence</div>
     <h1>{{if .HasGraph}}Your architecture is mapped.{{else}}Ready to map this repository.{{end}}</h1>
     <p>{{if .HasGraph}}See what Enola found and whether the analysis is complete enough to trust.{{else}}Generate a snapshot from your coding agent to reveal dependencies, hotspots, routes, and structural findings.{{end}}</p>
@@ -177,24 +216,39 @@
     </div>
   </section>
 
+  <div class="grid">
+    {{if .HasReceipt}}{{with .Receipt}}
+    <div class="card"><div class="k">Current facts</div><div class="v">{{.FactCount}}</div></div>
+    <div class="card"><div class="k">Findings</div><div class="v">{{if $.Insights}}<button type="button" class="count-link" onclick="openModal('insights-modal')">{{$.InsightTotal}}</button>{{else}}{{.InsightCount}}{{end}}</div></div>
+    <div class="card"><div class="k">Source files indexed</div><div class="v">{{.Quality.FilesParsed}}</div></div>
+    {{end}}{{end}}
+    {{if .HasGraph}}{{with .Graph}}
+    <div class="card"><div class="k">Repositories</div><div class="v">{{len .Repos}}</div></div>
+    <div class="card"><div class="k">Services</div><div class="v">{{if $.Services}}<button type="button" class="count-link" onclick="openModal('services-modal')">{{.ServiceCount}}</button>{{else}}{{.ServiceCount}}{{end}}</div></div>
+    <div class="card"><div class="k">Cross-repo edges</div><div class="v">{{if $.CrossRepoEdges}}<button type="button" class="count-link" onclick="openModal('edges-modal')">{{.CrossRepoEdgeCount}}</button>{{else}}{{.CrossRepoEdgeCount}}{{end}}</div></div>
+    {{end}}{{end}}
+    {{/* extra-cards: extension slot — see pkg/dashboard.Options.Overlay */}}
+    {{block "extra-cards" $}}{{end}}
+  </div>
+  </section>
+
+  <section class="tab-panel" id="panel-architecture" role="tabpanel" aria-labelledby="tab-architecture" hidden>
+  <div class="panel-intro"><div class="section-kicker">Explore</div><h2>Architecture</h2><p>Search dependencies, inspect connected modules, and review structural findings.</p></div>
   {{if .ModuleGraph}}
   <div class="explorer-head">
-    <div><div class="section-kicker">Explore</div><h2>Architecture map</h2></div>
-    <input id="module-search" class="graph-search" type="search" placeholder="Find a module…" oninput="filterModules(this.value)" aria-label="Find a module">
+    <div><h2>Architecture map</h2></div>
+    <input id="module-search" class="graph-search" type="search" placeholder="Filter visible modules…" oninput="filterModules(this.value)" aria-label="Filter visible modules">
   </div>
+  {{$graph := .ModuleGraph}}
+  <div class="graph-summary">
+    <span class="chip">Showing {{len $graph.Nodes}} of {{$graph.Total}} connected modules</span>
+    <span class="chip">{{len $graph.Edges}} visible dependencies</span>
+    <span class="chip">Ranked by connectedness</span>
+  </div>
+  <p class="note">Select a node or table row to highlight its immediate dependency neighborhood; the full edge set stays faint until focused.</p>
   <section class="explorer" aria-label="Architecture explorer">
-    <aside class="findings-pane">
-      <h3>Findings <span class="note">({{.InsightTotal}})</span></h3>
-      {{range .Insights}}
-      <details class="finding-group">
-        <summary><span>{{.Label}}</span><span class="finding-count">{{.Count}}</span></summary>
-        {{range .Items}}<button type="button" class="finding-button" data-evidence="{{.Evidence}}" onclick="selectFinding(this)">{{.Title}}<span class="finding-meta">{{.Confidence}}%{{if .Evidence}} · {{.Evidence}}{{end}}</span></button>{{end}}
-      </details>
-      {{end}}
-    </aside>
     <div class="graph-pane">
       <div class="graph-canvas">
-        {{$graph := .ModuleGraph}}
         <svg class="module-graph" viewBox="0 0 {{$graph.Width}} {{$graph.Height}}" role="img" aria-label="Module dependency graph">
           <defs><marker id="module-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#536a9f"/></marker></defs>
           {{range $graph.Edges}}<line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}
@@ -202,39 +256,191 @@
         </svg>
       </div>
       <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div></div>
-      {{if $graph.Limited}}<div class="graph-note">Focused on 36 of {{$graph.Total}} connected modules. Search filters this view.</div>{{end}}
+      {{if $graph.Limited}}<div class="graph-note">This is a focused map, not the complete repository graph. It keeps the most-connected modules so individual relationships remain inspectable.</div>{{end}}
     </div>
+    {{if .Insights}}<aside class="findings-pane">
+      <h3>Findings <span class="note">({{.InsightTotal}})</span> <button type="button" class="count-link" onclick="openModal('insights-modal')">review all</button></h3>
+      <div class="findings-groups">{{range .Insights}}
+      <details class="finding-group">
+        <summary><span>{{.Label}}</span><span class="finding-count">{{.Count}}</span></summary>
+        {{range .Items}}<button type="button" class="finding-button" data-evidence="{{.Evidence}}" onclick="selectFinding(this)">{{.Title}}<span class="finding-meta">{{.Confidence}}%{{if .Evidence}} · {{.Evidence}}{{end}}</span></button>{{end}}
+      </details>
+      {{end}}</div>
+    </aside>{{end}}
   </section>
-  {{end}}
+
+  <div class="data-section"><h2>Most-connected modules in this view</h2>
+  <p class="note">Select a row to isolate its incoming and outgoing dependencies on the map.</p>
+  <div class="table-scroll"><table class="module-table">
+    <thead><tr><th>Module</th><th>File</th><th class="num">Used by</th><th class="num">Depends on</th><th class="num">Connections</th></tr></thead>
+    <tbody>{{range $graph.Nodes}}<tr><td><button type="button" class="count-link" onclick="focusModule('{{.ID}}')">{{.Name}}</button></td><td>{{.File}}</td><td class="num">{{.FanIn}}</td><td class="num">{{.FanOut}}</td><td class="num">{{.Degree}}</td></tr>{{end}}</tbody>
+  </table></div></div>
+  {{else}}<p class="note">No module dependencies loaded yet.</p>{{end}}
 
   {{if .HasGraph}}{{with .Graph}}{{if or (gt (len .Repos) 1) .ServiceCount .CrossRepoEdgeCount}}
-  <h2 id="architecture">Architecture</h2>
+  <h2>Graph summary</h2>
   <div class="grid">
     {{if gt (len .Repos) 1}}<div class="card"><div class="k">Repositories</div><div class="v">{{len .Repos}}</div></div>{{end}}
     {{if .ServiceCount}}<div class="card"><div class="k">Services</div><div class="v">{{if $.Services}}<button type="button" class="count-link" onclick="openModal('services-modal')">{{.ServiceCount}}</button>{{else}}{{.ServiceCount}}{{end}}</div></div>{{end}}
     {{if .CrossRepoEdgeCount}}<div class="card"><div class="k">Cross-repo edges</div><div class="v">{{if $.CrossRepoEdges}}<button type="button" class="count-link" onclick="openModal('edges-modal')">{{.CrossRepoEdgeCount}}</button>{{else}}{{.CrossRepoEdgeCount}}{{end}}</div></div>{{end}}
   </div>
   {{end}}{{end}}{{else}}<p class="note">{{.GraphNote}}</p>{{end}}
+  </section>
+
+  <section class="tab-panel" id="panel-snapshots" role="tabpanel" aria-labelledby="tab-snapshots" hidden>
+  <div class="panel-intro"><div class="section-kicker">Snapshot state</div><h2>Snapshots</h2><p>When this architecture was captured, what it represents, and whether anything needs attention.</p></div>
+  {{if .HasReceipt}}{{with .Receipt}}
+  <div class="snapshot-head">
+    <div><h2>{{$.Snapshot.RepoName}}</h2><p>{{if $.Snapshot.Age}}Generated {{$.Snapshot.Age}}{{else}}Generated {{.GeneratedAt}}{{end}} · snapshot <code>{{$.Snapshot.ShortID}}</code></p></div>
+    <span class="badge {{$.Snapshot.StatusClass}}">{{$.Snapshot.Status}}</span>
+  </div>
   <div class="grid">
-    {{/* extra-cards: extension slot — see pkg/dashboard.Options.Overlay */}}
-    {{block "extra-cards" $}}{{end}}
+    {{if .Git}}<div class="card"><div class="k">Git capture</div><div class="v">{{.Git.Ref}}{{if $.Snapshot.ShortCommit}} @ {{$.Snapshot.ShortCommit}}{{end}}</div></div>{{end}}
+    <div class="card"><div class="k">Source files indexed</div><div class="v">{{.Quality.FilesParsed}}</div></div>
+    <div class="card"><div class="k">Architecture facts</div><div class="v">{{.FactCount}}</div></div>
+    <div class="card"><div class="k">Findings</div><div class="v">{{if $.Insights}}<button type="button" class="count-link" onclick="openModal('insights-modal')">{{$.InsightTotal}}</button>{{else}}{{.InsightCount}}{{end}}</div></div>
+    <div class="card"><div class="k">Extraction schema</div><div class="v">{{if .ExtractorVersion}}{{.ExtractorVersion}}{{else}}not recorded{{end}}</div></div>
+    <div class="card"><div class="k">Analysis duration</div><div class="v">{{.Duration}}</div></div>
+  </div>
+  {{if and .Git .Git.Dirty}}<p class="snapshot-alert">This snapshot was generated while the working tree had local changes. It describes that exact working state, not only commit <code>{{$.Snapshot.ShortCommit}}</code>.</p>{{end}}
+
+  <div class="data-section"><h2>Analysis scope</h2>
+    <p class="note">These extractors contributed facts. Quality details explain ignored and unsupported files.</p>
+    {{if .Extractors}}<div class="chips">{{range .Extractors}}<span class="chip">{{.}}</span>{{end}}</div>{{else}}<p class="note">No extractors recorded.</p>{{end}}
+    <p style="margin:.8rem 0 0"><button type="button" class="count-link" onclick="selectTab('quality')">Review analysis completeness →</button></p>
   </div>
 
+  <div class="data-section"><h2>Graph composition</h2>
+  {{if $.HasGraph}}{{with $.Graph}}
+  {{if gt (len .Repos) 1}}
+  <div class="grid">
+    <div class="card"><div class="k">Repositories</div><div class="v">{{len .Repos}}</div></div>
+    <div class="card"><div class="k">Services</div><div class="v">{{if $.Services}}<button type="button" class="count-link" onclick="openModal('services-modal')">{{.ServiceCount}}</button>{{else}}{{.ServiceCount}}{{end}}</div></div>
+    <div class="card"><div class="k">Cross-repo edges</div><div class="v">{{if $.CrossRepoEdges}}<button type="button" class="count-link" onclick="openModal('edges-modal')">{{.CrossRepoEdgeCount}}</button>{{else}}{{.CrossRepoEdgeCount}}{{end}}</div></div>
+  </div>
+  <h3 style="margin:1.25rem 0 .5rem">Repositories in graph</h3><div class="table-scroll"><table>
+    <thead><tr><th>Repository</th><th>Git capture</th><th>In graph for</th><th class="num">Facts</th></tr></thead>
+    <tbody>{{range .Repos}}<tr><td>{{.Label}}</td><td>{{if .Git}}{{.Git.Ref}}{{if .Git.Commit}} @ {{.Git.Commit}}{{end}}{{if .Git.Dirty}} (local changes){{end}}{{else}}—{{end}}</td><td>{{.InGraphFor}}</td><td class="num">{{.FactCount}}</td></tr>{{end}}</tbody>
+  </table></div>
+  {{else}}<p class="note">Single-repository graph. The loaded graph is the current snapshot, so a second receipt would duplicate the same facts and findings.</p>{{end}}
+  {{end}}{{else}}<p class="note">{{$.GraphNote}}</p>{{end}}
+  </div>
+
+  <details class="technical-receipt"><summary>Technical receipt</summary>
+    <dl class="technical-grid">
+      <dt>Snapshot ID</dt><dd>{{.SnapshotID}}</dd>
+      <dt>Generated</dt><dd>{{if $.Snapshot.Generated}}{{$.Snapshot.Generated}}{{else}}{{.GeneratedAt}}{{end}}</dd>
+      <dt>Repository</dt><dd>{{.RepoPath}}</dd>
+      <dt>Enola build</dt><dd>{{.EnolaVersion}}</dd>
+      <dt>Extractor schema</dt><dd>{{.ExtractorVersion}}</dd>
+      <dt>Configuration hash</dt><dd>{{.ConfigHash}}</dd>
+      <dt>Ignore rules hash</dt><dd>{{.IgnoreGlobHash}}</dd>
+    </dl>
+    {{if .Explainers}}<h3>Explainers run</h3><div class="chips">{{range .Explainers}}<span class="chip">{{.}}</span>{{end}}</div>{{end}}
+    {{if .Renderers}}<h3>Renderers</h3><div class="chips">{{range .Renderers}}<span class="chip">{{.}}</span>{{end}}</div>{{end}}
+  </details>
+  {{end}}{{else}}<p class="note">{{.ReceiptNote}}</p>{{end}}
+  </section>
+
+  <section class="tab-panel" id="panel-activity" role="tabpanel" aria-labelledby="tab-activity" hidden>
+  <div class="panel-intro"><div class="section-kicker">Usage</div><h2>Activity</h2><p>What this server has done now, separated from Enola's lifetime activity across repositories.</p></div>
+
+  <div class="snapshot-head">
+    <div><h2>Current server session</h2><p>{{if .ReposLoaded}}{{.ReposLoaded}}{{else}}No repository label available{{end}}{{if .Uptime}} · running for {{.Uptime}}{{end}}</p></div>
+    {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">stopped</span>{{end}}
+  </div>
+  <div class="grid">
+    <div class="card"><div class="k">Tool calls this session</div><div class="v">{{.SessionCalls}}</div></div>
+    {{if .StartedAt}}<div class="card"><div class="k">Session started</div><div class="v">{{.StartedAt}}</div></div>{{end}}
+  </div>
+  {{if .SessionCalls}}<div class="data-section"><h2>Tools used this session</h2><div class="table-scroll"><table>
+    <thead><tr><th>Tool</th><th class="num">Calls</th></tr></thead>
+    <tbody>{{range .Tools}}{{if .Session}}<tr><td>{{.Name}}</td><td class="num">{{.Session}}</td></tr>{{end}}{{end}}</tbody>
+  </table></div></div>{{else}}<p class="note">No MCP tool calls have reached this server session yet. Snapshot generation performed by a separate command is recorded in lifetime activity, not here.</p>{{end}}
+
+  <div class="data-section"><div class="snapshot-head"><div><h2>Lifetime activity</h2><p>{{.ReposTracked}} repositories{{if .TrackingSince}} · tracked since {{.TrackingSince}}{{end}}</p></div></div>
+  {{if .Tools}}<div class="table-scroll"><table>
+    <thead><tr><th>Tool</th><th class="num">Total calls</th></tr></thead>
+    <tbody>{{range .Tools}}<tr><td>{{.Name}}</td><td class="num">{{.Total}}</td></tr>{{end}}</tbody>
+  </table></div>{{else}}<p class="note">No lifetime tool activity recorded yet.</p>{{end}}</div>
+
+  <div class="data-section"><h2>Estimated value across all repositories <span class="note">(approximate)</span></h2>{{if .Values}}<div class="table-scroll"><table>
+    <thead><tr><th>Tool</th><th class="num">Calls</th><th class="num">~Time saved</th><th class="num">~Tokens saved</th></tr></thead>
+    <tbody>{{range .Values}}<tr><td>{{.Label}}</td><td class="num">{{.Calls}}</td><td class="num">{{.TimeSaved}}</td><td class="num">{{.TokensSaved}}</td></tr>{{end}}<tr class="total"><td>{{.ValueTotal.Label}}</td><td class="num">{{.ValueTotal.Calls}}</td><td class="num">{{.ValueTotal.TimeSaved}}</td><td class="num">{{.ValueTotal.TokensSaved}}{{if $.BeyondContext}}+{{end}}</td></tr></tbody>
+  </table></div>{{else}}<p class="note">No value recorded yet.</p>{{end}}</div>
+
+  <details class="technical-receipt"><summary>Runtime details</summary>
+  <div class="grid">
+    <div class="card"><div class="k">Server process</div><div class="v">{{if .Running}}PID {{.PID}}{{else}}stopped{{end}}</div></div>
+    {{if .Binary}}<div class="card"><div class="k">Binary</div><div class="v">{{.Binary}}</div></div>{{end}}
+    <div class="card"><div class="k">Dashboard port</div><div class="v">{{.Port}}</div></div>
+  </div>
+  {{if .WorkDir}}<div class="card path-card" style="margin-top:.75rem"><div class="k">Working directory</div><div class="v">{{.WorkDir}}</div></div>{{end}}
+  {{if .ConfigPath}}<div class="card path-card" style="margin-top:.75rem"><div class="k">Config path</div><div class="v">{{.ConfigPath}}</div></div>{{end}}
+  {{if .StableURL}}<div class="card path-card" style="margin-top:.75rem"><div class="k">Shared dashboard URL</div><div class="v"><a href="{{.StableURL}}">{{.StableURL}}</a>{{if .FrontDoor}} · this server is the front door{{end}}</div></div>{{end}}
+  {{if .Instances}}<div class="data-section"><h2>Servers running</h2><div class="table-scroll"><table>
+    <thead><tr><th>Server</th><th>Repositories</th><th>Uptime</th><th class="num">Calls</th><th>Dashboard</th></tr></thead>
+    <tbody>{{range .Instances}}<tr{{if .Self}} class="self-row"{{end}}><td>{{.Binary}} · PID {{.PID}}{{if .Self}} <span class="chip">this page</span>{{end}}</td><td>{{.Repos}}</td><td>{{.Uptime}}</td><td class="num">{{.Calls}}</td><td>{{if .URL}}<a href="{{.URL}}">open{{if .FrontDoor}} · shared{{end}}</a>{{else}}—{{end}}</td></tr>{{end}}</tbody>
+  </table></div></div>{{end}}
+  </details>
+  </section>
+
+  <section class="tab-panel" id="panel-quality" role="tabpanel" aria-labelledby="tab-quality" hidden>
+  <div class="panel-intro"><div class="section-kicker">Completeness</div><h2>Analysis quality</h2><p>Extraction coverage, skipped inputs, parsing failures, and unresolved connections.</p></div>
   {{if .HasReceipt}}{{with .Receipt}}
-  <details class="quality-disclosure" id="quality">
-  <summary>{{if .Quality.ParseErrors}}Analysis quality needs attention · {{.Quality.ParseErrors}} parse error(s){{else}}Analysis complete · no parse errors{{end}}</summary>
+  <div class="snapshot-head">
+    <div><h2>{{$.Quality.Status}}</h2><p>{{$.Quality.Summary}}</p></div>
+    <span class="badge {{$.Quality.StatusClass}}">{{if .Quality.ParseErrors}}{{.Quality.ParseErrors}} error(s){{else}}{{if $.Quality.CoverageLabel}}{{$.Quality.CoverageLabel}}{{else}}no parse errors{{end}}{{end}}</span>
+  </div>
+  {{if $.Quality.Inactive}}<div class="snapshot-alert"><b>Extractor coverage detail:</b> {{range $i, $cause := $.Quality.Inactive}}{{if $i}} · {{end}}{{$cause.Count}} file(s) {{$cause.Cause}}{{end}}. This affects {{$.Quality.InactiveShare}} of the {{$.Quality.FilesWalked}} files walked and does not mean the rest of the snapshot failed.</div>{{end}}
+
+  {{if .Quality.Census}}{{with .Quality.Census}}
+  <h2>File accounting</h2>
   <div class="quality-row">
-    <div class="quality-item"><span class="k">Files seen</span><span class="v">{{.Quality.FilesSeen}}</span></div>
-    <div class="quality-item"><span class="k">Files parsed</span><span class="v">{{.Quality.FilesParsed}}</span></div>
-    <div class="quality-item"><span class="k">Skipped</span><span class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.FilesSkipped}}</button>{{else}}{{.Quality.FilesSkipped}}{{end}}</span></div>
-    <div class="quality-item"><span class="k">Parse errors</span><span class="v">{{if $.ParseErrors}}<button type="button" class="count-link" onclick="openModal('parse-errors-modal')">{{.Quality.ParseErrors}}</button>{{else}}{{.Quality.ParseErrors}}{{end}}</span></div>
+    <div class="quality-item"><span class="k">Files walked</span><span class="v">{{.FilesWalked}}</span><span class="why">All files encountered before classification.</span></div>
+    <div class="quality-item"><span class="k">Indexed</span><span class="v">{{.Parsed}}</span><span class="why">Source files that produced architecture facts.</span></div>
+    <div class="quality-item"><span class="k">Intentionally ignored</span><span class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.ExcludedByIgnore}}</button>{{else}}{{.ExcludedByIgnore}}{{end}}</span><span class="why">Matched configured ignore rules.</span></div>
+    <div class="quality-item"><span class="k">Non-source / unsupported</span><span class="v">{{.ExcludedByKind}}</span><span class="why">Assets, data, or file types without an extractor.</span></div>
+    <div class="quality-item"><span class="k">No facts emitted</span><span class="v">{{.SkippedWithCause}}</span><span class="why">Recognized files that contained no indexable structure.</span></div>
+  </div>
+  <p class="accounting-note ok">These categories account for every walked file. Ignored and non-source files are not parse failures.</p>
+
+  {{if $.Quality.Potential}}<div class="data-section"><h2>Potential architecture blind spots</h2><p class="note">These file types can carry behavior or architecture, but are outside the current graph. Review whether they matter for this repository.</p><div class="table-scroll"><table>
+    <thead><tr><th>File kind</th><th class="num">Files</th><th>Why review it</th></tr></thead>
+    <tbody>{{range $.Quality.Potential}}<tr><td>{{.Kind}}</td><td class="num">{{.Count}}</td><td class="title">{{.Reason}}</td></tr>{{end}}</tbody>
+  </table></div></div>{{end}}
+
+  {{if $.Quality.NoFacts}}<div class="data-section"><h2>Recognized files with no facts</h2><p class="note">These were analyzed successfully but contained no indexable architecture.</p><div class="table-scroll"><table>
+    <thead><tr><th>Reason</th><th class="num">Files</th></tr></thead>
+    <tbody>{{range $.Quality.NoFacts}}<tr><td>{{.Cause}}</td><td class="num">{{.Count}}</td></tr>{{end}}</tbody>
+  </table></div></div>{{end}}
+
+  {{if $.Quality.ExpectedFiles}}<details class="technical-receipt"><summary>Expected non-source exclusions · {{$.Quality.ExpectedFiles}} files across {{$.Quality.ExpectedKinds}} kinds</summary>
+    <p class="note">Assets, fixtures, snapshots, certificates, and other file kinds that normally do not define application architecture.</p>
+    <div class="table-scroll"><table><thead><tr><th>File kind</th><th class="num">Files</th></tr></thead><tbody>
+    {{range $.Quality.Expected}}<tr><td>{{.Kind}}</td><td class="num">{{.Count}}</td></tr>{{end}}
+    </tbody></table></div>
+  </details>{{end}}
+  {{end}}{{else}}
+  <div class="quality-row">
+    <div class="quality-item"><span class="k">Source files seen</span><span class="v">{{.Quality.FilesSeen}}</span></div>
+    <div class="quality-item"><span class="k">Indexed</span><span class="v">{{.Quality.FilesParsed}}</span></div>
+    <div class="quality-item"><span class="k">Intentionally ignored</span><span class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.FilesSkipped}}</button>{{else}}{{.Quality.FilesSkipped}}{{end}}</span></div>
+  </div>
+  {{end}}
+
+  <div class="data-section"><h2>Errors and cross-repository coverage</h2><div class="quality-row">
+    <div class="quality-item"><span class="k">Parse errors</span><span class="v">{{if $.ParseErrors}}<button type="button" class="count-link" onclick="openModal('parse-errors-modal')">{{.Quality.ParseErrors}}</button>{{else}}{{.Quality.ParseErrors}}{{end}}</span><span class="why">Actual extractor failures requiring attention.</span></div>
+    <div class="quality-item"><span class="k">Ignored directories</span><span class="v">{{if $.SkippedSample}}<button type="button" class="count-link" onclick="openModal('skipped-modal')">{{.Quality.DirsSkipped}}</button>{{else}}{{.Quality.DirsSkipped}}{{end}}</span><span class="why">Pruned directories; their contents were never walked.</span></div>
     {{if .Quality.Coverage}}{{with .Quality.Coverage}}
+    <div class="quality-item"><span class="k">Services</span><span class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.ServicesTotal}}</button>{{else}}{{.ServicesTotal}}{{end}}</span></div>
     <div class="quality-item"><span class="k">Coverage gaps</span><span class="v">{{if $.Coverage}}<button type="button" class="count-link" onclick="openModal('coverage-modal')">{{.CoverageGaps}}</button>{{else}}{{.CoverageGaps}}{{end}}</span></div>
     <div class="quality-item"><span class="k">Unresolved edges</span><span class="v">{{if $.UnresolvedRoutes}}<button type="button" class="count-link" onclick="openModal('coverage-unresolved-modal')">{{.UnresolvedEdges}}</button>{{else}}{{.UnresolvedEdges}}{{end}}</span></div>
     {{end}}{{end}}
-  </div>
-  </details>
+  </div></div>
   {{end}}{{else}}<p class="note">{{.ReceiptNote}}</p>{{end}}
+  </section>
+  </main>
 
   <footer>{{.Title}} · read-only · updates every {{.RefreshSeconds}} seconds</footer>
 </div>
@@ -403,6 +609,29 @@
 {{block "extra-modals" $}}{{end}}
 
 <script>
+  function selectTab(name, updateHash) {
+    var panel = document.getElementById('panel-' + name);
+    var tab = document.getElementById('tab-' + name);
+    if (!panel || !tab) return;
+    document.querySelectorAll('.tab-panel').forEach(function(p) {
+      var active = p === panel;
+      p.classList.toggle('active', active);
+      p.hidden = !active;
+    });
+    document.querySelectorAll('.tab').forEach(function(t) {
+      var active = t === tab;
+      t.classList.toggle('active', active);
+      t.setAttribute('aria-selected', active ? 'true' : 'false');
+      t.setAttribute('tabindex', active ? '0' : '-1');
+    });
+    if (updateHash !== false && history.replaceState) history.replaceState(null, '', '#' + name);
+  }
+  function initialTab() {
+    var name = location.hash.replace(/^#/, '');
+    if (!document.getElementById('tab-' + name)) name = 'overview';
+    selectTab(name, false);
+  }
+
   // JS-driven auto-refresh (replaces the old <meta refresh>) so it can be paused
   // while a modal is open — otherwise a reload would close the modal mid-read.
   var refreshMs = {{.RefreshSeconds}} * 1000;
@@ -510,6 +739,13 @@
       document.getElementById('module-detail-out').textContent = 'depends on ' + node.getAttribute('data-out');
     }
   }
+  function focusModule(id) {
+    var node = document.querySelector('.module-node[data-id="' + id + '"]');
+    if (!node) return;
+    selectModule(node);
+    var canvas = node.closest('.graph-canvas');
+    if (canvas) canvas.scrollIntoView({behavior: 'smooth', block: 'center'});
+  }
   function filterModules(query) {
     clearGraphFocus();
     query = (query || '').trim().toLowerCase();
@@ -551,7 +787,16 @@
       var open = document.querySelector('.modal.open');
       if (open) closeModal(open);
     }
+    if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && document.activeElement.classList.contains('tab')) {
+      var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+      var current = tabs.indexOf(document.activeElement);
+      var next = (current + (e.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length;
+      tabs[next].focus();
+      selectTab(tabs[next].getAttribute('data-tab'));
+    }
   });
+  window.addEventListener('hashchange', initialTab);
+  initialTab();
   startRefresh();
 </script>
 </body>

--- a/pkg/facts/facts.go
+++ b/pkg/facts/facts.go
@@ -33,6 +33,8 @@ type (
 	SnapshotMeta    = internal.SnapshotMeta
 	Receipt         = internal.Receipt
 	ReceiptQuality  = internal.ReceiptQuality
+	FileCensus      = internal.FileCensus
+	CensusCause     = internal.CensusCause
 	GraphReceipt    = internal.GraphReceipt
 	GraphRepoEntry  = internal.GraphRepoEntry
 	CoverageSummary = internal.CoverageSummary

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -673,7 +673,7 @@ func PrintStatus() {
 		fmt.Fprintf(os.Stderr, "Server:    running (PID %d)\n", ss.PID)
 		fmt.Fprintf(os.Stderr, "Uptime:    %s\n", formatDuration(time.Since(ss.StartTime)))
 		if ss.DashboardPort > 0 {
-			fmt.Fprintf(os.Stderr, "Dashboard: http://127.0.0.1:%d (auto-refreshes every 30s)\n", ss.DashboardPort)
+			fmt.Fprintf(os.Stderr, "Dashboard: http://127.0.0.1:%d (refresh data explicitly)\n", ss.DashboardPort)
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "Server:    not running (was PID %d)\n", ss.PID)


### PR DESCRIPTION
### Summary
Redesigns the Enola dashboard into a developer-focused, multi-tab workspace with clearer snapshot quality, architecture exploration, and change information.

### What changed
- Organises dashboard information into Overview, Architecture, Snapshots, Activity, and Quality tabs.
- Adds a focused module dependency explorer with:
  - Layered module overview
  - Search across connected modules
  - Consumer → selected module → dependency neighbourhoods
  - Clickable nodes and dependency edges
  - Persistent Inspector for modules, edges, and findings
  - Fit/readable-size controls
  - Finding-to-module navigation
- Clarifies symbol-level findings versus module-level graph counts.
- Adds snapshot comparison cards for facts, edges, and findings.
- Adds drill-down details for newly introduced findings.
- Explains skipped files by cause instead of presenting an alarming percentage.
- Separates expected exclusions from actionable extraction gaps and parse errors.
- Improves snapshot freshness, identity, Git state, and extractor-version context.
- Separates current-session Activity from lifetime usage.
- Replaces automatic 30-second reloads with explicit user refresh.
- Adds a subtle link to the Enola open-source project.