### PR TITLE
A constant reference is never its own predecessor

### DIFF
--- a/internal/providers/rubydex/provider.go
+++ b/internal/providers/rubydex/provider.go
@@ -44,6 +44,7 @@ type collector struct {
 	dependencyPaths     int
 	bundleAbsent        bool
 	documentCache       map[uint64][]span
+	declarationNames    map[uint64]string
 }
 
 type span struct {
@@ -63,7 +64,7 @@ func Collect(ctx context.Context, lib *Library, root string) Result {
 	if _, err := os.Stat(filepath.Join(root, "Gemfile")); err != nil {
 		return Result{Census: facts.ProviderCensus{ConstructsSkipped: 1, SkipCauses: []facts.CensusCause{{Cause: "no Gemfile: not a workspace Rubydex can index", Count: 1}}}}
 	}
-	c := &collector{root: root, workspace: "file://" + root + "/", documentCache: map[uint64][]span{}}
+	c := &collector{root: root, workspace: "file://" + root + "/", documentCache: map[uint64][]span{}, declarationNames: map[uint64]string{}}
 	paths, dependencyPaths, bundleAbsent := workspacePaths(ctx, root)
 	c.dependencyPaths = dependencyPaths
 	c.bundleAbsent = bundleAbsent
@@ -254,6 +255,13 @@ func (c *collector) emitReferences(ids []cConstantReference) {
 
 // pathPrefixes walks back from a leaf over the adjacent segments on its line
 // and returns their written names, outermost first.
+//
+// Adjacency is a property of one line, so a candidate qualifies only when it
+// is another reference and its end column belongs to the line the walk is on.
+// A reference spanning lines carries an end column from its last line, and
+// `<LibDDWAF>` at lib_ddwaf.rb:262 spans to 267 with end column 25 against
+// start column 27: without both conditions it satisfies the arithmetic
+// against itself, is returned as its own predecessor, and the walk never ends.
 func (c *collector) pathPrefixes(byLine map[string][]*constantReference, leaf *constantReference) []string {
 	line := byLine[leaf.location.URI+"\x00"+strconv.Itoa(leaf.location.StartLine)]
 	var prefixes []string
@@ -261,6 +269,9 @@ func (c *collector) pathPrefixes(byLine map[string][]*constantReference, leaf *c
 	for {
 		var previous *constantReference
 		for _, candidate := range line {
+			if candidate == current || candidate.location.EndLine != current.location.StartLine {
+				continue
+			}
 			if candidate.location.EndColumn+len("::") == current.location.StartColumn {
 				previous = candidate
 			}
@@ -268,17 +279,32 @@ func (c *collector) pathPrefixes(byLine map[string][]*constantReference, leaf *c
 		if previous == nil {
 			break
 		}
-		prefixes = append([]string{c.writtenName(previous)}, prefixes...)
+		prefixes = append(prefixes, c.writtenName(previous))
 		current = previous
+	}
+	for i, j := 0, len(prefixes)-1; i < j; i, j = i+1, j-1 {
+		prefixes[i], prefixes[j] = prefixes[j], prefixes[i]
 	}
 	return prefixes
 }
 
+// A declaration referenced many times is marshalled across the seam once:
+// a Rails monolith resolves 1,624,360 references to 132,603 declarations, so the
+// same name is asked for a dozen times on average. An unresolved reference
+// carries its own written name and has nothing to share.
 func (c *collector) writtenName(ref *constantReference) string {
-	if ref.resolved {
-		return plainName(c.g.declarationName(ref.target.id))
+	if !ref.resolved {
+		return c.g.constantReferenceName(ref.id)
 	}
-	return c.g.constantReferenceName(ref.id)
+	if name, known := c.declarationNames[ref.target.id]; known {
+		return name
+	}
+	name := plainName(c.g.declarationName(ref.target.id))
+	if c.declarationNames == nil {
+		c.declarationNames = map[uint64]string{}
+	}
+	c.declarationNames[ref.target.id] = name
+	return name
 }
 
 func (c *collector) emitReference(ref *constantReference, prefixes []string) {

--- a/internal/providers/rubydex/provider_test.go
+++ b/internal/providers/rubydex/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/enola-labs/enola/internal/facts"
 )
@@ -239,4 +240,33 @@ func TestCollect_ReopenedLeafCarriesNoTargetFile(t *testing.T) {
 		return
 	}
 	t.Fatal("the bare read of a reopened module is still a dependency on the name")
+}
+
+// The shape that hung the provider on a Rails monolith: `<LibDDWAF>` at
+// lib_ddwaf.rb:262 spans to line 267, so its end column belongs to another
+// line and, at 25 against a start column of 27, satisfies the adjacency
+// arithmetic against itself. Before the identity and same-line conditions the
+// walk returned it as its own predecessor and never terminated, which cost a
+// cluster regeneration 26 minutes and 6.7GB before it was killed.
+func TestPathPrefixes_AReferenceIsNeverItsOwnPredecessor(t *testing.T) {
+	leaf := &constantReference{
+		id:       1,
+		location: Location{URI: "file:///w/lib_ddwaf.rb", StartLine: 262, EndLine: 267, StartColumn: 27, EndColumn: 25},
+	}
+	byLine := map[string][]*constantReference{
+		leaf.location.URI + "\x00262": {leaf},
+	}
+	c := &collector{declarationNames: map[uint64]string{}}
+
+	walked := make(chan []string, 1)
+	go func() { walked <- c.pathPrefixes(byLine, leaf) }()
+
+	select {
+	case prefixes := <-walked:
+		if len(prefixes) != 0 {
+			t.Fatalf("a reference on its own line has no prefixes, got %v", prefixes)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("pathPrefixes did not return: the reference was accepted as its own predecessor")
+	}
 }


### PR DESCRIPTION
The Rubydex provider can stop returning. On a Rails monolith it was killed at 26 minutes holding 6.7GB with nothing written, on a tree the engine itself indexes in 24 seconds, and a second Rails application hung the same way. Both complete after this change.

`pathPrefixes` walks back over the segments written before a leaf so that `Foo::VERSION` reports `VERSION` with `Foo` as its path. It finds the previous segment by comparing a candidate's end column plus the separator against the current segment's start column, and it compares columns alone. A reference spanning several lines carries an end column belonging to its last line, so when that number plus two happens to equal its own start column, the reference is its own predecessor and the loop cannot end. One reference does it on that monolith: `<LibDDWAF>` at lib_ddwaf.rb:262 in the libddwaf gem spans to line 267, end column 25 against start column 27.

A candidate now qualifies only when it is a different reference and its end line is the line being walked. Those are the two conditions `emitReferences` already asserts twenty lines earlier when it marks inner segments, so this makes one comparison agree with the other rather than inventing a rule.

Two smaller things ride along because they are in the same loop: names are appended and reversed once rather than prepended into a fresh slice at each step, and a declaration's name crosses the library boundary once instead of per reference. That monolith resolves 1,624,360 references to 132,603 declarations, so the same name was fetched about a dozen times.

The regression test constructs the reference shape rather than depending on a workspace, and fails against the current code by never returning within its deadline. Facts are byte-for-byte identical on a repository where both builds complete, and the full suite passes.

Worth noting for anyone measuring this: the graph underneath is not slow. Rubydex indexes that monolith in 13.5 seconds through its own CLI, and the provider's index and resolve phases cost 9 seconds. Three earlier explanations for the cost, a cold extractor cache, an unsharded provider seam, and the volume of library calls, were each measured and each wrong before a step cap on the walk showed it was not terminating.