### PR TITLE
Let a wrapper binary be itself in the shared commands

### DIFF
--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -401,6 +401,7 @@ func binary() cli.Binary {
 		Name:       "enola",
 		CmdPackage: "./cmd/enola",
 		VersionVar: "github.com/enola-labs/enola/internal/version.Version",
+		Version:    version.Version,
 	}
 }
 

--- a/pkg/check/format.go
+++ b/pkg/check/format.go
@@ -61,25 +61,38 @@ func ParseHost(s string) (Host, error) {
 	return "", fmt.Errorf("unknown host %q: expected buildkite or github", s)
 }
 
+// Output is everything a writer needs besides the verdict itself: which format
+// to render, and the two things only some formats read — the CI host the
+// annotations writer targets, and the tool identity the SARIF driver block is
+// attributed to. The zero value renders text as enola.
+type Output struct {
+	Format Format
+	Host   Host
+	Link   string
+	// Tool attributes a SARIF document to the binary that produced it. Ignored
+	// by every other format. Zero means enola; see Tool.
+	Tool Tool
+}
+
 // Write renders the verdict in the named format. Text is Render, JSON is JSON;
 // the two host writers are the new rows. Annotations need a host, because
 // without one there is no markup to write and an empty document would read
 // as "no findings".
-func (v Verdict) Write(format Format, host Host, link string) ([]byte, error) {
-	switch format {
+func (v Verdict) Write(o Output) ([]byte, error) {
+	switch o.Format {
 	case FormatText:
 		return []byte(v.Render()), nil
 	case FormatJSON:
 		return v.JSON()
 	case FormatSARIF:
-		return v.SARIF()
+		return v.SARIF(o.Tool)
 	case FormatAnnotations:
-		if host == HostNone {
+		if o.Host == HostNone {
 			return nil, fmt.Errorf("-format annotations needs -host buildkite or -host github")
 		}
-		return v.Annotations(host, link)
+		return v.Annotations(o.Host, o.Link)
 	}
-	return nil, fmt.Errorf("unknown format %q", format)
+	return nil, fmt.Errorf("unknown format %q", o.Format)
 }
 
 // bucket is one named section of the verdict, with the level a host should

--- a/pkg/check/format_test.go
+++ b/pkg/check/format_test.go
@@ -40,7 +40,7 @@ func formatVerdict() Verdict {
 }
 
 func TestSARIF_ShapeAndContents(t *testing.T) {
-	out, err := formatVerdict().SARIF()
+	out, err := formatVerdict().SARIF(Tool{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,25 +195,25 @@ func TestAnnotations_GitHubWorkflowCommandsAndEscaping(t *testing.T) {
 func TestWrite_IsDeterministicAndTextAndJSONUnchanged(t *testing.T) {
 	v := formatVerdict()
 	for _, f := range []Format{FormatSARIF, FormatAnnotations} {
-		a, err := v.Write(f, HostGitHub, "")
+		a, err := v.Write(Output{Format: f, Host: HostGitHub})
 		if err != nil {
 			t.Fatal(err)
 		}
-		b, _ := v.Write(f, HostGitHub, "")
+		b, _ := v.Write(Output{Format: f, Host: HostGitHub})
 		if !bytes.Equal(a, b) {
 			t.Fatalf("%s differs between two runs", f)
 		}
 	}
-	text, _ := v.Write(FormatText, HostNone, "")
+	text, _ := v.Write(Output{Format: FormatText})
 	if string(text) != v.Render() {
 		t.Fatal("text format must be Render, byte for byte")
 	}
-	js, _ := v.Write(FormatJSON, HostNone, "")
+	js, _ := v.Write(Output{Format: FormatJSON})
 	want, _ := v.JSON()
 	if !bytes.Equal(js, want) {
 		t.Fatal("json format must be JSON, byte for byte")
 	}
-	if _, err := v.Write(FormatAnnotations, HostNone, ""); err == nil {
+	if _, err := v.Write(Output{Format: FormatAnnotations}); err == nil {
 		t.Fatal("annotations without a host must refuse, never print an empty document")
 	}
 	if _, err := ParseFormat("yaml"); err == nil {

--- a/pkg/check/sarif.go
+++ b/pkg/check/sarif.go
@@ -94,6 +94,40 @@ const (
 	fingerprintKey = "enola/v1"
 )
 
+// Tool identifies the binary that produced a verdict, for the SARIF driver block
+// a consumer attributes its findings to.
+//
+// It is a parameter rather than the constant it used to be because a wrapper
+// binary produces verdicts too, and a SARIF document is uploaded rather than
+// read locally: GitHub code scanning keys alerts on the driver name, so an
+// `enola-enterprise check --format sarif` that declared itself "enola" would
+// merge its alerts into another tool's and stamp them with a version it was
+// never built at — enola's internal/version, which no wrapper stamps, so "dev".
+//
+// The zero value is enola, which is what keeps every existing caller correct.
+type Tool struct {
+	Name           string
+	Version        string
+	InformationURI string
+}
+
+// resolve fills the enola defaults for whatever the caller left empty.
+func (t Tool) resolve() Tool {
+	if t.Name == "" {
+		t.Name = "enola"
+	}
+	if t.Version == "" {
+		t.Version = version.Version
+	}
+	if t.InformationURI == "" {
+		// The engine's project page, deliberately, even for a wrapper: it is
+		// where the rules a reader has just been shown are documented.
+		t.InformationURI = "https://github.com/enola-labs/enola"
+	}
+	t.Version = strings.TrimPrefix(t.Version, "v")
+	return t
+}
+
 // SARIF renders the verdict as one SARIF 2.1.0 run: a rule per distinct rule
 // id with the team's reason as its short description, a result per finding in
 // every bucket, the region from the evidence the explainer measured, the
@@ -102,7 +136,8 @@ const (
 // position they had is on the baseline side and the tree may no longer have
 // that line. Suppressed and exempted findings carry the excuse that kept them
 // out of the gate, as a SARIF suppression.
-func (v Verdict) SARIF() ([]byte, error) {
+func (v Verdict) SARIF(tool Tool) ([]byte, error) {
+	driver := tool.resolve()
 	places := v.placements()
 	reasons := map[string]string{}
 	for _, p := range places {
@@ -158,9 +193,9 @@ func (v Verdict) SARIF() ([]byte, error) {
 		Version: sarifVer,
 		Runs: []sarifRun{{
 			Tool: sarifTool{Driver: sarifDriver{
-				Name:           "enola",
-				Version:        strings.TrimPrefix(version.Version, "v"),
-				InformationURI: "https://github.com/enola-labs/enola",
+				Name:           driver.Name,
+				Version:        driver.Version,
+				InformationURI: driver.InformationURI,
 				Rules:          rules,
 			}},
 			Results: results,

--- a/pkg/check/sarif_identity_test.go
+++ b/pkg/check/sarif_identity_test.go
@@ -1,0 +1,63 @@
+package check
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A SARIF document is uploaded and attributed, not read locally. GitHub code scanning
+// keys alerts on the driver name, so a wrapper binary that declared itself "enola"
+// merged its alerts into another tool's and stamped them with enola's internal/version —
+// which no wrapper stamps, so "dev".
+func TestSARIF_DriverNamesTheBinaryThatGraded(t *testing.T) {
+	out, err := formatVerdict().SARIF(Tool{Name: "enola-enterprise", Version: "v1.4.2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Runs []struct {
+			Tool struct {
+				Driver struct {
+					Name           string `json:"name"`
+					Version        string `json:"version"`
+					InformationURI string `json:"informationUri"`
+				} `json:"driver"`
+			} `json:"tool"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatal(err)
+	}
+	d := doc.Runs[0].Tool.Driver
+	if d.Name != "enola-enterprise" {
+		t.Errorf("driver.name = %q, want the binary that produced the verdict", d.Name)
+	}
+	if d.Version != "1.4.2" {
+		t.Errorf("driver.version = %q, want the caller's version with the v stripped", d.Version)
+	}
+	if d.InformationURI == "" {
+		t.Error("driver.informationUri must always be set; it is where the rules are documented")
+	}
+}
+
+// The zero Tool is enola, which is what keeps every caller that never asked for a
+// different identity byte-identical.
+func TestSARIF_ZeroToolIsEnola(t *testing.T) {
+	a, err := formatVerdict().SARIF(Tool{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Runs []struct {
+			Tool struct {
+				Driver struct{ Name string } `json:"driver"`
+			} `json:"tool"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(a, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Runs[0].Tool.Driver.Name != "enola" {
+		t.Errorf("zero Tool rendered %q, want enola", doc.Runs[0].Tool.Driver.Name)
+	}
+}

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -41,6 +41,19 @@ type Binary struct {
 	// BuildOutput is the artifact name a source build produces, when it differs
 	// from Name (e.g. "enola-ent" for enola-enterprise). Defaults to Name.
 	BuildOutput string
+
+	// Version is the build version of THIS binary, as its own main package knows
+	// it — the value VersionVar names, already resolved.
+	//
+	// It is carried here rather than read from internal/version because that
+	// variable is enola's, stamped by enola's release workflow. A wrapper is
+	// stamped through a different -X target (enola-enterprise uses
+	// `main.version`), so anything reading internal/version inside a wrapper
+	// reports "dev" forever: `doctor` said "enola dev", the SARIF driver claimed
+	// to be enola dev, and the dashboard registered its instance as dev. Empty
+	// falls back to internal/version, which is correct for the OSS binary and is
+	// what keeps this field optional.
+	Version string
 }
 
 // output returns the artifact name to show in the BUILD section.

--- a/pkg/command/check.go
+++ b/pkg/command/check.go
@@ -17,7 +17,6 @@ import (
 	"github.com/enola-labs/enola/internal/diff"
 	"github.com/enola-labs/enola/internal/engine"
 	"github.com/enola-labs/enola/internal/facts"
-	"github.com/enola-labs/enola/internal/updatecheck"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/check"
 	"github.com/enola-labs/enola/pkg/cli"
@@ -333,7 +332,14 @@ func (r *Runner) Check(ctx context.Context, args []string) {
 			fmt.Printf("\n%s\n", verdict.Detail())
 		}
 	default:
-		out, err := verdict.Write(outFormat, outHost, *link)
+		out, err := verdict.Write(check.Output{
+			Format: outFormat,
+			Host:   outHost,
+			Link:   *link,
+			// A SARIF document is uploaded and attributed, so it names the
+			// binary that actually graded the change. See check.Tool.
+			Tool: check.Tool{Name: r.name(), Version: r.buildVersion()},
+		})
 		if err != nil {
 			r.checkFatal("failed to encode verdict: %v", err)
 		}
@@ -348,7 +354,7 @@ func (r *Runner) Check(ctx context.Context, args []string) {
 	if *write && cli.ShowDashboardHint(os.Stderr) {
 		fmt.Fprint(os.Stderr, cli.DashboardHint(r.name(), arg))
 	}
-	updatecheck.Fprint(os.Stderr, engine.ExtractorVersion())
+	r.updateNotice(os.Stderr)
 	os.Exit(verdict.ExitCode())
 }
 
@@ -414,7 +420,7 @@ func (r *Runner) cmdFatal(cmd, format string, args ...any) {
 // After the error, never before it: what failed is what they need first.
 func (r *Runner) writeFatal(w io.Writer, cmd, format string, args ...any) {
 	_, _ = fmt.Fprintf(w, r.name()+" "+cmd+": "+format+"\n", args...)
-	updatecheck.Fprint(w, engine.ExtractorVersion())
+	r.updateNotice(w)
 }
 
 // runBaseline is `enola baseline pin|show|clear` — the CLI half of the loop, so the

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -18,13 +18,18 @@ package command
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/engine"
+	"github.com/enola-labs/enola/internal/updatecheck"
+	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/cli"
+	"github.com/enola-labs/enola/pkg/dashboard"
 )
 
 // Runner runs the shared subcommands on behalf of one binary.
@@ -48,6 +53,58 @@ type Runner struct {
 	// plain OSS engine here. That is how `baseline pin` came to write a snapshot with a
 	// different explainer set than `--generate` on the same tree, from the same binary.
 	setup func(*bootstrap.Engine)
+	// dashboardOpts builds the options the standalone `dashboard` command serves with,
+	// so a wrapper's page is its own here as well as on its MCP server. See
+	// WithDashboard.
+	dashboardOpts func(*bootstrap.Engine) dashboard.Options
+	// extraInstructions and extraHooksNote are what a wrapper adds to the agent
+	// instructions `install` writes, so its own tools are named there. See
+	// WithInstructions.
+	extraInstructions string
+	extraHooksNote    string
+}
+
+// WithDashboard registers the dashboard options `dashboard` serves with. Returns the
+// Runner so it can be chained onto New.
+//
+// It exists for the same reason WithEngine does, one layer further out. This command
+// starts a dashboard of its OWN — a standalone one, without an MCP server — so a wrapper
+// that only passed its options to bootstrap's server got the plain OSS page here: OSS
+// title, no licensed panel, and, worse, no licensed entries in Options.InsightLabels.
+// That map is the page's admission list, so the dead-code, performance and
+// package-metrics findings the wrapper's own explainers had just computed were filtered
+// out of its own Insights modal. Licensed value, silently absent from the newest surface
+// that shows it.
+//
+// The callback takes the Engine because a wrapper's options are computed per engine (the
+// Package Metrics panel reads the live store); Tracker and StablePort are set by this
+// package afterwards and must not be set here — see Dashboard.
+func (r *Runner) WithDashboard(opts func(*bootstrap.Engine) dashboard.Options) *Runner {
+	r.dashboardOpts = opts
+	return r
+}
+
+// dashboardOptions is the options a dashboard this package starts is built from: the
+// wrapper's, when it registered any, and the OSS defaults otherwise.
+func (r *Runner) dashboardOptions(eng *bootstrap.Engine) dashboard.Options {
+	if r.dashboardOpts == nil {
+		return dashboard.Options{}
+	}
+	return r.dashboardOpts(eng)
+}
+
+// WithInstructions registers text appended to the agent instructions `install` writes,
+// and to the hooks note it adds under --hooks. Returns the Runner so it can be chained
+// onto New.
+//
+// install.Options has carried these two seams since it was written, for a wrapper that
+// serves tools this package cannot know about. Nothing reached them: `install` built its
+// Options here and left both empty, so a licensed binary wrote instruction files that
+// named only the OSS tools, and an agent in that repository had no way to learn its
+// licensed tools existed. Either string may be empty.
+func (r *Runner) WithInstructions(extra, hooksNote string) *Runner {
+	r.extraInstructions, r.extraHooksNote = extra, hooksNote
+	return r
 }
 
 // WithEngine registers a hook applied to every engine these commands construct. Returns
@@ -95,6 +152,40 @@ func (r *Runner) name() string {
 		return "enola"
 	}
 	return r.bin.Name
+}
+
+// buildVersion is the version of the binary running these commands — its own, not
+// enola's. See cli.Binary.Version for why the two differ in a wrapper.
+func (r *Runner) buildVersion() string {
+	if r.bin.Version == "" {
+		return version.Version
+	}
+	return r.bin.Version
+}
+
+// selfUpgrades reports whether this binary can replace itself in place, which is the
+// same question as whether it dispatches `upgrade`: cmd/enola passes it to New as its
+// own subcommand, and a wrapper — shipping through its own release path — does not.
+//
+// It gates the update notice as well as the suggested command, because the two are one
+// decision. The notice compares against ENOLA's release manifest, so in a wrapper it
+// would not merely name a command that does not exist: it would compare a version from
+// a different release stream against enola's and advertise the difference as an
+// upgrade. Silence is the only correct output there.
+//
+// Today the notice is suppressed in the wrapper by accident — updatecheck.Suppressed
+// reads internal/version, which no wrapper stamps, so it is permanently "dev". This
+// makes the intent explicit rather than a consequence of an unstamped variable, which
+// is the sort of thing that stops being true the moment somebody adds a -X flag.
+func (r *Runner) selfUpgrades() bool { return slices.Contains(r.own, "upgrade") }
+
+// updateNotice writes the "a newer enola is available" line, when there is one to write
+// and this binary is the one it is about. See selfUpgrades.
+func (r *Runner) updateNotice(w io.Writer) {
+	if !r.selfUpgrades() {
+		return
+	}
+	updatecheck.Fprint(w, engine.ExtractorVersion())
 }
 
 // Subcommands are the commands Dispatch handles. Exported so a binary's --help can be

--- a/pkg/command/dashboard.go
+++ b/pkg/command/dashboard.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/dashboard"
 	"github.com/enola-labs/enola/pkg/status"
@@ -89,7 +88,7 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	wd, _ := os.Getwd()
 	tracker.SetIdentity(status.Identity{
 		Binary:     r.name() + " dashboard",
-		Version:    version.Version,
+		Version:    r.buildVersion(),
 		ConfigPath: t.cfgPath,
 		WorkDir:    wd,
 	})
@@ -97,7 +96,13 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	defer tracker.Close()
 
 	port := dashboard.ResolveStablePort(t.engine.Config().Dashboard.Port)
-	dash, err := dashboard.Start(t.engine, dashboard.Options{Tracker: tracker, StablePort: port})
+	// The binary's own options — title, overlay panels, and the InsightLabels
+	// admission list that decides which explainers' findings the page will show at
+	// all. Tracker and StablePort are this command's to set, and are stamped over
+	// whatever the callback returned: they describe THIS process, not the binary.
+	opts := r.dashboardOptions(t.engine)
+	opts.Tracker, opts.StablePort = tracker, port
+	dash, err := dashboard.Start(t.engine, opts)
 	if err != nil {
 		r.dashboardFatal("starting dashboard: %v", err)
 	}

--- a/pkg/command/doctor.go
+++ b/pkg/command/doctor.go
@@ -13,7 +13,6 @@ import (
 	"github.com/enola-labs/enola/internal/hookstate"
 	"github.com/enola-labs/enola/internal/providers"
 	"github.com/enola-labs/enola/internal/updatecheck"
-	"github.com/enola-labs/enola/internal/version"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/check"
 )
@@ -71,7 +70,13 @@ func (r *Runner) Doctor(args []string) {
 	baselineIssue := r.baselineUsability(repoDir, outDir)
 
 	memLimit, memSource := bootstrap.MemoryLimit()
-	update := updatecheck.For(engine.ExtractorVersion())
+	// Zero — "nothing to say" — for a binary this manifest does not describe, so the
+	// --json contract carries the same silence the text output does rather than an
+	// answer to a question that was not asked. See Runner.selfUpgrades.
+	var update updatecheck.Notice
+	if r.selfUpgrades() {
+		update = updatecheck.For(engine.ExtractorVersion())
+	}
 
 	if *asJSON {
 		out := map[string]any{
@@ -96,7 +101,7 @@ func (r *Runner) Doctor(args []string) {
 	// at the top of every command's output, which is where it used to be.
 	fmt.Println("Runtime")
 	fmt.Printf("  %s\n", bootstrap.MemoryLimitLine())
-	fmt.Printf("  enola %s (extractors %s)\n", version.Version, engine.ExtractorVersion())
+	fmt.Printf("  %s %s (extractors %s)\n", r.name(), r.buildVersion(), engine.ExtractorVersion())
 	fmt.Println()
 
 	fmt.Println("Providers carried by this binary")
@@ -111,6 +116,12 @@ func (r *Runner) Doctor(args []string) {
 	// than leaving to be inferred from silence.
 	fmt.Println("Updates")
 	switch {
+	case !r.selfUpgrades():
+		// The manifest this check reads advertises enola releases. A wrapper ships
+		// on its own schedule with its own version numbers, so comparing the two
+		// would not report an upgrade — it would report the distance between two
+		// unrelated release streams. See Runner.selfUpgrades.
+		fmt.Printf("  not checked (%s ships through its own release path)\n", r.name())
 	case updatecheck.Suppressed():
 		fmt.Println("  not checked (disabled, or this is a dev build)")
 	case update.Available:

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -69,6 +69,10 @@ func (r *Runner) Install(args []string, remove bool) {
 		Hooks:       *hooks && !remove,
 		DryRun:      *dryRun,
 		HookCommand: hookBinary(),
+		// Empty for the OSS binary, so its output is unchanged; a wrapper names the
+		// tools only it serves. See Runner.WithInstructions.
+		ExtraInstructions: r.extraInstructions,
+		ExtraHooksNote:    r.extraHooksNote,
 	}
 	if *global {
 		opts.Scope = install.ScopeGlobal

--- a/pkg/command/wrapper_test.go
+++ b/pkg/command/wrapper_test.go
@@ -1,0 +1,140 @@
+package command
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/version"
+	"github.com/enola-labs/enola/pkg/bootstrap"
+	"github.com/enola-labs/enola/pkg/cli"
+	"github.com/enola-labs/enola/pkg/dashboard"
+)
+
+// ossRunner and wrapperRunner are the two binaries these commands serve: the OSS one,
+// which dispatches `upgrade` itself and is stamped through internal/version, and a
+// wrapper, which does neither.
+func ossRunner() *Runner {
+	return New(cli.Binary{Name: "enola", Version: version.Version}, "upgrade")
+}
+
+func wrapperRunner() *Runner {
+	return New(cli.Binary{Name: "enola-enterprise", Version: "1.4.2"}, "activate")
+}
+
+// A wrapper is stamped through its own -X target, so anything reading enola's
+// internal/version inside one reports "dev" forever. That is what made `doctor` print
+// "enola dev", the SARIF driver claim to be enola dev, and the standalone dashboard
+// register its instance as dev — three surfaces, one cause.
+func TestBuildVersion_IsTheBinarysOwnNotEnolas(t *testing.T) {
+	if got := wrapperRunner().buildVersion(); got != "1.4.2" {
+		t.Errorf("buildVersion() = %q, want the wrapper's own version", got)
+	}
+	// Unset stays enola's, which is what keeps cli.Binary.Version optional.
+	if got := New(cli.Binary{Name: "enola"}).buildVersion(); got != version.Version {
+		t.Errorf("buildVersion() = %q with no Version set, want enola's %q", got, version.Version)
+	}
+}
+
+// The update notice reads ENOLA's release manifest. In a binary that ships on another
+// release schedule it would not merely name a command that does not exist — it would
+// compare two unrelated version streams and advertise the difference as an upgrade.
+//
+// It is suppressed there today only because internal/version is never stamped in a
+// wrapper, so updatecheck.Suppressed sees "dev". That is an accident, and this test is
+// what stops it from being the only thing holding the line.
+func TestUpdateNotice_IsSilentInABinaryTheManifestDoesNotDescribe(t *testing.T) {
+	var buf bytes.Buffer
+	wrapperRunner().updateNotice(&buf)
+	if buf.Len() != 0 {
+		t.Errorf("a wrapper printed an enola update notice:\n%s", buf.String())
+	}
+	if wrapperRunner().selfUpgrades() {
+		t.Error("a binary that does not dispatch `upgrade` must not claim to self-upgrade")
+	}
+	if !ossRunner().selfUpgrades() {
+		t.Error("cmd/enola passes `upgrade` to New; the Runner must recognise it")
+	}
+}
+
+// `dashboard` starts a dashboard of its OWN, so a wrapper that passed its options only
+// to bootstrap's MCP server got the plain OSS page here. InsightLabels is the part that
+// matters: it is the page's admission list, so the wrapper's own explainers' findings
+// were computed and then filtered out of its own Insights modal.
+func TestDashboardOptions_ComeFromTheBinaryWhenItRegistersThem(t *testing.T) {
+	if got := ossRunner().dashboardOptions(nil); got.Title != "" || got.InsightLabels != nil {
+		t.Errorf("a binary that registers nothing must get the OSS defaults, got %+v", got)
+	}
+
+	r := wrapperRunner().WithDashboard(func(*bootstrap.Engine) dashboard.Options {
+		return dashboard.Options{
+			Title:         "enola enterprise",
+			InsightLabels: map[string]string{"dead-code": "Dead code"},
+		}
+	})
+	got := r.dashboardOptions(nil)
+	if got.Title != "enola enterprise" {
+		t.Errorf("Title = %q, want the wrapper's", got.Title)
+	}
+	if got.InsightLabels["dead-code"] == "" {
+		t.Error("the wrapper's explainers are not in the page's admission list, so its own findings would be filtered out")
+	}
+}
+
+// install.Options has carried ExtraInstructions/ExtraHooksNote since it was written, and
+// nothing reached them: `install` built its Options here and left both empty, so a
+// licensed binary wrote instruction files naming only the OSS tools.
+func TestInstructionSeam_ReachesTheInstallOptions(t *testing.T) {
+	r := wrapperRunner().WithInstructions("- `find_orphans` — unreferenced symbols.", "It also grades dead code.")
+	if !strings.Contains(r.extraInstructions, "find_orphans") {
+		t.Errorf("WithInstructions did not record the body: %q", r.extraInstructions)
+	}
+	if !strings.Contains(r.extraHooksNote, "dead code") {
+		t.Errorf("WithInstructions did not record the hooks note: %q", r.extraHooksNote)
+	}
+	if got := ossRunner(); got.extraInstructions != "" || got.extraHooksNote != "" {
+		t.Error("the OSS binary must add nothing, so its instruction files stay byte-identical")
+	}
+}
+
+// The link the seam actually needed: runInstall must copy the Runner's text into the
+// install.Options it builds. install.Options has carried those fields since it was
+// written and this is the line that had been missing, so a unit test on
+// WithInstructions alone would have passed while `install` still wrote OSS-only
+// instructions to disk.
+func TestInstall_WritesTheBinarysOwnInstructions(t *testing.T) {
+	repo := t.TempDir()
+	agents := filepath.Join(repo, "AGENTS.md")
+	if err := os.WriteFile(agents, []byte("# Agents\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const marker = "- `find_orphans` — symbols nothing references."
+	r := wrapperRunner().WithInstructions(marker, "")
+
+	// --yes: the confirmation prompt reads a terminal this test does not have.
+	// Output is discarded; what is being asserted is what landed on disk.
+	stdout := os.Stdout
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = devnull
+	r.Install([]string{"--yes", repo}, false)
+	os.Stdout = stdout
+	_ = devnull.Close()
+
+	got, err := os.ReadFile(agents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), marker) {
+		t.Errorf("AGENTS.md does not name this binary's tools:\n%s", got)
+	}
+	// The shared body must still be there — the wrapper adds, it does not replace.
+	if !strings.Contains(string(got), "impact_analysis") {
+		t.Errorf("the shared instruction body was lost:\n%s", got)
+	}
+}


### PR DESCRIPTION
pkg/command read internal/version, which only enola's own release stamps, so a wrapper binary reported "dev" in three places at once: doctor, the SARIF driver it uploads under, and its dashboard instance record. cli.Binary carries the version now.

Whether a binary can upgrade itself is derived from the subcommands it dispatches for itself rather than a new field — `upgrade` in that list already IS the question. It gates the update notice too: the manifest describes enola releases, so measuring another release stream against it would report the distance between two unrelated version series as an upgrade.

WithDashboard and WithInstructions are the two seams that had no way through: `dashboard` starts a dashboard of its own, and install.Options has carried ExtraInstructions since it was written with nothing setting it.

Verdict.Write now takes a check.Output; the zero Tool is still enola.