### PR TITLE
Tell a built-in provider what the configuration excludes

### DIFF
--- a/internal/providers/builtin.go
+++ b/internal/providers/builtin.go
@@ -17,7 +17,7 @@ import (
 // `providers:` entry with no command uses. Each runs in-process and answers
 // with facts that pass the same validation as JSONL from an external tool,
 // a census, and the version of the engine it read through.
-var builtIns = map[string]func(ctx context.Context, repoPath string) ([]facts.Fact, string, facts.ProviderCensus, string){
+var builtIns = map[string]func(ctx context.Context, repoPath string, ignored func(file string) bool) ([]facts.Fact, string, facts.ProviderCensus, string){
 	"rubydex": runRubydex,
 }
 
@@ -48,7 +48,7 @@ func runBuiltIn(ctx context.Context, p Provider, in Input) ([]facts.Fact, facts.
 			return accepted, record
 		}
 	}
-	accepted, version, census, refusal := run(ctx, repoPath)
+	accepted, version, census, refusal := run(ctx, repoPath, in.Ignored)
 	if refusal != "" {
 		return skip("%s", refusal)
 	}
@@ -169,7 +169,7 @@ func readRubydexMeta(cache Cache) (rubydexIndexMeta, bool) {
 	return meta, true
 }
 
-func runRubydex(ctx context.Context, repoPath string) ([]facts.Fact, string, facts.ProviderCensus, string) {
+func runRubydex(ctx context.Context, repoPath string, ignored func(file string) bool) ([]facts.Fact, string, facts.ProviderCensus, string) {
 	path, installed := rubydex.Installed()
 	if !installed {
 		return nil, "", facts.ProviderCensus{}, fmt.Sprintf("the Rubydex library is not installed at %s; run `%s`", path, rubydex.FetchHint)
@@ -178,7 +178,7 @@ func runRubydex(ctx context.Context, repoPath string) ([]facts.Fact, string, fac
 	if err != nil {
 		return nil, "", facts.ProviderCensus{}, err.Error()
 	}
-	result := rubydex.Collect(ctx, lib, repoPath)
+	result := rubydex.Collect(ctx, lib, repoPath, ignored)
 	if result.Refusal != "" {
 		return nil, "", facts.ProviderCensus{}, result.Refusal
 	}

--- a/internal/providers/rubydex/provider.go
+++ b/internal/providers/rubydex/provider.go
@@ -45,6 +45,9 @@ type collector struct {
 	bundleAbsent        bool
 	documentCache       map[uint64][]span
 	declarationNames    map[uint64]string
+	ignored             func(file string) bool
+	excludedDocuments   int
+	excludedReferences  int
 }
 
 type span struct {
@@ -56,7 +59,16 @@ type span struct {
 
 // Collect indexes the repository at root with the loaded library and returns
 // the facts the reference script would have emitted for it.
-func Collect(ctx context.Context, lib *Library, root string) Result {
+//
+// ignored reports whether a repo-relative file is excluded by the
+// repository's configuration. The seam drops facts about such files after a
+// provider returns, which for a built-in is work done to be thrown away: on a
+// Rails monolith 1,520,163 of 2,155,664 facts. A built-in runs in the
+// engine's own address space and can be told, so it is: an excluded document
+// is skipped before its definitions are read, which also skips the graph
+// calls behind them, and an excluded reference before its fact is built. A
+// nil predicate accepts everything.
+func Collect(ctx context.Context, lib *Library, root string, ignored func(file string) bool) Result {
 	root, err := filepath.Abs(root)
 	if err != nil {
 		return Result{Refusal: err.Error()}
@@ -64,7 +76,7 @@ func Collect(ctx context.Context, lib *Library, root string) Result {
 	if _, err := os.Stat(filepath.Join(root, "Gemfile")); err != nil {
 		return Result{Census: facts.ProviderCensus{ConstructsSkipped: 1, SkipCauses: []facts.CensusCause{{Cause: "no Gemfile: not a workspace Rubydex can index", Count: 1}}}}
 	}
-	c := &collector{root: root, workspace: "file://" + root + "/", documentCache: map[uint64][]span{}, declarationNames: map[uint64]string{}}
+	c := &collector{root: root, workspace: "file://" + root + "/", documentCache: map[uint64][]span{}, declarationNames: map[uint64]string{}, ignored: ignored}
 	paths, dependencyPaths, bundleAbsent := workspacePaths(ctx, root)
 	c.dependencyPaths = dependencyPaths
 	c.bundleAbsent = bundleAbsent
@@ -76,9 +88,15 @@ func Collect(ctx context.Context, lib *Library, root string) Result {
 
 	var documents []uint64
 	for _, doc := range c.g.documents() {
-		if c.inWorkspace(c.g.documentURI(doc)) {
-			documents = append(documents, doc)
+		uri := c.g.documentURI(doc)
+		if !c.inWorkspace(uri) {
+			continue
 		}
+		if c.excluded(uri) {
+			c.excludedDocuments++
+			continue
+		}
+		documents = append(documents, doc)
 	}
 	for _, doc := range documents {
 		for _, definition := range c.g.definitions(doc) {
@@ -130,6 +148,10 @@ func workspacePaths(ctx context.Context, root string) (paths []string, dependenc
 		}
 	}
 	return paths, dependencyPaths, false
+}
+
+func (c *collector) excluded(uri string) bool {
+	return c.ignored != nil && c.ignored(c.relative(uri))
 }
 
 func (c *collector) inWorkspace(uri string) bool {
@@ -227,6 +249,10 @@ func (c *collector) emitReferences(ids []cConstantReference) {
 	for _, id := range ids {
 		location, ok := c.g.constantReferenceLocation(id.id)
 		if !ok || !c.inWorkspace(location.URI) {
+			continue
+		}
+		if c.excluded(location.URI) {
+			c.excludedReferences++
 			continue
 		}
 		ref := &constantReference{id: id.id, location: location}
@@ -473,6 +499,8 @@ func (c *collector) census(filesSeen, diagnostics int) facts.ProviderCensus {
 	add("receiver resolves to no constant", c.untypedReceivers)
 	add("declaration is a constant alias, not a class", c.aliasedDeclarations)
 	add("rubydex diagnostic", diagnostics)
+	add("document excluded by the repository's ignore globs", c.excludedDocuments)
+	add("reference in a file the repository's ignore globs exclude", c.excludedReferences)
 	if c.bundleAbsent {
 		add("bundle not on PATH or not readable: workspace indexed without its gems", 1)
 	}

--- a/internal/providers/rubydex/provider_test.go
+++ b/internal/providers/rubydex/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ func writeFixture(t *testing.T) string {
 func TestCollect_EmitsTheReferenceScriptsFacts(t *testing.T) {
 	lib := requireLibrary(t)
 	repo := writeFixture(t)
-	result := Collect(context.Background(), lib, repo)
+	result := Collect(context.Background(), lib, repo, nil)
 	if result.Refusal != "" {
 		t.Fatalf("refused: %s", result.Refusal)
 	}
@@ -109,8 +110,8 @@ func TestCollect_EmitsTheReferenceScriptsFacts(t *testing.T) {
 func TestCollect_IsDeterministic(t *testing.T) {
 	lib := requireLibrary(t)
 	repo := writeFixture(t)
-	first := Collect(context.Background(), lib, repo)
-	second := Collect(context.Background(), lib, repo)
+	first := Collect(context.Background(), lib, repo, nil)
+	second := Collect(context.Background(), lib, repo, nil)
 	if !reflect.DeepEqual(first, second) {
 		t.Fatal("two runs over the same tree must agree")
 	}
@@ -122,7 +123,7 @@ func TestCollect_NoGemfileIsARefusalInTheCensus(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "a.rb"), []byte("class A; end\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	result := Collect(context.Background(), lib, repo)
+	result := Collect(context.Background(), lib, repo, nil)
 	if result.Refusal != "" || len(result.Facts) != 0 || len(result.Census.SkipCauses) != 1 || result.Census.SkipCauses[0].Cause != "no Gemfile: not a workspace Rubydex can index" {
 		t.Fatalf("result = %+v, want a named refusal in the census and nothing emitted", result)
 	}
@@ -170,7 +171,7 @@ func TestCollect_EmitsOneDependencyPerResolvedLeaf(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	result := Collect(context.Background(), lib, repo)
+	result := Collect(context.Background(), lib, repo, nil)
 	byName := map[string]facts.Fact{}
 	for _, f := range result.Facts {
 		byName[f.Name] = f
@@ -229,7 +230,7 @@ func TestCollect_ReopenedLeafCarriesNoTargetFile(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	result := Collect(context.Background(), lib, repo)
+	result := Collect(context.Background(), lib, repo, nil)
 	for _, f := range result.Facts {
 		if f.Name != "rubydex-ref: Use#v -> Foo" {
 			continue
@@ -268,5 +269,60 @@ func TestPathPrefixes_AReferenceIsNeverItsOwnPredecessor(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("pathPrefixes did not return: the reference was accepted as its own predecessor")
+	}
+}
+
+// The built-in is told what the configuration excludes, so the seam has
+// nothing left to drop for it. A file the predicate rejects contributes no
+// facts at all, and the census names both what it skipped and why.
+func TestCollect_ExcludedFilesProduceNoFacts(t *testing.T) {
+	lib := requireLibrary(t)
+	repo := t.TempDir()
+	files := map[string]string{
+		"Gemfile":                      "source \"https://rubygems.org\"\n",
+		"lib/kept.rb":                  "class Kept\n  def run\n    Helper::VALUE\n  end\nend\n",
+		"lib/helper.rb":                "module Helper\n  VALUE = 1\nend\n",
+		"vendor/bundle/lib/dropped.rb": "class Dropped\n  def run\n    Helper::VALUE\n  end\nend\n",
+	}
+	for rel, body := range files {
+		path := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ignored := func(file string) bool { return strings.HasPrefix(file, "vendor/") }
+
+	all := Collect(context.Background(), lib, repo, nil)
+	filtered := Collect(context.Background(), lib, repo, ignored)
+
+	dropped := 0
+	for _, f := range all.Facts {
+		if ignored(f.File) {
+			dropped++
+		}
+	}
+	if dropped == 0 {
+		t.Fatal("the fixture must produce facts about the excluded file, or the test asserts nothing")
+	}
+	for _, f := range filtered.Facts {
+		if ignored(f.File) {
+			t.Fatalf("the seam had a fact left to drop: %s in %s", f.Name, f.File)
+		}
+	}
+	if len(filtered.Facts) != len(all.Facts)-dropped {
+		t.Fatalf("filtering removed %d facts, the excluded file accounts for %d",
+			len(all.Facts)-len(filtered.Facts), dropped)
+	}
+	var named bool
+	for _, cause := range filtered.Census.SkipCauses {
+		if strings.Contains(cause.Cause, "ignore globs") {
+			named = true
+		}
+	}
+	if !named {
+		t.Fatal("the census must name what the exclusions cost, not only remove it")
 	}
 }


### PR DESCRIPTION
Follows #254. With the walk fixed, the Rubydex provider's remaining cost is work it does so the seam can throw it away: on a Rails monolith it built 2,155,664 facts and the repository's ignore globs rejected 1,520,163 of them, 71%. The same tree now snapshots in 193 seconds instead of 440, with the surviving 1,800,829 facts byte-for-byte identical.

The drop pass exists because a provider walks the tree itself and cannot know what the configuration leaves out. That fits an external provider, a separate process handed a repository path. A built-in runs in the engine's own address space and `Input` already carries `Ignored`, so `Collect` now takes it: an excluded document is skipped before its definitions are read, which also skips the per-definition library calls behind those facts, and an excluded reference before its fact is built. The census names both counts.

The phase timings chose that shape. The document loop was 2m34.8s producing 1,480,769 facts, the reference walk 2m2.8s producing 674,895, over a graph that indexes and resolves in nine seconds. Filtering only the walk, which is where I started, would have left most of the waste in place.

Indexing is deliberately untouched: vendored gems and engine directories are still handed to the indexer, because that is what lets a workspace constant resolve to a declaration outside it. Indexing is how the graph resolves, emission is what enters it.

The test asserts three things rather than one: no fact survives about an excluded file, the count removed equals exactly what the predicate rejects, and the census names the cause. A nil predicate accepts everything, so existing callers are unchanged, and the seam keeps its drop pass as the backstop for providers you do not control.

One consequence worth naming: this makes a built-in something other than an external provider that happens to be compiled in. It can be told what the seam knows. The next built-in inherits both the capability and the obligation to use it.