### PR TITLE
Give insight evidence a fact id, and fix two citations that named not…

### DIFF
--- a/docs/schema/insights.md
+++ b/docs/schema/insights.md
@@ -26,7 +26,27 @@ always an array: a repository with no findings produces `[]`, never `null`.
 | `fact` | string | when set | A fact's name, cited by kind-agnostic reference (modules and other non-symbol facts) |
 | `detail` | string | when set | One line explaining what this piece of evidence shows |
 | `line` / `end_line` / `column` / `end_column` | int | when the extractor measured a span | The position of the cited fact. Never derived from a name: a reader that prints a frame shows the line the extractor saw, or none |
+| `fact_id` | string, 32 hex chars | when the citation resolves | The `id` of the fact this entry cites — the same identity `facts.jsonl` carries. See [facts.md, Identity and ids](facts.md#identity-and-ids) |
 
 An evidence entry cites at most one of `symbol`/`fact`, plus an optional
-`file`. A consumer that links evidence to graph nodes matches by fact name
-within the snapshot, as with relation targets.
+`file`. Link it by `fact_id` where that is present; the name fields stay for
+readability.
+
+## When fact_id is absent
+
+Absent is a normal outcome and must not be read as a defect. Three ways it
+happens, and only the first is about resolution failing:
+
+- The name matches facts of more than one identity, so there is no honest single
+  answer. Rare: one entry in 872 in a measured corpus.
+- The entry cites something the snapshot does not contain — a third-party symbol
+  the repository calls but does not declare. Same condition as a relation whose
+  `target` names a standard-library function.
+- **The finding is ABOUT the absence.** A finding that a route names a handler
+  which is not defined here cites a name no fact carries, on purpose. Its
+  evidence resolving to nothing is the finding being true, and a consumer that
+  treats a missing `fact_id` as a parse failure would discard exactly the
+  findings that matter most.
+
+Measured on a 20,808-fact snapshot: of 872 evidence entries, 88.5% carry a
+`fact_id`.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1407,7 +1407,7 @@ func (e *Engine) WriteArtifacts(repoPath string) error {
 	if insights == nil {
 		insights = []facts.Insight{}
 	}
-	insightsJSON, err := json.MarshalIndent(insights, "", "  ")
+	insightsJSON, err := b.store.MarshalInsights(insights)
 	if err != nil {
 		return fmt.Errorf("marshaling insights: %w", err)
 	}
@@ -1541,7 +1541,16 @@ func (e *Engine) GetArtifact(name string) ([]byte, error) {
 		}
 		return buf.Bytes(), nil
 	case "insights.json":
-		return json.MarshalIndent(b.snapshot.Insights, "", "  ")
+		// The same nil guard WriteArtifacts applies. Without it this path served
+		// `null` where the file said `[]`, so a repository with no findings
+		// handed the MCP server and the dashboard a document that breaks any
+		// consumer iterating the parsed value — and handed it a DIFFERENT
+		// document from the one on disk.
+		insights := b.snapshot.Insights
+		if insights == nil {
+			insights = []facts.Insight{}
+		}
+		return b.store.MarshalInsights(insights)
 	case "snapshot.meta.json":
 		return json.MarshalIndent(b.snapshot.Meta, "", "  ")
 	case "receipt.json":

--- a/internal/engine/insights_artifact_test.go
+++ b/internal/engine/insights_artifact_test.go
@@ -5,55 +5,65 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/enola-labs/enola/internal/config"
+	"github.com/enola-labs/enola/internal/extractors/goextractor"
+	"github.com/enola-labs/enola/internal/facts"
 )
 
-// insightsAfterSnapshot generates a snapshot of repo, writes the artifacts, and
-// returns the exact bytes of insights.json plus the hash the receipt recorded for it.
-func insightsAfterSnapshot(t *testing.T, e *Engine, repo, outDir string) (string, string) {
-	t.Helper()
+// insights.json is written twice: WriteArtifacts puts it on disk, and
+// GetArtifact serves the same document to the MCP server and the dashboard.
+// They marshal through the same store call so a consumer cannot be handed two
+// different documents — and, before fact ids existed, they did not: GetArtifact
+// skipped WriteArtifacts' nil guard. These tests hold the two together and
+// check that a citation reaching the file resolves to a fact that is in it.
+func TestInsightsArtifact_BothPathsAgree(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "go.mod", "module example.com/ins\n\ngo 1.25\n")
+	// A cycle, so at least one explainer has something to cite.
+	writeRepoFile(t, repo, "a/a.go", "package a\n\nimport \"example.com/ins/b\"\n\nfunc A() { b.B() }\n")
+	writeRepoFile(t, repo, "b/b.go", "package b\n\nimport \"example.com/ins/a\"\n\nfunc B() { a.A() }\n")
+
+	cfg := config.Default()
+	cfg.Repo = repo
+
+	e, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The engine registers no extractors of its own; the CLI bootstrap does.
+	e.RegisterExtractor(goextractor.New())
 	if _, err := e.GenerateSnapshot(context.Background(), repo, false); err != nil {
 		t.Fatalf("GenerateSnapshot: %v", err)
 	}
 	if err := e.WriteArtifacts(repo); err != nil {
 		t.Fatalf("WriteArtifacts: %v", err)
 	}
-	raw, err := os.ReadFile(filepath.Join(repo, outDir, "insights.json"))
-	if err != nil {
-		t.Fatalf("reading insights.json: %v", err)
-	}
 
-	metaRaw, err := os.ReadFile(filepath.Join(repo, outDir, "snapshot.meta.json"))
+	onDisk, err := os.ReadFile(filepath.Join(repo, cfg.Output.Dir, "insights.json"))
 	if err != nil {
-		t.Fatalf("reading snapshot.meta.json: %v", err)
-	}
-	var meta struct {
-		OutputHashes map[string]string `json:"output_hashes"`
-	}
-	if err := json.Unmarshal(metaRaw, &meta); err != nil {
 		t.Fatal(err)
 	}
-	return string(raw), meta.OutputHashes["insights.json"]
+	served, err := e.GetArtifact("insights.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != string(served) {
+		t.Errorf("insights.json on disk and from GetArtifact differ:\n disk %d bytes\nserved %d bytes",
+			len(onDisk), len(served))
+	}
 }
 
-// The receipt records output_hashes["insights.json"], so the file has to be
-// byte-reproducible or comparing two runs — on one machine or across two — fails for
-// a reason that has nothing to do with the code being analysed.
-//
-// The unit-level guarantee lives in explainers/common (MeanStdDev is a function of
-// the multiset) and in godclass. This asserts the property a consumer actually sees:
-// the same tree, twice, produces the same file.
-func TestWriteArtifacts_InsightsAreByteReproducible(t *testing.T) {
+// TestInsightsArtifact_FactIDsNameFactsInTheSnapshot — an id that names nothing
+// is worse than no id: it invites a consumer to link an edge to a node that does
+// not exist. Every fact_id written must appear as an id in facts.jsonl.
+func TestInsightsArtifact_FactIDsNameFactsInTheSnapshot(t *testing.T) {
 	repo := t.TempDir()
-	writeRepoFile(t, repo, "go.mod", "module example.com/rep\n\ngo 1.25\n")
-	writeRepoFile(t, repo, "core/hub.go", "package core\n\nfunc Hub() string { return \"hub\" }\n")
-	for i := range 12 {
-		writeRepoFile(t, repo, filepath.Join("callers", "c"+string(rune('a'+i))+".go"),
-			"package callers\n\nimport \"example.com/rep/core\"\n\nfunc C"+string(rune('A'+i))+
-				"() string { return core.Hub() }\n")
-	}
+	writeRepoFile(t, repo, "go.mod", "module example.com/ins2\n\ngo 1.25\n")
+	writeRepoFile(t, repo, "a/a.go", "package a\n\nimport \"example.com/ins2/b\"\n\nfunc A() { b.B() }\n")
+	writeRepoFile(t, repo, "b/b.go", "package b\n\nimport \"example.com/ins2/a\"\n\nfunc B() { a.A() }\n")
 
 	cfg := config.Default()
 	cfg.Repo = repo
@@ -61,41 +71,82 @@ func TestWriteArtifacts_InsightsAreByteReproducible(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	first, firstHash := insightsAfterSnapshot(t, e, repo, cfg.Output.Dir)
-	second, secondHash := insightsAfterSnapshot(t, e, repo, cfg.Output.Dir)
-
-	if first != second {
-		t.Errorf("insights.json differs between two runs of an unchanged tree:\n--- first\n%s\n--- second\n%s",
-			first, second)
+	// The engine registers no extractors of its own; the CLI bootstrap does.
+	e.RegisterExtractor(goextractor.New())
+	snap, err := e.GenerateSnapshot(context.Background(), repo, false)
+	if err != nil {
+		t.Fatalf("GenerateSnapshot: %v", err)
 	}
-	if firstHash != secondHash {
-		t.Errorf("output_hashes[insights.json] = %q then %q — the receipt is not reproducible",
-			firstHash, secondHash)
+	// Findings are injected rather than waited for: which explainer fires on a
+	// three-file fixture is not this test's subject, and a fixture that stops
+	// producing one would turn this into a test that passes by measuring nothing.
+	// The citations name facts the snapshot definitely has.
+	withEvidence := *snap
+	withEvidence.Insights = []facts.Insight{{
+		Title: "injected", Source: "test", Description: "d", Confidence: 1,
+		Evidence: []facts.Evidence{
+			{Symbol: "a.A", Detail: "a symbol the fixture declares"},
+			{Fact: "a", Detail: "a module the fixture declares"},
+			{Symbol: "NoSuchThing", Detail: "names nothing: must get no id"},
+		},
+	}}
+	e.SetSnapshot(&withEvidence)
+	if err := e.WriteArtifacts(repo); err != nil {
+		t.Fatalf("WriteArtifacts: %v", err)
 	}
-}
 
-// A repository with no findings must still write a JSON array. A nil slice marshals
-// to `null`, which breaks any consumer that iterates the parsed value without a nil
-// check — on exactly the repositories nobody thinks to test against.
-func TestWriteArtifacts_EmptyInsightsAreAnArrayNotNull(t *testing.T) {
-	repo := t.TempDir()
-	writeRepoFile(t, repo, "go.mod", "module example.com/quiet\n\ngo 1.25\n")
-	writeRepoFile(t, repo, "a/a.go", "package a\n\nfunc A() string { return \"a\" }\n")
-
-	cfg := config.Default()
-	cfg.Repo = repo
-	e, err := New(cfg)
+	factsRaw, err := os.ReadFile(filepath.Join(repo, cfg.Output.Dir, "facts.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	ids := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(string(factsRaw)), "\n") {
+		var f struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(line), &f); err != nil {
+			t.Fatal(err)
+		}
+		ids[f.ID] = true
+	}
 
-	raw, _ := insightsAfterSnapshot(t, e, repo, cfg.Output.Dir)
-	if raw == "null" {
-		t.Fatal("insights.json is `null` for a repository with no findings, not `[]`")
+	insightsRaw, err := os.ReadFile(filepath.Join(repo, cfg.Output.Dir, "insights.json"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	var parsed []any
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		t.Fatalf("insights.json does not parse as an array: %v\n%s", err, raw)
+	var insights []struct {
+		Source   string `json:"source"`
+		Evidence []struct {
+			Symbol string `json:"symbol"`
+			Fact   string `json:"fact"`
+			FactID string `json:"fact_id"`
+		} `json:"evidence"`
 	}
+	if err := json.Unmarshal(insightsRaw, &insights); err != nil {
+		t.Fatal(err)
+	}
+
+	cited, resolved := 0, 0
+	for _, in := range insights {
+		for _, e := range in.Evidence {
+			if e.Symbol == "" && e.Fact == "" {
+				continue
+			}
+			cited++
+			if e.FactID == "" {
+				continue
+			}
+			resolved++
+			if !ids[e.FactID] {
+				t.Errorf("%s cites fact_id %q, which is not an id in facts.jsonl", in.Source, e.FactID)
+			}
+		}
+	}
+	if cited == 0 {
+		t.Fatal("no evidence cited a symbol or fact: the fixture stopped exercising this")
+	}
+	if resolved == 0 {
+		t.Errorf("%d citations and not one resolved; ids are not reaching insights.json", cited)
+	}
+	t.Logf("%d citations, %d resolved to a fact in the snapshot", cited, resolved)
 }

--- a/internal/engine/testdata/golden/ts_layers_sample.insights.json
+++ b/internal/engine/testdata/golden/ts_layers_sample.insights.json
@@ -45,6 +45,7 @@
       },
       {
         "fact": "src/lib -\u003e src/components/sites/chabad-website",
+        "file": "src/lib/site-blocks.ts",
         "detail": "import edge"
       },
       {

--- a/internal/explainers/domain/domain.go
+++ b/internal/explainers/domain/domain.go
@@ -350,6 +350,37 @@ func namespacesOf(models []string) map[string]bool {
 	return out
 }
 
+// outboundEvidence cites the route fact behind each endpoint label.
+//
+// It does not use evidenceFor, and that is the whole point. evidenceFor puts the
+// string it is given in Evidence.Fact, which means "a fact's name" — and these
+// strings are display labels with the HTTP method glued on the front, so every
+// one of them named a fact that does not exist. Measured on one repository, 46
+// of its evidence entries pointed at nothing. The label still drives the count
+// and the prose; only the citation changes, and the method it carried moves into
+// the detail so a reader does not lose it.
+//
+// The route's file and line ride along, which evidenceFor could never supply:
+// these findings previously gave a reader no way to reach the call site.
+func outboundEvidence(labels []string, byLabel map[string]facts.Fact) []facts.Evidence {
+	if len(labels) > maxEvidence {
+		labels = labels[:maxEvidence]
+	}
+	out := make([]facts.Evidence, 0, len(labels))
+	for _, label := range labels {
+		fact, ok := byLabel[label]
+		if !ok {
+			continue
+		}
+		detail := "called from here"
+		if method, _ := fact.Props["method"].(string); method != "" {
+			detail = method + " " + detail
+		}
+		out = append(out, facts.Evidence{Fact: fact.Name, File: fact.File, Line: fact.Line, Detail: detail})
+	}
+	return out
+}
+
 func evidenceFor(items []string, detail string) []facts.Evidence {
 	if len(items) > maxEvidence {
 		items = items[:maxEvidence]
@@ -421,7 +452,12 @@ func stdDev(xs []float64) float64 {
 func outboundIntegrations(store *facts.Store) []facts.Insight {
 	type integration struct {
 		endpoints []string
-		hints     map[string]bool
+		// byLabel keeps the ROUTE FACT behind each display label. The label
+		// ("DELETE /v1/datasets/{}") is what the finding counts and prints; the
+		// fact is what its evidence has to cite, because evidence names a fact
+		// and no fact is called "DELETE /v1/datasets/{}".
+		byLabel map[string]facts.Fact
+		hints   map[string]bool
 	}
 	byComponent := map[string]*integration{}
 
@@ -460,10 +496,14 @@ func outboundIntegrations(store *facts.Store) []facts.Insight {
 		}
 		entry := byComponent[component]
 		if entry == nil {
-			entry = &integration{hints: map[string]bool{}}
+			entry = &integration{byLabel: map[string]facts.Fact{}, hints: map[string]bool{}}
 			byComponent[component] = entry
 		}
-		entry.endpoints = append(entry.endpoints, strings.TrimSpace(method+" "+fact.Name))
+		label := strings.TrimSpace(method + " " + fact.Name)
+		entry.endpoints = append(entry.endpoints, label)
+		if _, seen := entry.byLabel[label]; !seen {
+			entry.byLabel[label] = fact
+		}
 		if hint, _ := props["target_hint"].(string); hint != "" {
 			entry.hints[hint] = true
 		}
@@ -503,7 +543,7 @@ func outboundIntegrations(store *facts.Store) []facts.Insight {
 					"when the other side changes, and it is not visible from this repository's own routes.",
 				component, len(endpoints), named),
 			Confidence: 0.9,
-			Evidence:   evidenceFor(endpoints, "called from here"),
+			Evidence:   outboundEvidence(endpoints, entry.byLabel),
 		})
 	}
 	return out

--- a/internal/explainers/domain/outbound_test.go
+++ b/internal/explainers/domain/outbound_test.go
@@ -1,0 +1,107 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// The outbound-integrations finding used to cite its endpoints by DISPLAY LABEL
+// — the HTTP method glued onto the route path — in Evidence.Fact, a field that
+// means "a fact's name". No fact carries such a name, so every one of those
+// citations pointed at nothing: 46 entries on one measured repository, silently,
+// because nothing checked that a cited name exists.
+func TestOutboundIntegrations_CitesFactsThatExist(t *testing.T) {
+	store := facts.NewStore()
+	// Two client calls from one component, which is minOutboundCalls.
+	store.Add(
+		facts.Fact{
+			Kind: facts.KindRoute, Name: "/v1/datasets/{}", File: "app/client.py", Line: 12,
+			Props: map[string]any{"role": "client", "method": "DELETE"},
+		},
+		facts.Fact{
+			Kind: facts.KindRoute, Name: "/v1/datasets", File: "app/client.py", Line: 20,
+			Props: map[string]any{"role": "client", "method": "GET"},
+		},
+	)
+
+	insights := outboundIntegrations(store)
+	if len(insights) == 0 {
+		t.Fatal("no outbound finding: the fixture no longer exercises this")
+	}
+
+	names := map[string]bool{}
+	for _, f := range store.FactsRef() {
+		names[f.Name] = true
+	}
+
+	cited := 0
+	for _, in := range insights {
+		for _, e := range in.Evidence {
+			if e.Fact == "" {
+				continue
+			}
+			cited++
+			if !names[e.Fact] {
+				t.Errorf("evidence cites %q, which names no fact in the snapshot", e.Fact)
+			}
+			if e.File == "" {
+				t.Errorf("evidence for %q carries no file, so a reader cannot reach the call site", e.Fact)
+			}
+		}
+	}
+	if cited == 0 {
+		t.Error("the finding cited no fact at all")
+	}
+}
+
+// The method used to live in the cited name. It has to survive somewhere, or the
+// finding stops telling a reader which verb the call used.
+func TestOutboundIntegrations_KeepsTheMethodInTheDetail(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{
+			Kind: facts.KindRoute, Name: "/v1/datasets/{}", File: "app/client.py",
+			Props: map[string]any{"role": "client", "method": "DELETE"},
+		},
+		facts.Fact{
+			Kind: facts.KindRoute, Name: "/v1/datasets", File: "app/client.py",
+			Props: map[string]any{"role": "client", "method": "GET"},
+		},
+	)
+
+	var details []string
+	for _, in := range outboundIntegrations(store) {
+		for _, e := range in.Evidence {
+			details = append(details, e.Detail)
+		}
+	}
+	want := map[string]bool{"DELETE called from here": true, "GET called from here": true}
+	for _, d := range details {
+		delete(want, d)
+	}
+	if len(want) > 0 {
+		t.Errorf("these details never appeared: %v (got %v)", want, details)
+	}
+}
+
+// A route this repository also SERVES is not an outbound integration, and the
+// fix must not have disturbed that check.
+func TestOutboundIntegrations_SkipsRoutesServedHere(t *testing.T) {
+	store := facts.NewStore()
+	store.Add(
+		facts.Fact{Kind: facts.KindRoute, Name: "/local", File: "app/client.py",
+			Props: map[string]any{"role": "client", "method": "GET"}},
+		facts.Fact{Kind: facts.KindRoute, Name: "/local", File: "app/server.py",
+			Props: map[string]any{"role": "server", "method": "GET"}},
+		facts.Fact{Kind: facts.KindRoute, Name: "/remote", File: "app/client.py",
+			Props: map[string]any{"role": "client", "method": "GET"}},
+	)
+	for _, in := range outboundIntegrations(store) {
+		for _, e := range in.Evidence {
+			if e.Fact == "/local" {
+				t.Error("a route served by this repository was reported as an outbound integration")
+			}
+		}
+	}
+}

--- a/internal/explainers/layers/layers.go
+++ b/internal/explainers/layers/layers.go
@@ -1418,17 +1418,26 @@ func (e *LayerExplainer) detectViolations(scoped []facts.Fact, pattern *archPatt
 			{File: v.file, Detail: fmt.Sprintf("import of %s", v.targetModule)},
 		}
 		seenEntity := make(map[string]bool, 4)
-		addEntity := func(name, detail string) {
+		addEntity := func(name, file, detail string) {
 			if name == "" || seenEntity[name] {
 				return
 			}
 			seenEntity[name] = true
-			evidence = append(evidence, facts.Evidence{Fact: name, Detail: detail})
+			evidence = append(evidence, facts.Evidence{Fact: name, File: file, Detail: detail})
 		}
-		addEntity(v.depName, "import edge")
-		addEntity(v.rawTarget, "import edge target")
-		addEntity(v.sourceModule, "importing module")
-		addEntity(v.targetModule, "imported module")
+		// Only the dependency fact is known to live in v.file: it IS that import
+		// statement, so the file is its own. The other three name things declared
+		// elsewhere, and stamping the importing file on them would send a reader
+		// to the wrong place.
+		//
+		// It matters beyond the reader. One module can import the same target from
+		// several files, so the dependency NAME alone can belong to more than one
+		// fact — 459 such names in one measured repository — and a citation that
+		// carries no file leaves a consumer unable to tell which one is meant.
+		addEntity(v.depName, v.file, "import edge")
+		addEntity(v.rawTarget, "", "import edge target")
+		addEntity(v.sourceModule, "", "importing module")
+		addEntity(v.targetModule, "", "imported module")
 
 		insights = append(insights, facts.Insight{
 			// The taxonomy is named because a polyglot repository now gets one

--- a/internal/explainers/layers/violation_evidence_test.go
+++ b/internal/explainers/layers/violation_evidence_test.go
@@ -1,0 +1,71 @@
+package layers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/enola-labs/enola/internal/facts"
+)
+
+// A layer violation cites four entities: the import edge, its raw target, and
+// the two modules. Only the first of them lives in the file the violation was
+// found in, and only it may carry that file.
+//
+// It carried none, which cost twice. A reader got a name with no location. And a
+// consumer could not tell WHICH import edge was meant: one module importing the
+// same target from several files produces several dependency facts under one
+// name — 459 such names in one measured repository — so the citation resolved to
+// a set rather than to a fact, and was dropped.
+func TestLayerViolation_CitesTheImportEdgeWithItsFile(t *testing.T) {
+	const importFile = "svc/app/domain/thing.go"
+	store := facts.NewStore()
+	store.Add(
+		layerIntent("svc", "handlers", 0, "app/handlers/**"),
+		layerIntent("svc", "domain", 1, "app/domain/**"),
+		facts.Fact{Kind: facts.KindModule, Repo: "svc", Name: "svc/app/handlers"},
+		facts.Fact{Kind: facts.KindModule, Repo: "svc", Name: "svc/app/domain"},
+		facts.Fact{Kind: facts.KindDependency, Repo: "svc", Name: "domain-imports-handlers",
+			File:      importFile,
+			Relations: []facts.Relation{{Kind: facts.RelImports, Target: "svc/app/handlers"}}},
+	)
+
+	insights, err := New().Explain(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var violation *facts.Insight
+	for i := range insights {
+		if strings.Contains(strings.ToLower(insights[i].Title), "violation") {
+			violation = &insights[i]
+		}
+	}
+	if violation == nil {
+		t.Fatal("no layer violation reported: the fixture stopped exercising this")
+	}
+
+	byName := map[string]facts.Evidence{}
+	for _, e := range violation.Evidence {
+		if e.Fact != "" {
+			byName[e.Fact] = e
+		}
+	}
+
+	edge, ok := byName["domain-imports-handlers"]
+	if !ok {
+		t.Fatal("the violation does not cite the import edge at all")
+	}
+	if edge.File != importFile {
+		t.Errorf("the import edge is cited with file %q, want %q", edge.File, importFile)
+	}
+
+	// The other three are declared elsewhere. Claiming they live in the importing
+	// file would point a reader at the wrong place, and would make the citation
+	// resolve to the wrong fact or to none.
+	for _, name := range []string{"svc/app/handlers", "svc/app/domain"} {
+		if e, ok := byName[name]; ok && e.File == importFile {
+			t.Errorf("%q is cited with the importing file %q; it is declared elsewhere", name, importFile)
+		}
+	}
+}

--- a/internal/facts/id_test.go
+++ b/internal/facts/id_test.go
@@ -219,3 +219,89 @@ func TestWriteJSONL_IDsSurviveShuffling(t *testing.T) {
 		t.Error("reversing the insertion order changed the serialized ids")
 	}
 }
+
+// TestMarshalInsights_ResolvesEvidence covers each outcome an evidence citation
+// can have, including the two that must NOT be treated as failures.
+func TestMarshalInsights_ResolvesEvidence(t *testing.T) {
+	s := NewStore()
+	s.Add(
+		Fact{Kind: KindModule, Name: "app", File: "app", Repo: "r"},
+		Fact{Kind: KindSymbol, Name: "app.Run", File: "app/main.go", Repo: "r"},
+		// Same name in two files: no honest single answer.
+		Fact{Kind: KindSymbol, Name: "Split", File: "a.go", Repo: "r"},
+		Fact{Kind: KindSymbol, Name: "Split", File: "b.go", Repo: "r"},
+	)
+	want := s.FactsRef()[1].Identity()
+
+	out, err := s.MarshalInsights([]Insight{{
+		Title: "t", Description: "d", Confidence: 1,
+		Evidence: []Evidence{
+			{Symbol: "app.Run", Detail: "cited by symbol"},
+			{Fact: "app", Detail: "cited by fact"},
+			{Symbol: "NoResultFound", Detail: "third-party: nothing to point at"},
+			{Symbol: "Split", Detail: "ambiguous"},
+			{File: "app/main.go", Detail: "file only, cites no fact"},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	ev := got[0]["evidence"].([]any)
+	ids := make([]string, len(ev))
+	for i, e := range ev {
+		id, _ := e.(map[string]any)["fact_id"].(string)
+		ids[i] = id
+	}
+	if ids[0] != want {
+		t.Errorf("symbol citation got fact_id %q, want %q", ids[0], want)
+	}
+	if ids[1] == "" {
+		t.Error("a citation by fact name got no fact_id")
+	}
+	for i, why := range map[int]string{2: "third-party name", 3: "ambiguous name", 4: "no citation at all"} {
+		if ids[i] != "" {
+			t.Errorf("evidence %d (%s) got fact_id %q, want none", i, why, ids[i])
+		}
+	}
+}
+
+// TestMarshalInsights_LeavesTheDocumentAlone — adding ids must change nothing
+// else about insights.json, including the shapes that marshal as null. Callers
+// promised those before this existed.
+func TestMarshalInsights_LeavesTheDocumentAlone(t *testing.T) {
+	s := NewStore()
+	s.Add(Fact{Kind: KindModule, Name: "app", File: "app", Repo: "r"})
+
+	for _, tc := range []struct {
+		name string
+		in   []Insight
+		want string
+	}{
+		{"nil slice", nil, "null"},
+		{"empty slice", []Insight{}, "[]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := s.MarshalInsights(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != tc.want {
+				t.Errorf("marshalled %q, want %q", out, tc.want)
+			}
+		})
+	}
+
+	// Nil evidence stays null rather than becoming []: the same document as before.
+	out, err := s.MarshalInsights([]Insight{{Title: "t", Description: "d", Confidence: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), `"evidence": null`) {
+		t.Errorf("nil evidence did not stay null:\n%s", out)
+	}
+}

--- a/internal/facts/wire.go
+++ b/internal/facts/wire.go
@@ -1,5 +1,7 @@
 package facts
 
+import "encoding/json"
+
 // The wire shape of facts.jsonl.
 //
 // It differs from Fact and Relation by exactly the two id fields, and it exists
@@ -78,6 +80,141 @@ func (s *Store) targetFactFor(target, fromRepo string) int {
 	if pick == -1 {
 		// No fact in this repository carries the name, so the reference points
 		// outward: consider the whole snapshot, under the same all-or-nothing rule.
+		pick = idx[0]
+		for _, i := range idx[1:] {
+			if !sameIdentity(s.facts[pick], s.facts[i]) {
+				return -1
+			}
+		}
+	}
+
+	return pick
+}
+
+// The wire shape of insights.json.
+//
+// Evidence cites a fact by NAME, so a consumer linking a finding to the code it
+// is about re-runs the same name matching relations needed, and drops what it
+// cannot resolve. fact_id answers it directly, from the same identity the facts
+// carry.
+
+// wireEvidence is an Evidence plus the identity of the fact it cites, when that
+// citation resolves to exactly one.
+//
+// Absent is not a defect and must not be read as one. Some findings cite names
+// that are SUPPOSED to be missing — "this route names a handler that is not
+// defined here" is a finding about absence, and its evidence resolving to
+// nothing is the finding being true. Others cite third-party symbols the
+// repository calls but does not contain.
+type wireEvidence struct {
+	Evidence
+	FactID string `json:"fact_id,omitempty"`
+}
+
+// wireInsight restates Insight's fields instead of embedding it, which is the
+// one place this file does not mirror its model type.
+//
+// encoding/json orders an embedded struct's promoted fields before the outer
+// struct's own, so shadowing `evidence` the way wireFact shadows `relations`
+// would move it from the middle of the object to the end. That is invisible to a
+// parser and expensive to a reader: it rewrites every line of every insights
+// golden, which is exactly the diff a change to a finding needs to be legible
+// in. TestWireFormat_WireInsightFields pins the two shapes against each other so
+// restating them cannot drift.
+type wireInsight struct {
+	Title         string         `json:"title"`
+	Source        string         `json:"source,omitempty"`
+	Description   string         `json:"description"`
+	Confidence    float64        `json:"confidence"`
+	Evidence      []wireEvidence `json:"evidence"`
+	Actions       []string       `json:"suggested_actions,omitempty"`
+	Informational bool           `json:"informational,omitempty"`
+	Metrics       map[string]any `json:"metrics,omitempty"`
+}
+
+// MarshalInsights renders insights as the bytes of insights.json, resolving each
+// evidence entry's citation to the id of the fact it names.
+//
+// It marshals the slice it is given rather than normalising it: a nil slice
+// still renders as `null`, so the callers keep whatever they promised before
+// this existed, and adding ids cannot change anything else about the document.
+func (s *Store) MarshalInsights(insights []Insight) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []wireInsight
+	if insights != nil {
+		out = make([]wireInsight, 0, len(insights))
+	}
+	var scratch []byte
+	for _, in := range insights {
+		var ev []wireEvidence
+		if in.Evidence != nil {
+			ev = make([]wireEvidence, 0, len(in.Evidence))
+			for _, e := range in.Evidence {
+				we := wireEvidence{Evidence: e}
+				if i := s.evidenceFactFor(e); i >= 0 {
+					f := s.facts[i]
+					we.FactID, scratch = factIDInto(scratch, f.Repo, f.Kind, f.Name, f.File)
+				}
+				ev = append(ev, we)
+			}
+		}
+		out = append(out, wireInsight{
+			Title:         in.Title,
+			Source:        in.Source,
+			Description:   in.Description,
+			Confidence:    in.Confidence,
+			Evidence:      ev,
+			Actions:       in.Actions,
+			Informational: in.Informational,
+			Metrics:       in.Metrics,
+		})
+	}
+	return json.MarshalIndent(out, "", "  ")
+}
+
+// evidenceFactFor resolves the fact an evidence entry cites to its index, or -1
+// when the citation does not resolve to exactly one identity.
+//
+// An entry cites at most one of Symbol or Fact; both are fact names, and the
+// kinds they conventionally name differ, not the lookup. Where the entry also
+// names a file, that narrows the candidates — but only when some candidate
+// agrees, since a finding may render a path differently from the fact it cites.
+// In a measured corpus the file was set on 60 of 772 resolvable entries and
+// agreed every time, so it is a tiebreaker rather than the mechanism.
+//
+// The caller must hold s.mu.
+func (s *Store) evidenceFactFor(e Evidence) int {
+	ref := e.Symbol
+	if ref == "" {
+		ref = e.Fact
+	}
+	if ref == "" {
+		return -1
+	}
+	idx := s.byName[ref]
+	if len(idx) == 0 {
+		return -1
+	}
+
+	pick := -1
+	if e.File != "" {
+		for _, i := range idx {
+			if s.facts[i].File != e.File {
+				continue
+			}
+			if pick == -1 {
+				pick = i
+				continue
+			}
+			if !sameIdentity(s.facts[pick], s.facts[i]) {
+				return -1
+			}
+		}
+	}
+
+	if pick == -1 {
 		pick = idx[0]
 		for _, i := range idx[1:] {
 			if !sameIdentity(s.facts[pick], s.facts[i]) {

--- a/internal/facts/wireformat_test.go
+++ b/internal/facts/wireformat_test.go
@@ -1,6 +1,7 @@
 package facts
 
 import (
+	"bytes"
 	"encoding/json"
 	"go/ast"
 	"go/parser"
@@ -409,4 +410,87 @@ func TestWireFormat_WireRelationFields(t *testing.T) {
 
 	assertKeys(t, wireRelation{Relation: Relation{Kind: RelCalls, Target: "foo"}},
 		[]string{"kind", "target"})
+}
+
+// TestWireFormat_WireInsightFields pins the insights.json shape, the same way
+// TestWireFormat_WireFactFields pins facts.jsonl: the model's keys plus exactly
+// the one id field.
+func TestWireFormat_WireInsightFields(t *testing.T) {
+	full := wireInsight{
+		Title: "Dependency cycle", Source: "cycles", Description: "a -> b -> a",
+		Confidence: 1.0, Evidence: []wireEvidence{{}}, Actions: []string{"break it"},
+		Informational: true, Metrics: map[string]any{"modules": 2},
+	}
+	assertKeys(t, full, []string{
+		"title", "source", "description", "confidence", "evidence",
+		"suggested_actions", "informational", "metrics",
+	})
+
+	assertKeys(t, wireInsight{Title: "t", Description: "d", Confidence: 1.0, Evidence: []wireEvidence{}},
+		[]string{"title", "description", "confidence", "evidence"})
+}
+
+// TestWireFormat_WireEvidenceFields pins the evidence shape. fact_id is
+// omitempty: a citation that resolves to nothing is a normal and sometimes
+// correct outcome — a finding about a handler that is not defined here cites a
+// name no fact carries, and that absence IS the finding.
+func TestWireFormat_WireEvidenceFields(t *testing.T) {
+	assertKeys(t, wireEvidence{
+		Evidence: Evidence{File: "a.go", Symbol: "A", Fact: "mod/a", Detail: "d",
+			Line: 1, EndLine: 2, Column: 3, EndColumn: 4},
+		FactID: "0123456789abcdef0123456789abcdef",
+	}, []string{"file", "symbol", "fact", "detail", "line", "end_line", "column", "end_column", "fact_id"})
+
+	assertKeys(t, wireEvidence{Evidence: Evidence{File: "a.go"}}, []string{"file"})
+}
+
+// TestWireFormat_InsightKeyOrderIsUnchanged is why wireInsight restates its
+// fields instead of embedding Insight.
+//
+// encoding/json emits an embedded struct's promoted fields before the outer
+// struct's own, so shadowing `evidence` would silently move it from the middle
+// of every insight object to the end — rewriting every line of every insights
+// golden and burying the one changed finding a reviewer is trying to see. This
+// fails if anyone converts wireInsight to the embedded form.
+func TestWireFormat_InsightKeyOrderIsUnchanged(t *testing.T) {
+	model := Insight{
+		Title: "t", Source: "s", Description: "d", Confidence: 1.0,
+		Evidence: []Evidence{{}}, Actions: []string{"a"},
+		Informational: true, Metrics: map[string]any{"n": 1},
+	}
+	wire := wireInsight{
+		Title: "t", Source: "s", Description: "d", Confidence: 1.0,
+		Evidence: []wireEvidence{{}}, Actions: []string{"a"},
+		Informational: true, Metrics: map[string]any{"n": 1},
+	}
+	got, want := keyOrder(t, wire), keyOrder(t, model)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("insights.json key order changed\n got %v\nwant %v", got, want)
+	}
+}
+
+// keyOrder returns v's top-level JSON keys in the order they are emitted.
+func keyOrder(t *testing.T, v any) []string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshaling %T: %v", v, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if _, err := dec.Token(); err != nil { // opening brace
+		t.Fatalf("reading %T: %v", v, err)
+	}
+	var keys []string
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("reading %T: %v", v, err)
+		}
+		keys = append(keys, tok.(string))
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			t.Fatalf("reading %T: %v", v, err)
+		}
+	}
+	return keys
 }


### PR DESCRIPTION
…hing

A citation that resolves to nothing is not a failure, so fact_id is omitted rather than forced: some findings are ABOUT absence — a route naming a handler that is not defined here cites a name no fact carries, and that is the finding being true. Ids are computed when insights.json is written and never stored on an Evidence, so no explainer can come to depend on them.

Two findings cited names nothing carried. The outbound-integrations finding cited a display label with the HTTP method glued onto the path; a layer violation cited its import edge without the file it came from, so it could not be told from the same import in another file. Both now cite the fact, with its location. Also fixes the served insights.json emitting null where the written one emitted [].