### PR TITLE
A repository-scoped fact is not a file the change touched

### DIFF
--- a/pkg/check/guidance.go
+++ b/pkg/check/guidance.go
@@ -23,6 +23,15 @@ func changedFiles(d *diff.SnapshotDiff) []constraints.ChangedFile {
 	seen := map[string]bool{}
 	var out []constraints.ChangedFile
 	add := func(f facts.Fact) {
+		// A repository-scoped fact carries a LABEL in File, not a path: an
+		// extraction fact's File is the repository's directory name. Nobody edited
+		// that "file", and every consumer here reads File as something a change
+		// touched — so letting it through resolves to the root module and gives it
+		// a routing line of its own on any change that moves an extractor's
+		// coverage counters, which is most changes in a Ruby or TypeScript tree.
+		if f.Kind == facts.KindExtraction {
+			return
+		}
 		if f.File == "" || seen[f.File] {
 			return
 		}

--- a/pkg/check/reviewers_test.go
+++ b/pkg/check/reviewers_test.go
@@ -343,3 +343,37 @@ func TestSparseModuleStillMakesAnAbsentActorMinor(t *testing.T) {
 		t.Error("bob holds all of pkg/thin; sparse must not invert who is a stranger")
 	}
 }
+
+// A repository-scoped fact is not a file anybody touched. An extraction fact carries
+// the repository's directory name in File, and its coverage counters move on most
+// changes to a Ruby or TypeScript tree — so before changedFiles skipped it, every such
+// change opened the routing section with a line about the root module, measured over
+// the whole repository and telling the reader nothing.
+func TestRoutingIgnoresRepositoryScopedFacts(t *testing.T) {
+	store := storeWithModules(".", "pkg/auth")
+	a := authorshipOf(map[string]map[string]int{
+		".":        {"bob": 60, "ada": 10},
+		"pkg/auth": {"bob": 99, "ada": 1},
+	})
+	d := touchedDelta("pkg/auth/a.go")
+	// The shape enola actually produces: extcoverage puts filepath.Base(repoPath)
+	// in File, so the "path" here is the checkout's directory name.
+	d.FactsChanged = []diff.FactChange{{
+		Before: facts.Fact{Kind: facts.KindExtraction, Name: "ruby:calls", File: "chatwoot"},
+		After:  facts.Fact{Kind: facts.KindExtraction, Name: "ruby:calls", File: "chatwoot"},
+	}}
+
+	v := AttachReviewers(cleanVerdict(d), store, a, "ada")
+
+	if v.Reviewers == nil {
+		t.Fatal("no routing report")
+	}
+	for _, route := range v.Reviewers.Routes {
+		if route.Module == "." {
+			t.Fatalf("root module routed from an extraction fact: %+v", v.Reviewers.Routes)
+		}
+	}
+	if len(v.Reviewers.Routes) != 1 || v.Reviewers.Routes[0].Module != "pkg/auth" {
+		t.Fatalf("want the one touched module, got %+v", v.Reviewers.Routes)
+	}
+}


### PR DESCRIPTION
An extraction fact carries the repository's directory name in File rather than a path, and changedFiles handed it to callers that read File as something somebody edited. Routing then opened with a line about the root module, measured over the whole repository, on any change that moved an extractor's coverage counters.

Filtered in changedFiles rather than at the source: File is part of a fact's identity in every snapshot and diff, so moving it there would churn far more than the display bug it fixes. AttachGuidance reads the same list and wanted the same thing from it.