### PR TITLE
Improve dashboard snapshot loading, findings, and dependency graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ A report, not a gate - it always exits `0`. It is the fastest way to find out th
 enola dashboard --open
 ```
 
-It stays attached to the terminal until you press Ctrl-C and follows newer snapshots written for that repository. The opening screen prioritizes findings and architectural changes; lifetime usage has its own screen, while ports, processes, and paths live under Diagnostics. If no snapshot exists yet, the dashboard shows the exact generation command and updates when it appears. Repository data never leaves your machine. See the **[dashboard user guide](docs/DASHBOARD.md)** for a walkthrough of every tab.
+It stays attached to the terminal until you press Ctrl-C. Use **Refresh** when you want to load a newer snapshot written for that repository, so the graph does not change while you inspect it. The opening screen prioritizes findings and architectural changes; lifetime usage has its own screen, while ports, processes, and paths live under Diagnostics. If no snapshot exists yet, the dashboard shows the exact generation command. Repository data never leaves your machine. See the **[dashboard user guide](docs/DASHBOARD.md)** for a walkthrough of every tab.
 
 ### Not using an agent?
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ A report, not a gate - it always exits `0`. It is the fastest way to find out th
 enola dashboard --open
 ```
 
-It stays attached to the terminal until you press Ctrl-C. The dashboard brings together architectural changes, the dependency map, findings, snapshot provenance, every active Enola session, lifetime activity, and extraction quality. If no snapshot exists yet, create one with `enola --generate`; repository data never leaves your machine. See the **[dashboard user guide](docs/DASHBOARD.md)** for a walkthrough of every tab.
+It stays attached to the terminal until you press Ctrl-C and follows newer snapshots written for that repository. The opening screen prioritizes findings and architectural changes; lifetime usage has its own screen, while ports, processes, and paths live under Diagnostics. If no snapshot exists yet, the dashboard shows the exact generation command and updates when it appears. Repository data never leaves your machine. See the **[dashboard user guide](docs/DASHBOARD.md)** for a walkthrough of every tab.
 
 ### Not using an agent?
 

--- a/cmd/enola/main.go
+++ b/cmd/enola/main.go
@@ -299,7 +299,7 @@ func main() {
 
 	// Start the localhost HTTP dashboard alongside the MCP server. It binds a
 	// free loopback port — plus the shared, bookmarkable one if it can claim it —
-	// and serves a read-only, auto-refreshing view of THIS server's graph and
+	// and serves a read-only view of THIS server's graph and
 	// activity, with links to every other server running. Non-fatal: a dashboard
 	// failure must never stop the MCP server. The port is recorded on the tracker
 	// BEFORE the startup write, so a separate --status invocation can print the
@@ -308,6 +308,7 @@ func main() {
 		opts := dashboard.Options{
 			Tracker:    tracker,
 			StablePort: dashboard.ResolveStablePort(cfg.Dashboard.Port),
+			HistoryDir: cfg.History.Dir,
 		}
 		if dash, err := dashboard.Start(eng, opts); err != nil {
 			log.Printf("dashboard: not started: %v (continuing without it)", err)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -860,7 +860,7 @@ Open the latest snapshot directly:
 enola dashboard --open
 ```
 
-This serves only the dashboard and stays attached to the terminal until Ctrl-C. An MCP server is not required. Startup prints the selected snapshot directory and complete `http://` URL. Use `enola --status` in another terminal to list running sessions and their dashboard URLs. Starting the MCP server also starts the same **read-only dashboard** on a free loopback port (`127.0.0.1`), printed to stderr at startup. A standalone dashboard checks for newer snapshots written to its selected directory and reloads the page when one appears.
+This serves only the dashboard and stays attached to the terminal until Ctrl-C. An MCP server is not required. Startup prints the selected snapshot directory and complete `http://` URL. Use `enola --status` in another terminal to list running sessions and their dashboard URLs. Starting the MCP server also starts the same **read-only dashboard** on a free loopback port (`127.0.0.1`), printed to stderr at startup. A standalone dashboard keeps the current graph stable until you use **Refresh** to load a newer snapshot from its selected directory.
 
 The dashboard is organized into six tabs:
 
@@ -873,7 +873,7 @@ The dashboard is organized into six tabs:
 
 It is strictly a viewer: it never extracts source or writes snapshot data. It binds loopback only and serves nothing but the dashboard. **Refresh** checks the selected snapshot directory immediately. Pass `--no-dashboard` to skip the dashboard attached to an MCP server.
 
-`enola --generate` is different: it generates the snapshot files and exits, without starting an MCP server or dashboard and without registering a running instance. A running standalone dashboard notices that publication and reloads it. A normal repository dashboard restores only that repository's snapshot; pass an explicit cluster config to display a multi-repository graph.
+`enola --generate` is different: it generates the snapshot files and exits, without starting an MCP server or dashboard and without registering a running instance. Use **Refresh** in a running standalone dashboard to load that publication. A normal repository dashboard restores only that repository's snapshot; pass an explicit cluster config to display a multi-repository graph.
 
 #### Several servers at once
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -860,19 +860,20 @@ Open the latest snapshot directly:
 enola dashboard --open
 ```
 
-This serves only the dashboard and stays attached to the terminal until Ctrl-C. Startup prints the snapshot directory and complete `http://` URL. Use `enola --status` in another terminal to list running sessions and their dashboard URLs. Starting the MCP server also starts the same **read-only dashboard** on a free loopback port (`127.0.0.1`), printed to stderr at startup. Data refresh is explicit, so a graph investigation is never interrupted by a periodic page reload.
+This serves only the dashboard and stays attached to the terminal until Ctrl-C. An MCP server is not required. Startup prints the selected snapshot directory and complete `http://` URL. Use `enola --status` in another terminal to list running sessions and their dashboard URLs. Starting the MCP server also starts the same **read-only dashboard** on a free loopback port (`127.0.0.1`), printed to stderr at startup. A standalone dashboard checks for newer snapshots written to its selected directory and reloads the page when one appears.
 
-The dashboard is organized into five tabs:
+The dashboard is organized into six tabs:
 
 - **Overview** — architectural change cards, current facts, findings, repositories, services, and cross-repository edges.
 - **Architecture** — a searchable module graph, focused consumer/dependency neighborhoods, edge evidence, findings, and a synchronized module table.
 - **Snapshots** — freshness, Git capture, extractor schema, repositories in the graph, and the complete technical receipt.
-- **Activity** — every currently active Enola session, this page's highlighted session, lifetime totals across completed and active sessions, and estimated value. Lifetime totals are retained; individual completed-session records are not.
+- **Lifetime usage** — retained tool totals and estimated value across repositories and completed sessions, kept separate from current-snapshot data.
+- **Diagnostics** — active processes, dashboard URLs, paths, ports, and this page's runtime identity.
 - **Quality** — complete file accounting, expected exclusions, potential blind spots, inactive extractors, parse failures, and unresolved cross-repository connections. Genuine parse failures include a prefilled GitHub issue action.
 
-It is strictly a viewer: every request reads through the same concurrency-safe accessors the MCP tools use and never mutates server state. It binds loopback only and serves nothing but the dashboard. Use **Refresh data** when you want to reload the currently available state. Pass `--no-dashboard` to skip the dashboard attached to an MCP server.
+It is strictly a viewer: it never extracts source or writes snapshot data. It binds loopback only and serves nothing but the dashboard. **Refresh** checks the selected snapshot directory immediately. Pass `--no-dashboard` to skip the dashboard attached to an MCP server.
 
-`enola --generate` is different: it generates the snapshot files and exits, without starting an MCP server or dashboard and without registering a running instance. A later MCP server can auto-load those files when it starts. A dashboard that is already running still describes its own process and its own in-memory graph; a separate `--generate` invocation does not turn that dashboard into a viewer for the generator process.
+`enola --generate` is different: it generates the snapshot files and exits, without starting an MCP server or dashboard and without registering a running instance. A running standalone dashboard notices that publication and reloads it. A normal repository dashboard restores only that repository's snapshot; pass an explicit cluster config to display a multi-repository graph.
 
 #### Several servers at once
 
@@ -880,7 +881,7 @@ Agent tooling starts one enola server per session, so opening four terminals mea
 
 **One bookmarkable URL.** Besides its own port, every server competes for a fixed **shared URL**, `http://127.0.0.1:7171` by default. The first to start wins it; when that one exits another takes over within a few seconds, so the address keeps working for as long as any server is up. Whichever server answers there lists all the others. Set `ENOLA_DASHBOARD_PORT` (or `dashboard.port` in the config) to move it, or `ENOLA_DASHBOARD_PORT=off` to keep only the ephemeral ports.
 
-There is no standalone dashboard process. When the last agent session closes, the last MCP server and its dashboard exit too, so the shared URL stops responding. When a new session starts, its server claims the shared URL again. As sessions start and stop, click **Refresh data** on an open dashboard to update the server list; joining servers appear and departed servers disappear on that request.
+`enola dashboard` is a standalone dashboard process. MCP-hosted dashboards exit with their agent sessions; a standalone dashboard remains until Ctrl-C. Diagnostics refreshes its process list on each page request.
 
 **Every page describes its own server.** The PID, uptime, repos and per-server call counts on a page belong to the process serving it - never to whichever server happened to start last. If a page shows a graph you did not expect, the switcher tells you which server holds the one you want.
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -38,11 +38,11 @@ enola check --write
 enola dashboard --open
 ```
 
-Start on **Overview**. Change cards group new and resolved findings. Open a finding to
+Start on **Findings**. Change cards group new and resolved findings. Open a finding to
 inspect its evidence in the Architecture tab. Findings describe the measured structure;
 project policy determines which findings fail a check.
 
-New and resolved categories require a comparable baseline. Without one, Overview shows
+New and resolved categories require a comparable baseline. Without one, Findings shows
 the current snapshot.
 
 ## Follow a dependency

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,8 +1,8 @@
 # The dashboard
 
-The dashboard displays snapshots produced by Enola's CLI and MCP tools. Use it to review
-changes, follow dependencies, inspect snapshot metadata, and check extraction coverage.
-It runs locally and reads existing snapshot data.
+The dashboard displays snapshots produced by Enola's CLI and MCP tools. It opens on the
+findings and changes for the selected repository, follows newer snapshots written to disk,
+and keeps process details out of the way unless you open Diagnostics.
 
 ![The Architecture tab showing the searchable module graph, dependency direction, inspector, and finding summary](images/DashboardArchitecture.png)
 
@@ -101,15 +101,16 @@ The categories are:
 - **Unresolved cross-repository connections** lists edges whose remote target was absent
   from the cluster snapshot.
 
-## Understand sessions and usage
+## See lifetime usage
 
-**Activity** shows active processes and lifetime totals. The highlighted row identifies
-the process serving the page.
+**Lifetime usage** shows tool calls and estimated value accumulated across repositories
+and completed sessions. These machine-wide totals are deliberately separate from the
+repository snapshot shown on the other screens.
 
 ![The Activity tab showing the standalone dashboard session serving the current page](images/DashboardActivity.png)
 
-A dashboard-only process serves zero MCP tool calls. Snapshot generation performed by a
-separate command appears in lifetime activity.
+For active processes, dashboard URLs, ports, paths, and the process serving the current
+page, open **Diagnostics**.
 
 ![Lifetime activity aggregated across completed and active sessions](images/DashboardLifetimeActivity.png)
 
@@ -117,13 +118,19 @@ Lifetime activity aggregates completed and active sessions across repositories. 
 retains aggregate totals. Time and token savings estimate the repository reconstruction
 avoided by using snapshot data.
 
-## Refresh data
+## Automatic refresh
 
-After generating or writing a newer snapshot, choose **Refresh data**. The dashboard
-refreshes on request.
+After another Enola process writes a newer snapshot, a standalone dashboard reloads it
+from disk and updates the page automatically. **Refresh** performs the same disk check
+immediately. An MCP-hosted dashboard reads its server's live graph.
 
-Refresh reloads the state available to the process serving that page. Use
-`enola --status` in another terminal to find the URL for another workspace.
+An ordinary repository launch shows only that repository's snapshot. A multi-repository
+graph is restored only when the dashboard is launched with an explicit cluster config.
+Use `enola --status` to find the URL for another workspace.
+
+`enola upgrade` replaces the binary; it does not regenerate repository snapshots. When
+the extraction schema differs, the dashboard keeps the existing findings visible and
+shows one regeneration notice with the command to run.
 
 ## Several dashboards at once
 
@@ -133,7 +140,7 @@ running sessions and their dashboard URLs.
 
 While any dashboard is running, Enola also tries to provide the bookmarkable shared URL
 `http://127.0.0.1:7171`. The first process owns it; another can take over after that
-process exits. The Activity page identifies the process serving the page.
+process exits. Diagnostics identifies the process serving the page.
 
 ## Related commands
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,7 +1,7 @@
 # The dashboard
 
 The dashboard displays snapshots produced by Enola's CLI and MCP tools. It opens on the
-findings and changes for the selected repository, follows newer snapshots written to disk,
+findings and changes for the selected repository, loads newer snapshots from disk when requested,
 and keeps process details out of the way unless you open Diagnostics.
 
 ![The Architecture tab showing the searchable module graph, dependency direction, inspector, and finding summary](images/DashboardArchitecture.png)
@@ -118,11 +118,11 @@ Lifetime activity aggregates completed and active sessions across repositories. 
 retains aggregate totals. Time and token savings estimate the repository reconstruction
 avoided by using snapshot data.
 
-## Automatic refresh
+## Refreshing the snapshot
 
-After another Enola process writes a newer snapshot, a standalone dashboard reloads it
-from disk and updates the page automatically. **Refresh** performs the same disk check
-immediately. An MCP-hosted dashboard reads its server's live graph.
+The dashboard keeps the graph stable while you inspect it. After another Enola process
+writes a newer snapshot, use **Refresh** to load it from disk. An MCP-hosted dashboard
+shows its server's current graph when you refresh the page.
 
 An ordinary repository launch shows only that repository's snapshot. A multi-repository
 graph is restored only when the dashboard is launched with an explicit cluster config.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -224,8 +224,9 @@ func (e *Engine) SetSnapshot(snap *facts.Snapshot) {
 // already tagged, so pass an empty singleRepoLabel to preserve the baked-in labels.
 //
 // Missing insights/meta are tolerated (a partial restore still serves facts); a
-// missing facts.jsonl is an error. It MUST run single-threaded at startup, before
-// Server.Run begins serving — like SetSnapshot, it publishes a new bundle.
+// missing facts.jsonl is an error. The complete replacement is built off to the
+// side and atomically published, so a dashboard may use it to follow a newer
+// on-disk snapshot while requests continue reading the previous bundle.
 func (e *Engine) RestoreFromDir(dir string, repoPaths map[string]string, singleRepoLabel string) error {
 	factsPath := filepath.Join(dir, "facts.jsonl")
 	if _, err := os.Stat(factsPath); err != nil {

--- a/internal/engine/global_receipt.go
+++ b/internal/engine/global_receipt.go
@@ -334,6 +334,18 @@ func (e *Engine) workspaceRepo(b *snapshotBundle) string {
 // snapshot is loaded.
 func (e *Engine) GraphReceipt() *facts.GraphReceipt {
 	b := e.current.Load()
+	return e.graphReceipt(b)
+}
+
+// DashboardState captures the store, snapshot, and graph receipt from one
+// published bundle. A concurrent regeneration may publish another bundle after
+// this returns, but these three values will continue to describe one generation.
+func (e *Engine) DashboardState() (*facts.Store, *facts.Snapshot, *facts.GraphReceipt) {
+	b := e.current.Load()
+	return b.store, b.snapshot, e.graphReceipt(b)
+}
+
+func (e *Engine) graphReceipt(b *snapshotBundle) *facts.GraphReceipt {
 	if b.snapshot == nil {
 		return nil
 	}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -646,6 +646,35 @@ func AutoLoadSnapshot(eng *Engine, cfg *config.Config) map[string]int {
 	return nil
 }
 
+// LoadDashboardSnapshot restores exactly the scope selected by the dashboard
+// command. An explicit multi-repository config restores its graph; an ordinary
+// repository launch reads only that repository's own snapshot and never adopts
+// an accumulated MCP workspace graph by surprise.
+func LoadDashboardSnapshot(eng *Engine, cfg *config.Config) bool {
+	if len(cfg.Repos) > 1 {
+		repos, err := cfg.RepoPaths()
+		if err != nil || len(repos) == 0 {
+			return false
+		}
+		paths := make(map[string]string, len(repos))
+		for _, repo := range repos {
+			paths[filepath.Base(repo)] = repo
+		}
+		dir := filepath.Join(repos[0], cfg.Output.Dir)
+		return eng.RestoreFromDir(dir, paths, "") == nil
+	}
+	repoPath, err := filepath.Abs(cfg.Repo)
+	if err != nil {
+		return false
+	}
+	dir := filepath.Join(repoPath, cfg.Output.Dir)
+	label := restoredLabel(dir, repoPath)
+	if err := eng.RestoreFromDir(dir, map[string]string{label: repoPath}, label); err != nil {
+		return false
+	}
+	return true
+}
+
 // restoredLabel reads the repo label recorded in a snapshot directory, falling back to
 // the checkout directory name when the snapshot predates the recorded label — which is
 // exactly what labelled the facts in that older snapshot.

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -186,6 +186,12 @@ func (e *Engine) GraphReceipt() *facts.GraphReceipt {
 	return e.eng.GraphReceipt()
 }
 
+// DashboardState returns one immutable publication for a dashboard request.
+// Its store, snapshot, and graph receipt always describe the same generation.
+func (e *Engine) DashboardState() (*facts.Store, *facts.Snapshot, *facts.GraphReceipt) {
+	return e.eng.DashboardState()
+}
+
 // SetBaseline pins the current on-disk snapshot as the diff baseline.
 func (e *Engine) SetBaseline(repoPath string) error {
 	return e.eng.SetBaseline(repoPath)

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -358,6 +358,40 @@ func TestAutoLoadSnapshot_IgnoresForeignGlobalReceipt(t *testing.T) {
 	}
 }
 
+func TestLoadDashboardSnapshotKeepsOrdinaryRepoScope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := writeGoRepo(t)
+	other := writeBiggerGoRepo(t)
+	eng, cfg := engineFor(t, repo)
+	one, err := eng.GenerateSnapshot(context.Background(), repo, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.WriteArtifacts(repo); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := eng.GenerateSnapshot(context.Background(), other, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.WriteArtifacts(other); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.WriteGlobalReceipt(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, restartCfg := engineFor(t, cfg.Repo)
+	if !bootstrap.LoadDashboardSnapshot(restarted, restartCfg) {
+		t.Fatal("dashboard snapshot was not restored")
+	}
+	if got := restarted.Store().Count(); got != one.Meta.FactCount {
+		t.Fatalf("dashboard restored %d facts, want the selected repo's %d", got, one.Meta.FactCount)
+	}
+	if got := len(restarted.RepoPaths()); got != 1 {
+		t.Fatalf("dashboard restored %d repositories, want 1", got)
+	}
+}
+
 // TestNewServer exercises the public server constructor and its accessors,
 // which enterprise code relies on to register license-gated tools before Run.
 func TestNewServer(t *testing.T) {

--- a/pkg/command/dashboard.go
+++ b/pkg/command/dashboard.go
@@ -53,10 +53,11 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	// Validate before binding a listener so a missing snapshot produces the useful
 	// generate-first guidance without briefly registering a dashboard process.
 	t := r.resolveTarget(arg)
+	snapshotDir := t.engine.OutputDir(t.repoPaths[0])
+	fmt.Fprintf(os.Stderr, "Loading dashboard snapshot from %s...\n", snapshotDir)
 	if restored := bootstrap.AutoLoadSnapshot(t.engine, t.engine.Config()); restored == nil {
 		r.missingDashboardSnapshot(t.configNote, arg)
 	}
-	snapshotDir := t.engine.OutputDir(t.repoPaths[0])
 	// A dashboard-only process is still an active Enola session. Register it just
 	// like the MCP startup path does so Activity does not claim zero sessions while
 	// the process serving that very page is running. No tool callback is installed:
@@ -116,15 +117,22 @@ func (r *Runner) dashboardFatal(format string, args ...any) {
 }
 
 func openBrowser(url string) error {
+	name, args := browserCommand(runtime.GOOS, url)
+	return exec.Command(name, args...).Start()
+}
+
+func browserCommand(goos, url string) (string, []string) {
 	var name string
 	var args []string
-	switch runtime.GOOS {
+	switch goos {
 	case "darwin":
-		name, args = "open", []string{url}
+		// Force LaunchServices to interpret the argument as a URL. Without -u,
+		// `open` may classify a localhost address as a filesystem path instead.
+		name, args = "open", []string{"-u", url}
 	case "windows":
 		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
 	default:
 		name, args = "xdg-open", []string{url}
 	}
-	return exec.Command(name, args...).Start()
+	return name, args
 }

--- a/pkg/command/dashboard.go
+++ b/pkg/command/dashboard.go
@@ -2,13 +2,17 @@ package command
 
 import (
 	"context"
+	"crypto/sha256"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
+	"github.com/enola-labs/enola/internal/engine"
 	"github.com/enola-labs/enola/pkg/bootstrap"
 	"github.com/enola-labs/enola/pkg/dashboard"
 	"github.com/enola-labs/enola/pkg/status"
@@ -23,8 +27,8 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	open := fs.Bool("open", false, "open the dashboard in the default browser")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s dashboard [--open] [repo_path|config_path]\n\n", r.name())
-		fmt.Fprintln(os.Stderr, "Explore an existing architecture snapshot in a read-only local web dashboard.")
-		fmt.Fprintln(os.Stderr, "Nothing is regenerated automatically; run `"+r.name()+" --generate` first when no snapshot exists.")
+		fmt.Fprintln(os.Stderr, "Start a local dashboard for this repository. An MCP server is not required.")
+		fmt.Fprintln(os.Stderr, "The dashboard follows newer snapshots written by Enola automatically; it never regenerates source itself.")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Options:")
 		fmt.Fprintln(os.Stderr, "  --open         launch the dashboard in the default browser")
@@ -55,9 +59,7 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	t := r.resolveTarget(arg)
 	snapshotDir := t.engine.OutputDir(t.repoPaths[0])
 	fmt.Fprintf(os.Stderr, "Loading dashboard snapshot from %s...\n", snapshotDir)
-	if restored := bootstrap.AutoLoadSnapshot(t.engine, t.engine.Config()); restored == nil {
-		r.missingDashboardSnapshot(t.configNote, arg)
-	}
+	bootstrap.LoadDashboardSnapshot(t.engine, t.engine.Config())
 	// A dashboard-only process is still an active Enola session. Register it just
 	// like the MCP startup path does so Activity does not claim zero sessions while
 	// the process serving that very page is running. No tool callback is installed:
@@ -81,6 +83,10 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	// whatever the callback returned: they describe THIS process, not the binary.
 	opts := r.dashboardOptions(t.engine)
 	opts.Tracker, opts.StablePort = tracker, port
+	opts.SnapshotPath = snapshotDir
+	opts.GenerateCommand = r.dashboardGenerateCommand(arg)
+	opts.CurrentExtractorVersion = engine.ExtractorVersion()
+	opts.Refresh = snapshotReloader(t.engine, snapshotDir)
 	dash, err := dashboard.Start(t.engine, opts)
 	if err != nil {
 		r.dashboardFatal("starting dashboard: %v", err)
@@ -88,7 +94,12 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	tracker.SetDashboardPort(dash.Port())
 	tracker.PersistStartup()
 	fmt.Fprintln(os.Stderr, "Dashboard running")
-	fmt.Fprintf(os.Stderr, "Snapshot: %s\n", snapshotDir)
+	if t.engine.Snapshot() == nil {
+		fmt.Fprintf(os.Stderr, "Snapshot: none yet (watching %s)\n", snapshotDir)
+		fmt.Fprintf(os.Stderr, "Generate: %s\n", opts.GenerateCommand)
+	} else {
+		fmt.Fprintf(os.Stderr, "Snapshot: %s\n", snapshotDir)
+	}
 	fmt.Fprintf(os.Stderr, "Open: %s\n", dash.URL())
 	if port > 0 {
 		fmt.Fprintf(os.Stderr, "Bookmarkable URL: http://127.0.0.1:%d\n", port)
@@ -102,14 +113,42 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	<-ctx.Done()
 }
 
-func (r *Runner) missingDashboardSnapshot(subject, target string) {
-	generate := r.name() + " --generate"
-	open := r.name() + " dashboard --open"
+func (r *Runner) dashboardGenerateCommand(target string) string {
+	cmd := r.name() + " --generate"
 	if target != "" {
-		generate += fmt.Sprintf(" %q", target)
-		open += fmt.Sprintf(" %q", target)
+		cmd += fmt.Sprintf(" %q", target)
 	}
-	r.dashboardFatal("no snapshot found for %s\n\nCreate one:\n  %s\n\nThen open it:\n  %s", subject, generate, open)
+	return cmd
+}
+
+// snapshotReloader turns a dashboard-only process into a live view of the
+// selected persisted snapshot. Receipt writes complete after the rest of the
+// artifact bundle, so its digest is the publication marker. A mutex prevents a
+// manual refresh and the background browser poll from restoring concurrently.
+func snapshotReloader(eng *bootstrap.Engine, snapshotDir string) func() (bool, error) {
+	var mu sync.Mutex
+	last := snapshotMarker(snapshotDir)
+	return func() (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		next := snapshotMarker(snapshotDir)
+		if next == last || next == ([sha256.Size]byte{}) {
+			return false, nil
+		}
+		if !bootstrap.LoadDashboardSnapshot(eng, eng.Config()) {
+			return false, fmt.Errorf("snapshot artifacts appeared at %s but could not be loaded", snapshotDir)
+		}
+		last = next
+		return true, nil
+	}
+}
+
+func snapshotMarker(snapshotDir string) [sha256.Size]byte {
+	b, err := os.ReadFile(filepath.Join(snapshotDir, "receipt.json"))
+	if err != nil {
+		return [sha256.Size]byte{}
+	}
+	return sha256.Sum256(b)
 }
 
 func (r *Runner) dashboardFatal(format string, args ...any) {

--- a/pkg/command/dashboard.go
+++ b/pkg/command/dashboard.go
@@ -28,7 +28,7 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s dashboard [--open] [repo_path|config_path]\n\n", r.name())
 		fmt.Fprintln(os.Stderr, "Start a local dashboard for this repository. An MCP server is not required.")
-		fmt.Fprintln(os.Stderr, "The dashboard follows newer snapshots written by Enola automatically; it never regenerates source itself.")
+		fmt.Fprintln(os.Stderr, "Use Refresh to load a newer snapshot written by Enola; the dashboard never regenerates source itself.")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Options:")
 		fmt.Fprintln(os.Stderr, "  --open         launch the dashboard in the default browser")
@@ -86,6 +86,7 @@ func (r *Runner) Dashboard(ctx context.Context, args []string) {
 	opts.SnapshotPath = snapshotDir
 	opts.GenerateCommand = r.dashboardGenerateCommand(arg)
 	opts.CurrentExtractorVersion = engine.ExtractorVersion()
+	opts.HistoryDir = t.engine.Config().History.Dir
 	opts.Refresh = snapshotReloader(t.engine, snapshotDir)
 	dash, err := dashboard.Start(t.engine, opts)
 	if err != nil {

--- a/pkg/command/dashboard_browser_test.go
+++ b/pkg/command/dashboard_browser_test.go
@@ -1,0 +1,27 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBrowserCommandPreservesDashboardURL(t *testing.T) {
+	const url = "http://127.0.0.1:54279"
+	tests := []struct {
+		goos string
+		name string
+		args []string
+	}{
+		{goos: "darwin", name: "open", args: []string{"-u", url}},
+		{goos: "windows", name: "rundll32", args: []string{"url.dll,FileProtocolHandler", url}},
+		{goos: "linux", name: "xdg-open", args: []string{url}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			name, args := browserCommand(tt.goos, url)
+			if name != tt.name || !reflect.DeepEqual(args, tt.args) {
+				t.Fatalf("browserCommand(%q, %q) = %q, %q; want %q, %q", tt.goos, url, name, args, tt.name, tt.args)
+			}
+		})
+	}
+}

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -94,6 +94,18 @@ type Options struct {
 	// others retry in the background and take it over when that server exits.
 	// Zero disables it.
 	StablePort int
+
+	// Refresh reloads the selected persisted snapshot when it changed. It is used
+	// by dashboard-only processes; an MCP-hosted dashboard already sees its
+	// engine's live publications. The bool reports whether a new snapshot was
+	// published.
+	Refresh func() (bool, error)
+
+	// SnapshotPath and GenerateCommand support a useful empty state and keep
+	// operational detail out of the primary UI unless the user asks for it.
+	SnapshotPath            string
+	GenerateCommand         string
+	CurrentExtractorVersion string
 }
 
 // defaultTitle is the product name shown when Options.Title is empty.
@@ -175,6 +187,7 @@ func Start(eng *bootstrap.Engine, opts Options) (*Server, error) {
 
 	s.mux = http.NewServeMux()
 	s.mux.HandleFunc("/", s.handleIndex)
+	s.mux.HandleFunc("/api/refresh", s.handleRefresh)
 
 	go func() {
 		if err := http.Serve(ln, s.mux); err != nil {
@@ -279,11 +292,35 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.opts.Refresh != nil {
+		if _, err := s.opts.Refresh(); err != nil {
+			log.Printf("dashboard: refreshing snapshot: %v", err)
+		}
+	}
 	data := s.buildPageForModule(r.URL.Query().Get("module"))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.Execute(w, data); err != nil {
 		log.Printf("dashboard: render failed: %v", err)
 	}
+}
+
+func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/refresh" {
+		http.NotFound(w, r)
+		return
+	}
+	changed := false
+	var err error
+	if s.opts.Refresh != nil {
+		changed, err = s.opts.Refresh()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{"changed": false, "error": err.Error()})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"changed": changed})
 }
 
 // titleOr returns the configured product name, or the default when unset.
@@ -405,7 +442,10 @@ type changeFinding struct {
 
 // pageData is the full template model.
 type pageData struct {
-	Title string
+	Title           string
+	SnapshotPath    string
+	GenerateCommand string
+	VersionNotice   string
 
 	// This server's own identity. Never sourced from the cross-process aggregate:
 	// with several agent terminals open, that would name a sibling process.
@@ -486,8 +526,10 @@ type pageData struct {
 // module if non-empty. Every source degrades gracefully to a note on error.
 func (s *Server) buildPageForModule(module string) pageData {
 	data := pageData{
-		Title: s.title,
-		Port:  s.port,
+		Title:           s.title,
+		Port:            s.port,
+		SnapshotPath:    s.opts.SnapshotPath,
+		GenerateCommand: s.opts.GenerateCommand,
 	}
 
 	now := time.Now()
@@ -547,6 +589,9 @@ func (s *Server) buildPageForModule(module string) pageData {
 		data.SkippedSample = rv.Quality.SkippedSample
 		data.ParseErrors = rv.Quality.ParseErrorSample
 		data.Quality = assessQuality(rv)
+		if s.opts.CurrentExtractorVersion != "" && rv.ExtractorVersion != "" && rv.ExtractorVersion != s.opts.CurrentExtractorVersion {
+			data.VersionNotice = "This snapshot uses a different extraction schema. Regenerate it before relying on comparisons or completeness."
+		}
 	} else {
 		data.ReceiptNote = "No snapshot loaded yet — run generate_snapshot to populate this."
 	}

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -106,6 +106,10 @@ type Options struct {
 	SnapshotPath            string
 	GenerateCommand         string
 	CurrentExtractorVersion string
+
+	// HistoryDir is the configured history.dir override. Change summaries must
+	// read the same timeline that snapshot generation writes.
+	HistoryDir string
 }
 
 // defaultTitle is the product name shown when Options.Title is empty.
@@ -124,16 +128,10 @@ type engineView interface {
 	GetArtifact(name string) ([]byte, error)
 	ActiveRepo() string
 	OutputDir(repoPath string) string
-	// Store exposes the live fact store, from which the dashboard enumerates the
-	// service and cross-repo-edge lists behind the graph-receipt counters (the
-	// receipt itself stores only the counts). Reads are concurrency-safe.
-	Store() *facts.Store
-	// GraphReceipt describes the graph THIS engine holds, assembled in memory.
-	// It is what the graph panel renders, so that panel and the store-derived
-	// panels below it can never describe different repo sets — which reading the
-	// machine-wide ~/.enola/receipt.json would allow whenever a second server is
-	// running. Nil when no snapshot is loaded.
-	GraphReceipt() *facts.GraphReceipt
+	// DashboardState captures one immutable engine publication. Every snapshot
+	// panel in a response must use these returned values rather than independently
+	// loading live accessors that a concurrent regeneration could swap between.
+	DashboardState() (*facts.Store, *facts.Snapshot, *facts.GraphReceipt)
 }
 
 // Server is a running dashboard HTTP server bound to a loopback port.
@@ -187,7 +185,6 @@ func Start(eng *bootstrap.Engine, opts Options) (*Server, error) {
 
 	s.mux = http.NewServeMux()
 	s.mux.HandleFunc("/", s.handleIndex)
-	s.mux.HandleFunc("/api/refresh", s.handleRefresh)
 
 	go func() {
 		if err := http.Serve(ln, s.mux); err != nil {
@@ -284,43 +281,29 @@ func (s *Server) Port() int { return s.port }
 // URL returns the dashboard's localhost URL.
 func (s *Server) URL() string { return fmt.Sprintf("http://127.0.0.1:%d", s.port) }
 
-// handleIndex gathers live data on each request (so the periodic reload shows
-// fresh numbers) and renders the page. Only the root path is served.
+// handleIndex gathers live data on each request and renders the page. Only the
+// root path is served; the user decides when to refresh the displayed graph.
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		http.NotFound(w, r)
 		return
 	}
 
+	var refreshErr error
 	if s.opts.Refresh != nil {
 		if _, err := s.opts.Refresh(); err != nil {
+			refreshErr = err
 			log.Printf("dashboard: refreshing snapshot: %v", err)
 		}
 	}
 	data := s.buildPageForModule(r.URL.Query().Get("module"))
+	if refreshErr != nil {
+		data.RefreshError = "Could not load the latest snapshot. The previously loaded graph is still shown."
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.Execute(w, data); err != nil {
 		log.Printf("dashboard: render failed: %v", err)
 	}
-}
-
-func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/api/refresh" {
-		http.NotFound(w, r)
-		return
-	}
-	changed := false
-	var err error
-	if s.opts.Refresh != nil {
-		changed, err = s.opts.Refresh()
-	}
-	w.Header().Set("Content-Type", "application/json")
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]any{"changed": false, "error": err.Error()})
-		return
-	}
-	_ = json.NewEncoder(w).Encode(map[string]any{"changed": changed})
 }
 
 // titleOr returns the configured product name, or the default when unset.
@@ -446,6 +429,7 @@ type pageData struct {
 	SnapshotPath    string
 	GenerateCommand string
 	VersionNotice   string
+	RefreshError    string
 
 	// This server's own identity. Never sourced from the cross-process aggregate:
 	// with several agent terminals open, that would name a sibling process.
@@ -499,10 +483,11 @@ type pageData struct {
 
 	// Insights (grouped by explainer) back the clickable Insights card; the
 	// structural/candidate split is shown in the modal header.
-	Insights          []insightGroup
-	InsightStructural int
-	InsightCandidate  int
-	InsightTotal      int // structural + candidate; initial "shown" count for the modal filter
+	Insights             []insightGroup
+	InsightStructural    int
+	InsightCandidate     int
+	InsightInformational int
+	InsightTotal         int
 
 	// Extraction-quality proof data: per-service coverage and the unmatched-route
 	// list (from the live store), plus the capped skip/parse-error samples (from the
@@ -533,6 +518,7 @@ func (s *Server) buildPageForModule(module string) pageData {
 	}
 
 	now := time.Now()
+	store, publishedSnapshot, graphReceipt := s.eng.DashboardState()
 
 	// Identity comes from THIS process's tracker. A user running one server per
 	// agent terminal must be able to tell, from the page alone, which one they are
@@ -581,7 +567,7 @@ func (s *Server) buildPageForModule(module string) pageData {
 
 	// Current-snapshot receipt: prefer the live in-memory receipt, falling back
 	// to the last-written one on disk (see currentReceipt).
-	if rv := s.currentReceipt(); rv != nil {
+	if rv := s.currentReceipt(publishedSnapshot); rv != nil {
 		data.HasReceipt = true
 		data.Receipt = rv
 		data.Snapshot = summarizeSnapshot(rv, now)
@@ -600,50 +586,61 @@ func (s *Server) buildPageForModule(module string) pageData {
 	// always describes the same store as the services/insights/coverage panels
 	// below it. Reading the shared ~/.enola/receipt.json here would show whichever
 	// repos another running server snapshotted last.
-	if gv := s.eng.GraphReceipt(); gv != nil {
+	if graphReceipt != nil {
 		data.HasGraph = true
-		data.Graph = gv
+		data.Graph = graphReceipt
 	} else {
 		data.GraphNote = "No graph loaded in this server yet — run generate_snapshot to populate this."
 	}
 
 	// Service and cross-repo-edge lists from the live store, backing the clickable
 	// counters. Empty (store not loaded) → the cards render as plain numbers.
-	data.Services, data.CrossRepoEdges = graphDetails(s.eng.Store())
+	data.Services, data.CrossRepoEdges = graphDetails(store)
 	data.EdgeDiagram = buildEdgeDiagram(data.Services, data.CrossRepoEdges)
 	currentSnapshotID := ""
 	if data.Receipt != nil {
 		currentSnapshotID = data.Receipt.SnapshotID
 	}
-	data.ModuleGraph = s.readModuleGraph(currentSnapshotID, module)
-	data.Changes = s.readChangeSummary(s.eng.ActiveRepo(), currentSnapshotID)
+	data.ModuleGraph = s.readModuleGraph(store, currentSnapshotID, module)
+	activeRepo := s.eng.ActiveRepo()
+	if publishedSnapshot != nil && publishedSnapshot.Meta.RepoPath != "" {
+		activeRepo = publishedSnapshot.Meta.RepoPath
+	}
+	data.Changes = s.readChangeSummary(activeRepo, currentSnapshotID)
 
 	// Insight list (grouped by explainer) backing the clickable Insights counter.
 	// Empty → the counter renders as a plain number.
-	data.Insights, data.InsightStructural, data.InsightCandidate = insightDetails(s.currentInsights(), s.labels)
-	data.InsightTotal = data.InsightStructural + data.InsightCandidate
+	data.Insights, data.InsightStructural, data.InsightCandidate = insightDetails(s.currentInsights(publishedSnapshot), s.labels)
+	for _, group := range data.Insights {
+		data.InsightTotal += group.Count
+		for _, item := range group.Items {
+			if item.Informational {
+				data.InsightInformational++
+			}
+		}
+	}
 
 	// Cross-repo coverage + unmatched routes from the live store, backing the
 	// clickable Extraction-quality coverage cards.
-	data.Coverage, data.UnresolvedRoutes = coverageDetails(s.eng.Store())
+	data.Coverage, data.UnresolvedRoutes = coverageDetails(store)
 
 	// Whatever a wrapper's overlay blocks render, recomputed per request from the
 	// same live store as everything above.
 	if s.opts.Extra != nil {
-		data.Extra = s.opts.Extra(s.eng.Store())
+		data.Extra = s.opts.Extra(store)
 	}
 
 	return data
 }
 
-func (s *Server) readModuleGraph(snapshotID, focus string) *moduleGraphView {
+func (s *Server) readModuleGraph(store *facts.Store, snapshotID, focus string) *moduleGraphView {
 	key := snapshotID + "\x00" + focus
 	s.graphMu.Lock()
 	defer s.graphMu.Unlock()
 	if snapshotID != "" && key == s.graphCacheKey {
 		return s.graphCache
 	}
-	result := buildModuleGraphFocused(s.eng.Store(), focus)
+	result := buildModuleGraphFocused(store, focus)
 	s.graphCacheKey, s.graphCache = key, result
 	return result
 }
@@ -654,16 +651,16 @@ func (s *Server) readChangeSummary(repoPath, snapshotID string) changeSummary {
 	if snapshotID != "" && snapshotID == s.changeCacheID {
 		return s.changeCache
 	}
-	result := readChangeSummary(repoPath, snapshotID, s.labels)
+	result := readChangeSummary(repoPath, snapshotID, s.opts.HistoryDir, s.labels)
 	s.changeCacheID, s.changeCache = snapshotID, result
 	return result
 }
 
-func readChangeSummary(repoPath, snapshotID string, labels map[string]string) changeSummary {
+func readChangeSummary(repoPath, snapshotID, historyDir string, labels map[string]string) changeSummary {
 	if repoPath == "" || snapshotID == "" {
 		return changeSummary{}
 	}
-	root, err := history.Root(repoPath, "")
+	root, err := history.Root(repoPath, historyDir)
 	if err != nil {
 		return changeSummary{}
 	}
@@ -842,7 +839,13 @@ func shortDigest(value string, n int) string {
 // generate_snapshot), but falls back to the last-written receipt on disk when the
 // in-memory one is missing or blank — the common case after a server restart,
 // where AutoLoadSnapshot restores facts without full receipt metadata.
-func (s *Server) currentReceipt() *facts.Receipt {
+func (s *Server) currentReceipt(snapshot *facts.Snapshot) *facts.Receipt {
+	if snapshot != nil {
+		rv := snapshot.Meta.Receipt()
+		if rv.SnapshotID != "" {
+			return &rv
+		}
+	}
 	if b, err := s.eng.GetArtifact("receipt.json"); err == nil {
 		var rv facts.Receipt
 		if err := json.Unmarshal(b, &rv); err == nil && rv.SnapshotID != "" {
@@ -870,10 +873,15 @@ func (s *Server) currentReceipt() *facts.Receipt {
 // falls back to the last-written insights.json on disk — AutoLoadSnapshot restores
 // facts without the snapshot's insights, so after a server restart the in-memory
 // list is empty while a full one persists at <repo>/.enola/insights.json.
-func (s *Server) currentInsights() []facts.Insight {
+func (s *Server) currentInsights(snapshot *facts.Snapshot) []facts.Insight {
+	// A published empty slice is authoritative: falling through to an older disk
+	// artifact would resurrect findings that the current generation resolved.
+	if snapshot != nil {
+		return snapshot.Insights
+	}
 	if b, err := s.eng.GetArtifact("insights.json"); err == nil {
 		var ins []facts.Insight
-		if err := json.Unmarshal(b, &ins); err == nil && len(ins) > 0 {
+		if err := json.Unmarshal(b, &ins); err == nil {
 			return ins
 		}
 	}

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -481,9 +482,11 @@ func TestBuildEdgeDiagram(t *testing.T) {
 	}
 }
 
-// TestInsightDetails covers the store-independent grouping: groups sorted by count
-// desc, items within a group sorted by confidence desc, the largest group's bar at
-// 100%, the structural/candidate split, evidence extraction, and nil → empty.
+// TestInsightDetails covers the store-independent grouping: groups with a proven
+// (structural) finding rank first regardless of size, then by count desc; items
+// within a group are sorted by confidence desc; the largest group's bar is at
+// 100%; the structural/candidate split and evidence extraction are correct; and
+// nil input yields empty output.
 func TestInsightDetails(t *testing.T) {
 	labels := mergedLabels(nil)
 
@@ -502,25 +505,92 @@ func TestInsightDetails(t *testing.T) {
 	if len(groups) != 2 {
 		t.Fatalf("groups = %d, want 2", len(groups))
 	}
-	// hotspots (3) ranks before cycles (1).
-	if groups[0].Source != "hotspots" || groups[0].Count != 3 || groups[0].BarPct != 100 {
-		t.Errorf("group0 = %+v, want hotspots/3/100%%", groups[0])
+	// cycles (1, but proven/structural) ranks before hotspots (3, heuristic) — a
+	// real problem outranks a bigger bucket of candidates.
+	if groups[0].Source != "cycles" || groups[0].BarPct != 33 || !groups[0].HasStructural {
+		t.Errorf("group0 = %+v, want cycles/33%%/structural", groups[0])
 	}
-	if groups[0].Label != "Hotspots" {
-		t.Errorf("group0 label = %q, want Hotspots", groups[0].Label)
+	if !groups[0].Items[0].Structural || groups[0].Items[0].Evidence != "foo" {
+		t.Errorf("cycles item = %+v, want structural + evidence foo", groups[0].Items[0])
+	}
+	if groups[1].Source != "hotspots" || groups[1].Count != 3 || groups[1].BarPct != 100 || groups[1].HasStructural {
+		t.Errorf("group1 = %+v, want hotspots/3/100%%/not structural", groups[1])
+	}
+	if groups[1].Label != "Hotspots" {
+		t.Errorf("group1 label = %q, want Hotspots", groups[1].Label)
 	}
 	// Within hotspots, highest confidence first (85, 65, 65 by title).
-	if groups[0].Items[0].Title != "Alloc in loop" || groups[0].Items[0].Confidence != 85 {
-		t.Errorf("hotspots item0 = %+v, want Alloc in loop/85", groups[0].Items[0])
-	}
-	if groups[1].Source != "cycles" || groups[1].BarPct != 33 {
-		t.Errorf("group1 = %+v, want cycles/33%%", groups[1])
-	}
-	if !groups[1].Items[0].Structural || groups[1].Items[0].Evidence != "foo" {
-		t.Errorf("cycles item = %+v, want structural + evidence foo", groups[1].Items[0])
+	if groups[1].Items[0].Title != "Alloc in loop" || groups[1].Items[0].Confidence != 85 {
+		t.Errorf("hotspots item0 = %+v, want Alloc in loop/85", groups[1].Items[0])
 	}
 	if structural != 1 || candidate != 3 {
 		t.Errorf("split = %d structural / %d candidate, want 1/3", structural, candidate)
+	}
+}
+
+// TestInsightDetailsExcludesInformationalFromBothCounts covers the fix for a real
+// leak: an Informational finding (e.g. "Architecture pattern: declared") describes
+// the graph rather than flagging a problem, and pkg/check never grades it — so it
+// must not inflate the "structural" count just because it happens to sit at 1.0,
+// nor count as a "candidate" needing a fix. It still renders in its group's Items.
+func TestInsightDetailsExcludesInformationalFromBothCounts(t *testing.T) {
+	ins := []facts.Insight{
+		{Source: "domain", Title: "Architecture pattern: declared", Confidence: 1.0, Informational: true},
+		{Source: "domain", Title: "Real boundary violation", Confidence: 1.0},
+	}
+	groups, structural, candidate := insightDetails(ins, mergedLabels(nil))
+	if structural != 1 || candidate != 0 {
+		t.Fatalf("split = %d/%d, want 1 structural / 0 candidate — the informational note must be counted in neither", structural, candidate)
+	}
+	if len(groups) != 1 || len(groups[0].Items) != 2 {
+		t.Fatalf("groups = %+v, want one group with both items", groups)
+	}
+	var sawInformational bool
+	for _, item := range groups[0].Items {
+		if item.Title == "Architecture pattern: declared" {
+			sawInformational = true
+			if !item.Informational || item.Structural {
+				t.Errorf("informational item = %+v, want Informational=true, Structural=false", item)
+			}
+		}
+	}
+	if !sawInformational {
+		t.Fatalf("groups = %+v, want the informational item still present", groups)
+	}
+}
+
+// TestInsightDetailsCapsPreviewAndCarriesTopAction covers the overview's per-group
+// preview cap (Items stays complete for the modal; Shown/Hidden bound what the
+// overview renders inline) and that each row carries only the first suggested
+// action, since explainers already order their own Actions most-direct-fix first.
+func TestInsightDetailsCapsPreviewAndCarriesTopAction(t *testing.T) {
+	ins := make([]facts.Insight, 0, 7)
+	for i := 0; i < 7; i++ {
+		in := facts.Insight{Source: "hotspots", Title: fmt.Sprintf("Hot symbol %d", i), Confidence: 0.7}
+		if i == 0 {
+			in.Actions = []string{"do X", "do Y"}
+		}
+		ins = append(ins, in)
+	}
+	groups, _, _ := insightDetails(ins, mergedLabels(nil))
+	if len(groups) != 1 {
+		t.Fatalf("groups = %d, want 1", len(groups))
+	}
+	g := groups[0]
+	if len(g.Items) != 7 || len(g.Shown) != 5 || g.Hidden != 2 {
+		t.Fatalf("g = %+v, want 7 items / 5 shown / 2 hidden", g)
+	}
+	var found bool
+	for _, item := range g.Items {
+		if item.Title == "Hot symbol 0" {
+			found = true
+			if item.Action != "do X" {
+				t.Errorf("action = %q, want only the first suggested action (do X)", item.Action)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("items = %+v, want Hot symbol 0 present", g.Items)
 	}
 }
 

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -216,18 +216,34 @@ func TestHandlerDegradesGracefully(t *testing.T) {
 	}
 	body := rec.Body.String()
 	wantContains := []string{
-		"Refresh data",                   // explicit refresh; investigations are never interrupted
+		"Refresh",                        // explicit disk refresh remains available
 		"Ready to map this repository.",  // product-facing empty state
 		"No snapshot loaded yet",         // degraded current receipt
 		"No graph loaded in this server", // degraded graph receipt
+		"refreshSnapshot(false)",         // newer snapshots are discovered automatically
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}
 	}
-	if strings.Contains(body, "setTimeout(function () { location.reload()") || strings.Contains(body, "updates every") {
-		t.Error("dashboard still contains automatic refresh behavior")
+}
+
+func TestRefreshEndpointReportsPublishedSnapshot(t *testing.T) {
+	isolateHome(t)
+	calls := 0
+	s := newTestServer(54321, fakeArtifacts{}, Options{Refresh: func() (bool, error) {
+		calls++
+		return true, nil
+	}})
+
+	rec := httptest.NewRecorder()
+	s.handleRefresh(rec, httptest.NewRequest(http.MethodGet, "/api/refresh", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"changed":true`) {
+		t.Fatalf("refresh response = %d %s", rec.Code, rec.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("refresh callback called %d times, want 1", calls)
 	}
 }
 

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -697,7 +697,8 @@ func TestHandlerRendersInsightsModal(t *testing.T) {
 		"UserService is a god class", // an insight title
 		"90%", "100%",                // confidence rendering
 		"structural",   // structural chip on the 100% insight
-		"1 structural", // header split
+		"1 <span",      // header split count
+		">structural<", // header split label
 		// confidence-band filter wiring
 		`id="insight-band"`,
 		"Structural (100%)",

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -803,7 +803,7 @@ func TestHandlerRendersQualityModals(t *testing.T) {
 	for _, want := range []string{
 		`id="coverage-modal"`, `id="coverage-unresolved-modal"`, `id="skipped-modal"`, `id="parse-errors-modal"`,
 		`Files walked`, `Intentionally ignored`, `Non-source / unsupported`, `No facts emitted`,
-		`Ignored and non-source files are not parse failures`, `.sql`, `claimed by go, no facts emitted`,
+		`Ignored and non-source files aren't parse failures`, `.sql`, `claimed by go, no facts emitted`,
 		`onclick="openModal('coverage-modal')"`,
 		`onclick="openModal('coverage-unresolved-modal')"`,
 		`onclick="openModal('skipped-modal')"`,

--- a/pkg/dashboard/dashboard_test.go
+++ b/pkg/dashboard/dashboard_test.go
@@ -79,10 +79,11 @@ func TestAssessQualityEscalatesOnlyMaterialExtractorGaps(t *testing.T) {
 	}
 }
 
-func TestReadChangeSummaryMatchesLoadedSnapshot(t *testing.T) {
+func TestReadChangeSummaryMatchesLoadedSnapshotInConfiguredHistory(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	repo := t.TempDir()
-	root, err := history.Root(repo, "")
+	const historyDir = ".enola/history"
+	root, err := history.Root(repo, historyDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,11 +106,11 @@ func TestReadChangeSummaryMatchesLoadedSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := readChangeSummary(repo, "sha256:loaded", mergedLabels(nil))
+	got := readChangeSummary(repo, "sha256:loaded", historyDir, mergedLabels(nil))
 	if !got.Available || got.FactsAdded != 2 || got.EdgesAdded != 7 || got.FactsRemoved != 0 {
 		t.Fatalf("summary = %+v, want loaded snapshot rather than newest history entry", got)
 	}
-	if got := readChangeSummary(repo, "sha256:missing", mergedLabels(nil)); got.Available {
+	if got := readChangeSummary(repo, "sha256:missing", historyDir, mergedLabels(nil)); got.Available {
 		t.Fatalf("missing snapshot unexpectedly returned %+v", got)
 	}
 }
@@ -155,6 +156,7 @@ type fakeArtifacts struct {
 	activeRepo string
 	outputDir  string
 	store      *facts.Store
+	snapshot   *facts.Snapshot
 	graph      *facts.GraphReceipt
 }
 
@@ -172,9 +174,9 @@ func (f fakeArtifacts) ActiveRepo() string { return f.activeRepo }
 
 func (f fakeArtifacts) OutputDir(repoPath string) string { return f.outputDir }
 
-func (f fakeArtifacts) Store() *facts.Store { return f.store }
-
-func (f fakeArtifacts) GraphReceipt() *facts.GraphReceipt { return f.graph }
+func (f fakeArtifacts) DashboardState() (*facts.Store, *facts.Snapshot, *facts.GraphReceipt) {
+	return f.store, f.snapshot, f.graph
+}
 
 // newTestServer builds a Server exactly as Start does — parsed template and
 // merged insight labels included — but without binding a port. Constructing the
@@ -221,30 +223,27 @@ func TestHandlerDegradesGracefully(t *testing.T) {
 		"Ready to map this repository.",  // product-facing empty state
 		"No snapshot loaded yet",         // degraded current receipt
 		"No graph loaded in this server", // degraded graph receipt
-		"refreshSnapshot(false)",         // newer snapshots are discovered automatically
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}
 	}
+	if strings.Contains(body, "setInterval") || strings.Contains(body, "refreshSnapshot") {
+		t.Error("dashboard must refresh only when the user requests it")
+	}
 }
 
-func TestRefreshEndpointReportsPublishedSnapshot(t *testing.T) {
+func TestRefreshFailureIsVisibleAndKeepsServingThePage(t *testing.T) {
 	isolateHome(t)
-	calls := 0
 	s := newTestServer(54321, fakeArtifacts{}, Options{Refresh: func() (bool, error) {
-		calls++
-		return true, nil
+		return false, errors.New("restore failed")
 	}})
 
 	rec := httptest.NewRecorder()
-	s.handleRefresh(rec, httptest.NewRequest(http.MethodGet, "/api/refresh", nil))
-	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"changed":true`) {
-		t.Fatalf("refresh response = %d %s", rec.Code, rec.Body.String())
-	}
-	if calls != 1 {
-		t.Fatalf("refresh callback called %d times, want 1", calls)
+	s.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Could not load the latest snapshot") {
+		t.Fatalf("response = %d %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -334,9 +333,43 @@ func TestReceiptDiskFallback(t *testing.T) {
 	}
 	s := newTestServer(9, fakeArtifacts{receipt: blank, activeRepo: repo, outputDir: outDir})
 
-	rv := s.currentReceipt()
+	rv := s.currentReceipt(nil)
 	if rv == nil || rv.SnapshotID != "sha256:ondisk" || rv.FactCount != 77 {
 		t.Fatalf("currentReceipt = %+v, want the on-disk receipt", rv)
+	}
+}
+
+func TestPublishedEmptyInsightsDoNotFallBackToStaleArtifact(t *testing.T) {
+	stale, err := json.Marshal([]facts.Insight{{Source: "cycles", Title: "resolved finding", Confidence: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newTestServer(9, fakeArtifacts{insights: stale})
+	current := &facts.Snapshot{Insights: []facts.Insight{}}
+	if got := s.currentInsights(current); len(got) != 0 {
+		t.Fatalf("currentInsights = %+v, want authoritative empty publication", got)
+	}
+}
+
+func TestPageUsesOnePublishedDashboardState(t *testing.T) {
+	isolateHome(t)
+	st := facts.NewStore()
+	st.Add(facts.Fact{Kind: facts.KindService, Name: "fresh-service"})
+	fresh := &facts.Snapshot{Meta: facts.SnapshotMeta{SnapshotID: "fresh", FactCount: 1, RepoPath: "/fresh"}}
+	graph := &facts.GraphReceipt{SnapshotID: "fresh", ServiceCount: 1}
+	staleReceipt, err := json.Marshal(facts.Receipt{SnapshotID: "stale", FactCount: 99})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newTestServer(9, fakeArtifacts{
+		receipt: staleReceipt, store: st, snapshot: fresh, graph: graph,
+	})
+	data := s.buildPageForModule("")
+	if data.Receipt == nil || data.Receipt.SnapshotID != "fresh" || data.Graph != graph {
+		t.Fatalf("page state = receipt %+v graph %+v, want one fresh publication", data.Receipt, data.Graph)
+	}
+	if len(data.Services) != 1 || data.Services[0].Name != "fresh-service" {
+		t.Fatalf("services = %+v, want store captured with fresh publication", data.Services)
 	}
 }
 
@@ -513,6 +546,9 @@ func TestInsightDetails(t *testing.T) {
 	if !groups[0].Items[0].Structural || groups[0].Items[0].Evidence != "foo" {
 		t.Errorf("cycles item = %+v, want structural + evidence foo", groups[0].Items[0])
 	}
+	if groups[0].Items[0].Band != "structural" {
+		t.Errorf("cycles band = %q, want structural", groups[0].Items[0].Band)
+	}
 	if groups[1].Source != "hotspots" || groups[1].Count != 3 || groups[1].BarPct != 100 || groups[1].HasStructural {
 		t.Errorf("group1 = %+v, want hotspots/3/100%%/not structural", groups[1])
 	}
@@ -522,6 +558,9 @@ func TestInsightDetails(t *testing.T) {
 	// Within hotspots, highest confidence first (85, 65, 65 by title).
 	if groups[1].Items[0].Title != "Alloc in loop" || groups[1].Items[0].Confidence != 85 {
 		t.Errorf("hotspots item0 = %+v, want Alloc in loop/85", groups[1].Items[0])
+	}
+	if groups[1].Items[0].Band != "high" || groups[1].Items[1].Band != "medium" {
+		t.Errorf("candidate bands = %q/%q, want high/medium", groups[1].Items[0].Band, groups[1].Items[1].Band)
 	}
 	if structural != 1 || candidate != 3 {
 		t.Errorf("split = %d structural / %d candidate, want 1/3", structural, candidate)
@@ -549,13 +588,30 @@ func TestInsightDetailsExcludesInformationalFromBothCounts(t *testing.T) {
 	for _, item := range groups[0].Items {
 		if item.Title == "Architecture pattern: declared" {
 			sawInformational = true
-			if !item.Informational || item.Structural {
+			if !item.Informational || item.Structural || item.Band != "informational" {
 				t.Errorf("informational item = %+v, want Informational=true, Structural=false", item)
 			}
 		}
 	}
 	if !sawInformational {
 		t.Fatalf("groups = %+v, want the informational item still present", groups)
+	}
+}
+
+func TestInsightBandUsesFindingSemanticsBeforeRoundedDisplay(t *testing.T) {
+	ins := []facts.Insight{
+		{Source: "hotspots", Title: "Near certain candidate", Confidence: 0.999},
+		{Source: "domain", Title: "Architecture context", Confidence: 1, Informational: true},
+	}
+	groups, _, _ := insightDetails(ins, mergedLabels(nil))
+	bands := map[string]string{}
+	for _, group := range groups {
+		for _, item := range group.Items {
+			bands[item.Title] = item.Band
+		}
+	}
+	if bands["Near certain candidate"] != "high" || bands["Architecture context"] != "informational" {
+		t.Fatalf("bands = %+v, want rounded 100%% candidate kept high and context kept informational", bands)
 	}
 }
 
@@ -702,8 +758,9 @@ func TestHandlerRendersInsightsModal(t *testing.T) {
 		// confidence-band filter wiring
 		`id="insight-band"`,
 		"Structural (100%)",
+		"Context",
 		`onchange="filterInsights(this.value)"`,
-		`data-conf="90"`,
+		`data-band="high"`,
 		`id="insight-shown"`,
 	} {
 		if !strings.Contains(body, want) {

--- a/pkg/dashboard/identity_test.go
+++ b/pkg/dashboard/identity_test.go
@@ -87,12 +87,12 @@ func TestPageListsLiveInstances(t *testing.T) {
 		}
 	}
 	activeAt := strings.Index(body, "Active sessions")
-	runtimeAt := strings.Index(body, "Runtime details")
+	runtimeAt := strings.Index(body, "Paths and runtime details")
 	if activeAt < 0 || runtimeAt < 0 || activeAt > runtimeAt {
-		t.Error("active sessions must be visible before the collapsed runtime details")
+		t.Error("Diagnostics must show active sessions before collapsed runtime details")
 	}
-	if !strings.Contains(body, "Individual completed-session records are not retained") {
-		t.Error("Activity tab does not explain lifetime aggregation versus session history")
+	if !strings.Contains(body, "These totals do not affect the snapshot shown elsewhere") {
+		t.Error("Lifetime usage must be clearly separated from the current snapshot")
 	}
 }
 

--- a/pkg/dashboard/insights.go
+++ b/pkg/dashboard/insights.go
@@ -7,22 +7,34 @@ import (
 	"github.com/enola-labs/enola/pkg/facts"
 )
 
+// insightGroupPreviewCap bounds how many of a group's items the overview shows
+// inline, mirroring pkg/explain's topPerGroup: each explainer already sorts its
+// own findings worst-first, so showing the first few and linking to the full
+// list (the Insights modal, which still renders every item) turns "91
+// candidates" from a wall of rows into something worth reading.
+const insightGroupPreviewCap = 5
+
 // insightRow is one insight in a category group of the Insights modal.
 type insightRow struct {
-	Title      string
-	Confidence int  // 0-100
-	Structural bool // confidence >= 1.0 — a certain (non-heuristic) finding
-	Evidence   string
+	Title         string
+	Confidence    int  // 0-100
+	Structural    bool // confidence >= 1.0 and not Informational — a proven, non-heuristic finding
+	Informational bool // describes the architecture rather than flagging a problem; never gradeable (see pkg/check)
+	Evidence      string
+	Action        string // the finding's first suggested action, if any — the concrete "what to do about it"
 }
 
 // insightGroup is all insights produced by one explainer (Source), with a bar
 // width proportional to its share of the largest group.
 type insightGroup struct {
-	Source string
-	Label  string
-	Count  int
-	BarPct int // 0-100, relative to the largest group
-	Items  []insightRow
+	Source        string
+	Label         string
+	Count         int
+	BarPct        int  // 0-100, relative to the largest group
+	HasStructural bool // true if any item is a proven (Structural) finding — ranks the group ahead of larger but purely heuristic ones
+	Items         []insightRow // full list, for the modal
+	Shown         []insightRow // capped to insightGroupPreviewCap, for the overview
+	Hidden        int          // len(Items) - len(Shown)
 }
 
 // insightLabels maps an explainer Source id to a human-friendly label, one entry
@@ -102,17 +114,27 @@ func insightDetails(ins []facts.Insight, labels map[string]string) (groups []ins
 			continue // produced by explainers this build does not have
 		}
 		conf := int(math.Round(in.Confidence * 100))
-		isStructural := in.Confidence >= 1.0
-		if isStructural {
+		isStructural := in.Confidence >= 1.0 && !in.Informational
+		switch {
+		case in.Informational:
+			// Worth showing, but neither a proven problem nor a candidate to fix —
+			// pkg/check never grades these either. Counted in neither bucket.
+		case isStructural:
 			structural++
-		} else {
+		default:
 			candidate++
 		}
+		var action string
+		if len(in.Actions) > 0 {
+			action = in.Actions[0]
+		}
 		bySource[in.Source] = append(bySource[in.Source], insightRow{
-			Title:      in.Title,
-			Confidence: conf,
-			Structural: isStructural,
-			Evidence:   firstEvidence(in.Evidence),
+			Title:         in.Title,
+			Confidence:    conf,
+			Structural:    isStructural,
+			Informational: in.Informational,
+			Evidence:      firstEvidence(in.Evidence),
+			Action:        action,
 		})
 	}
 
@@ -130,16 +152,38 @@ func insightDetails(ins []facts.Insight, labels map[string]string) (groups []ins
 			}
 			return items[i].Title < items[j].Title
 		})
+		hasStructural := false
+		for _, it := range items {
+			if it.Structural {
+				hasStructural = true
+				break
+			}
+		}
+		shown, hidden := items, 0
+		if len(items) > insightGroupPreviewCap {
+			shown = items[:insightGroupPreviewCap]
+			hidden = len(items) - insightGroupPreviewCap
+		}
 		groups = append(groups, insightGroup{
-			Source: source,
-			Label:  labels[source],
-			Count:  len(items),
-			BarPct: int(math.Round(float64(len(items)) / float64(maxCount) * 100)),
-			Items:  items,
+			Source:        source,
+			Label:         labels[source],
+			Count:         len(items),
+			BarPct:        int(math.Round(float64(len(items)) / float64(maxCount) * 100)),
+			HasStructural: hasStructural,
+			Items:         items,
+			Shown:         shown,
+			Hidden:        hidden,
 		})
 	}
 
+	// Groups with a proven finding rank first regardless of size — a repo's one
+	// real dependency cycle matters more than its twenty-five heuristic god-class
+	// candidates, and burying it under bigger buckets is exactly what made this
+	// list feel like noise instead of guidance.
 	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].HasStructural != groups[j].HasStructural {
+			return groups[i].HasStructural
+		}
 		if groups[i].Count != groups[j].Count {
 			return groups[i].Count > groups[j].Count
 		}

--- a/pkg/dashboard/insights.go
+++ b/pkg/dashboard/insights.go
@@ -17,9 +17,10 @@ const insightGroupPreviewCap = 5
 // insightRow is one insight in a category group of the Insights modal.
 type insightRow struct {
 	Title         string
-	Confidence    int  // 0-100
-	Structural    bool // confidence >= 1.0 and not Informational — a proven, non-heuristic finding
-	Informational bool // describes the architecture rather than flagging a problem; never gradeable (see pkg/check)
+	Confidence    int    // 0-100
+	Band          string // structural | high | medium | low | informational
+	Structural    bool   // confidence >= 1.0 and not Informational — a proven, non-heuristic finding
+	Informational bool   // describes the architecture rather than flagging a problem; never gradeable (see pkg/check)
 	Evidence      string
 	Action        string // the finding's first suggested action, if any — the concrete "what to do about it"
 }
@@ -30,8 +31,8 @@ type insightGroup struct {
 	Source        string
 	Label         string
 	Count         int
-	BarPct        int  // 0-100, relative to the largest group
-	HasStructural bool // true if any item is a proven (Structural) finding — ranks the group ahead of larger but purely heuristic ones
+	BarPct        int          // 0-100, relative to the largest group
+	HasStructural bool         // true if any item is a proven (Structural) finding — ranks the group ahead of larger but purely heuristic ones
 	Items         []insightRow // full list, for the modal
 	Shown         []insightRow // capped to insightGroupPreviewCap, for the overview
 	Hidden        int          // len(Items) - len(Shown)
@@ -115,13 +116,21 @@ func insightDetails(ins []facts.Insight, labels map[string]string) (groups []ins
 		}
 		conf := int(math.Round(in.Confidence * 100))
 		isStructural := in.Confidence >= 1.0 && !in.Informational
+		band := "low"
 		switch {
 		case in.Informational:
+			band = "informational"
 			// Worth showing, but neither a proven problem nor a candidate to fix —
 			// pkg/check never grades these either. Counted in neither bucket.
 		case isStructural:
+			band = "structural"
 			structural++
 		default:
+			if in.Confidence >= 0.85 {
+				band = "high"
+			} else if in.Confidence >= 0.65 {
+				band = "medium"
+			}
 			candidate++
 		}
 		var action string
@@ -131,6 +140,7 @@ func insightDetails(ins []facts.Insight, labels map[string]string) (groups []ins
 		bySource[in.Source] = append(bySource[in.Source], insightRow{
 			Title:         in.Title,
 			Confidence:    conf,
+			Band:          band,
 			Structural:    isStructural,
 			Informational: in.Informational,
 			Evidence:      firstEvidence(in.Evidence),

--- a/pkg/dashboard/modulegraph.go
+++ b/pkg/dashboard/modulegraph.go
@@ -26,6 +26,8 @@ type moduleNode struct {
 type moduleEdge struct {
 	Source, Target         int
 	X1, Y1, X2, Y2         int
+	Curve                  bool // true when the target is not in a later column: a back or same-layer edge
+	CX, CY                 int  // quadratic control point, set only when Curve is true
 	SourceName, TargetName string
 	SourceFile, TargetFile string
 	Kind                   string
@@ -211,7 +213,41 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 			}
 			i := index[r.name]
 			a, b := view.Nodes[i], view.Nodes[j]
-			view.Edges = append(view.Edges, moduleEdge{Source: i, Target: j, X1: a.X + nodeW, Y1: a.Y + nodeH/2, X2: b.X, Y2: b.Y + nodeH/2, SourceName: a.Name, TargetName: b.Name, SourceFile: a.File, TargetFile: b.File, Kind: facts.RelImports})
+			edge := moduleEdge{Source: i, Target: j, SourceName: a.Name, TargetName: b.Name, SourceFile: a.File, TargetFile: b.File, Kind: facts.RelImports}
+			if b.X > a.X {
+				edge.X1, edge.Y1 = a.X+nodeW, a.Y+nodeH/2
+				edge.X2, edge.Y2 = b.X, b.Y+nodeH/2
+			} else {
+				// b is in the same column as a, or an earlier one (a cycle, or a
+				// forward-ranked node pointing back into one). A straight line from
+				// a's right edge to b's left edge would cross every node stacked
+				// between them, so loop it out past both nodes' right edges instead.
+				edge.Curve = true
+				edge.X1, edge.Y1 = a.X+nodeW, a.Y+nodeH/2
+				edge.X2, edge.Y2 = b.X+nodeW, b.Y+nodeH/2
+				rim := a.X + nodeW
+				if b.X+nodeW > rim {
+					rim = b.X + nodeW
+				}
+				dy := edge.Y2 - edge.Y1
+				if dy < 0 {
+					dy = -dy
+				}
+				// Nest the arcs by vertical span, like an arc diagram: edges spanning
+				// many rows bow further out than edges between neighbors. A fixed
+				// bow made every back-edge in a tangled column converge on the same
+				// curve, reading as one thick cable instead of distinct edges.
+				bow := 20 + dy/3
+				if max := nodeW + gapX/2; bow > max {
+					bow = max
+				}
+				edge.CX = rim + bow
+				edge.CY = (edge.Y1 + edge.Y2) / 2
+			}
+			if edge.CX+margin > view.Width {
+				view.Width = edge.CX + margin
+			}
+			view.Edges = append(view.Edges, edge)
 		}
 	}
 	sortEdgesByEndpoints(view.Edges)
@@ -228,6 +264,9 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 		view.Edges = view.Edges[:moduleGraphOverviewEdges]
 		sortEdgesByEndpoints(view.Edges)
 	}
+	// Paint wide arcs first so the tighter arcs and straight lines nested inside
+	// them (CX is 0 on straight edges) land on top and stay readable.
+	sort.SliceStable(view.Edges, func(i, j int) bool { return view.Edges[i].CX > view.Edges[j].CX })
 	return view
 }
 

--- a/pkg/dashboard/modulegraph.go
+++ b/pkg/dashboard/modulegraph.go
@@ -1,9 +1,11 @@
 package dashboard
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/enola-labs/enola/internal/explainers/common"
 	"github.com/enola-labs/enola/pkg/facts"
 )
 
@@ -18,9 +20,16 @@ type moduleNode struct {
 	ID                        int
 	Name, Display, File, Repo string
 	Role                      string
+	Members                   []string // non-nil only when Role == "cluster"
+	Tooltip                   string
 	X, Y                      int
 	FanIn, FanOut             int
 	Degree                    int
+}
+
+// MembersAttr renders Members for the "data-members" HTML attribute.
+func (n moduleNode) MembersAttr() string {
+	return strings.Join(n.Members, "|")
 }
 
 type moduleEdge struct {
@@ -44,6 +53,7 @@ type moduleGraphView struct {
 	Focused             bool
 	FocusName           string
 	OmittedEdges        int
+	ClusterCount        int
 }
 
 type moduleRaw struct {
@@ -163,6 +173,9 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 	const nodeW, nodeH, gapX, gapY, margin = 154, 36, 72, 34, 28
 	layers := make(map[string]int, len(ranked))
 	roles := make(map[string]string, len(ranked))
+	var clusters map[string][]string  // representative name -> sorted member names
+	var clusterOf map[string]string   // member name -> representative name
+	var clusterStats map[string][2]int // representative name -> [external fan-in, external fan-out]
 	if focused {
 		for _, r := range ranked {
 			switch {
@@ -175,43 +188,85 @@ func buildModuleGraphFocused(store *facts.Store, focus string) *moduleGraphView 
 			}
 		}
 	} else {
-		layers = dependencyLayers(ranked)
+		layers, clusters, clusterOf, clusterStats = condenseCycles(ranked)
 		for _, r := range ranked {
 			roles[r.name] = "module"
 		}
 	}
-	byLayer := map[int][]*moduleRaw{}
+	resolve := func(name string) string {
+		if id, ok := clusterOf[name]; ok {
+			return id
+		}
+		return name
+	}
+	byRankedName := make(map[string]*moduleRaw, len(ranked))
+	for _, r := range ranked {
+		byRankedName[r.name] = r
+	}
+	byLayer := map[int][]string{}
+	seen := map[string]bool{}
 	maxLayer, maxRows := 0, 0
 	for _, r := range ranked {
-		layer := layers[r.name]
-		byLayer[layer] = append(byLayer[layer], r)
+		id := resolve(r.name)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		layer := layers[id]
+		byLayer[layer] = append(byLayer[layer], id)
 		if layer > maxLayer {
 			maxLayer = layer
 		}
 	}
-	for _, rs := range byLayer {
-		if len(rs) > maxRows {
-			maxRows = len(rs)
+	for _, ids := range byLayer {
+		if len(ids) > maxRows {
+			maxRows = len(ids)
 		}
 	}
-	view := &moduleGraphView{Width: margin*2 + (maxLayer+1)*nodeW + maxLayer*gapX, Height: margin*2 + maxRows*nodeH + (maxRows-1)*gapY, AllModules: allModules, AllModulesTruncated: truncated, Total: total, Limited: total > len(ranked), Focused: focused, FocusName: focus}
-	index := make(map[string]int, len(ranked))
+	view := &moduleGraphView{Width: margin*2 + (maxLayer+1)*nodeW + maxLayer*gapX, Height: margin*2 + maxRows*nodeH + (maxRows-1)*gapY, AllModules: allModules, AllModulesTruncated: truncated, Total: total, Limited: total > len(ranked), Focused: focused, FocusName: focus, ClusterCount: len(clusters)}
+	index := make(map[string]int, len(seen))
 	for layer := 0; layer <= maxLayer; layer++ {
-		for row, r := range byLayer[layer] {
+		for row, id := range byLayer[layer] {
 			i := len(view.Nodes)
 			x := margin + layer*(nodeW+gapX)
 			y := margin + row*(nodeH+gapY)
-			view.Nodes = append(view.Nodes, moduleNode{ID: i, Name: r.name, Display: moduleLabel(r.name), File: r.file, Repo: r.repo, Role: roles[r.name], X: x, Y: y, FanIn: r.in, FanOut: len(r.out), Degree: r.in + len(r.out)})
-			index[r.name] = i
+			node := moduleNode{ID: i, X: x, Y: y}
+			if members, ok := clusters[id]; ok {
+				stats := clusterStats[id]
+				node.Name, node.Display, node.Role, node.Members = id, clusterLabel(id, members), "cluster", members
+				node.Tooltip = clusterTooltip(members)
+				node.FanIn, node.FanOut, node.Degree = stats[0], stats[1], stats[0]+stats[1]
+			} else {
+				r := byRankedName[id]
+				node.Name, node.Display, node.File, node.Repo = r.name, moduleLabel(r.name), r.file, r.repo
+				node.Role = roles[id]
+				node.Tooltip = r.name
+				node.FanIn, node.FanOut, node.Degree = r.in, len(r.out), r.in+len(r.out)
+			}
+			view.Nodes = append(view.Nodes, node)
+			index[id] = i
 		}
 	}
+	drawn := map[[2]int]bool{}
 	for _, r := range ranked {
+		srcID := resolve(r.name)
 		for target := range r.out {
-			j, ok := index[target]
+			tgtID := resolve(target)
+			if srcID == tgtID {
+				continue // intra-cluster edge; represented by the single node itself
+			}
+			i, ok := index[srcID]
 			if !ok {
 				continue
 			}
-			i := index[r.name]
+			j, ok := index[tgtID]
+			if !ok {
+				continue
+			}
+			if drawn[[2]int{i, j}] {
+				continue
+			}
+			drawn[[2]int{i, j}] = true
 			a, b := view.Nodes[i], view.Nodes[j]
 			edge := moduleEdge{Source: i, Target: j, SourceName: a.Name, TargetName: b.Name, SourceFile: a.File, TargetFile: b.File, Kind: facts.RelImports}
 			if b.X > a.X {
@@ -323,6 +378,112 @@ func dependencyLayers(ranked []*moduleRaw) map[string]int {
 		}
 	}
 	return layers
+}
+
+// condenseCycles collapses each strongly-connected component of more than one
+// module into a single supernode named after its most-connected member, so
+// the graph handed to dependencyLayers is always acyclic — the condensation of
+// any directed graph has no cycles, so every resulting layer edge is strictly
+// forward. Returns per-id layers (real module names for unclustered modules,
+// the representative's name for a cluster), the cluster's member lists keyed
+// by representative, the member->representative mapping, and each cluster's
+// external [fan-in, fan-out] counts (edges to/from modules outside it, after
+// resolving cluster membership — not the representative's own raw in/out,
+// which would still count the now-hidden intra-cluster edges).
+func condenseCycles(ranked []*moduleRaw) (layers map[string]int, clusters map[string][]string, clusterOf map[string]string, stats map[string][2]int) {
+	visible := make(map[string]bool, len(ranked))
+	byName := make(map[string]*moduleRaw, len(ranked))
+	for _, r := range ranked {
+		visible[r.name] = true
+		byName[r.name] = r
+	}
+	graph := make(map[string][]string, len(ranked))
+	for _, r := range ranked {
+		var out []string
+		for target := range r.out {
+			if visible[target] && target != r.name {
+				out = append(out, target)
+			}
+		}
+		graph[r.name] = out
+	}
+
+	clusterOf = make(map[string]string)
+	clusters = make(map[string][]string)
+	for _, members := range common.StronglyConnectedComponents(graph) {
+		if len(members) < 2 {
+			continue
+		}
+		sorted := append([]string(nil), members...)
+		sort.Strings(sorted)
+		rep, repDegree := sorted[0], -1
+		for _, m := range sorted {
+			if d := byName[m].in + len(byName[m].out); d > repDegree || (d == repDegree && m < rep) {
+				repDegree, rep = d, m
+			}
+		}
+		clusters[rep] = sorted
+		for _, m := range sorted {
+			clusterOf[m] = rep
+		}
+	}
+
+	resolve := func(name string) string {
+		if id, ok := clusterOf[name]; ok {
+			return id
+		}
+		return name
+	}
+	condensed := make(map[string]*moduleRaw, len(ranked))
+	for _, r := range ranked {
+		id := resolve(r.name)
+		c, ok := condensed[id]
+		if !ok {
+			c = &moduleRaw{name: id, out: map[string]bool{}}
+			condensed[id] = c
+		}
+		for target := range r.out {
+			if !visible[target] {
+				continue
+			}
+			if rt := resolve(target); rt != id {
+				c.out[rt] = true
+			}
+		}
+	}
+	condensedRanked := make([]*moduleRaw, 0, len(condensed))
+	for _, c := range condensed {
+		condensedRanked = append(condensedRanked, c)
+	}
+	sort.Slice(condensedRanked, func(i, j int) bool { return condensedRanked[i].name < condensedRanked[j].name })
+
+	stats = make(map[string][2]int, len(clusters))
+	if len(clusters) > 0 {
+		fanIn := make(map[string]int, len(condensed))
+		for _, c := range condensed {
+			for target := range c.out {
+				fanIn[target]++
+			}
+		}
+		for rep := range clusters {
+			stats[rep] = [2]int{fanIn[rep], len(condensed[rep].out)}
+		}
+	}
+	return dependencyLayers(condensedRanked), clusters, clusterOf, stats
+}
+
+// clusterLabel formats the display text for a collapsed cyclic cluster, named
+// after its most-connected member with a count of the others folded into it.
+// The ⟲ glyph is a self-explanatory visual flag: dashed borders alone are easy
+// to miss or forget the meaning of at a glance.
+func clusterLabel(rep string, members []string) string {
+	return fmt.Sprintf("⟲ %s +%d", moduleLabel(rep), len(members)-1)
+}
+
+// clusterTooltip is the hover title for a cluster node — it names every
+// member up front, since the collapsed label alone only names one of them.
+func clusterTooltip(members []string) string {
+	return fmt.Sprintf("%d modules import each other in a cycle: %s\nClick to see them, or click a name to explore just that one.", len(members), strings.Join(members, ", "))
 }
 
 func moduleLabel(name string) string {

--- a/pkg/dashboard/modulegraph_test.go
+++ b/pkg/dashboard/modulegraph_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestBuildModuleGraphRanksBoundsAndLinks(t *testing.T) {
 	st := facts.NewStore()
 	st.Add(
 		facts.Fact{Kind: facts.KindModule, Name: "core", File: "src/core", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "api"}, {Kind: facts.RelImports, Target: "storage"}}},
-		facts.Fact{Kind: facts.KindModule, Name: "api", File: "src/api", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "core"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "api", File: "src/api", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "storage"}}},
 		facts.Fact{Kind: facts.KindModule, Name: "storage", File: "src/storage"},
 		facts.Fact{Kind: facts.KindModule, Name: "core_test", File: "tests/core", Props: map[string]any{facts.PropModuleRole: facts.ModuleRoleTest}, Relations: []facts.Relation{{Kind: facts.RelImports, Target: "core"}}},
 	)
@@ -23,8 +24,8 @@ func TestBuildModuleGraphRanksBoundsAndLinks(t *testing.T) {
 	if view == nil || len(view.Nodes) != 3 || len(view.Edges) != 3 {
 		t.Fatalf("view = %+v, want 3 production nodes and 3 directed edges", view)
 	}
-	if view.Nodes[0].Name != "core" || view.Nodes[0].FanIn != 1 || view.Nodes[0].FanOut != 2 {
-		t.Errorf("top node = %+v, want core with fan-in 1 / fan-out 2", view.Nodes[0])
+	if view.Nodes[0].Name != "core" || view.Nodes[0].FanIn != 0 || view.Nodes[0].FanOut != 2 {
+		t.Errorf("top node = %+v, want core with fan-in 0 / fan-out 2", view.Nodes[0])
 	}
 }
 
@@ -130,6 +131,65 @@ func TestBuildModuleGraphLayersConsumersBeforeDependencies(t *testing.T) {
 	}
 }
 
+func TestBuildModuleGraphCondensesCyclesIntoClusterNode(t *testing.T) {
+	st := facts.NewStore()
+	st.Add(
+		facts.Fact{Kind: facts.KindModule, Name: "a", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "b"}, {Kind: facts.RelImports, Target: "db"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "b", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "c"}, {Kind: facts.RelImports, Target: "db"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "c", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "a"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "app", Relations: []facts.Relation{{Kind: facts.RelImports, Target: "a"}}},
+		facts.Fact{Kind: facts.KindModule, Name: "db"},
+	)
+
+	view := buildModuleGraph(st)
+	if view == nil {
+		t.Fatal("view is nil")
+	}
+
+	var cluster *moduleNode
+	for i := range view.Nodes {
+		if view.Nodes[i].Role == "cluster" {
+			if cluster != nil {
+				t.Fatalf("found more than one cluster node: %+v and %+v", *cluster, view.Nodes[i])
+			}
+			cluster = &view.Nodes[i]
+		}
+	}
+	if cluster == nil {
+		t.Fatalf("view = %+v, want one cluster node for the a/b/c cycle", view)
+	}
+	members := append([]string(nil), cluster.Members...)
+	sort.Strings(members)
+	if fmt.Sprint(members) != fmt.Sprint([]string{"a", "b", "c"}) {
+		t.Fatalf("cluster members = %v, want [a b c]", members)
+	}
+	if !strings.Contains(cluster.Display, "+2") {
+		t.Fatalf("cluster display = %q, want it to mention +2 (b and c folded in)", cluster.Display)
+	}
+
+	// The condensation of any cyclic graph is acyclic, so every drawn edge
+	// must run strictly left to right — this is the concrete check that the
+	// original tangle (same-column back-edges) can no longer occur.
+	for _, e := range view.Edges {
+		if view.Nodes[e.Source].X >= view.Nodes[e.Target].X {
+			t.Errorf("edge %+v is not forward: source X=%d, target X=%d", e, view.Nodes[e.Source].X, view.Nodes[e.Target].X)
+		}
+	}
+
+	seen := map[[2]int]int{}
+	for _, e := range view.Edges {
+		seen[[2]int{e.Source, e.Target}]++
+	}
+	for pair, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate edge %v drawn %d times", pair, count)
+		}
+	}
+	if len(view.Edges) != 2 {
+		t.Fatalf("edges = %+v, want exactly app->cluster and cluster->db, deduped from the two members (a and b) that both point at db", view.Edges)
+	}
+}
+
 func TestBuildModuleGraphCapsLargeRepositories(t *testing.T) {
 	st := facts.NewStore()
 	for i := 0; i < moduleGraphLimit+10; i++ {
@@ -148,7 +208,7 @@ func TestBuildModuleGraphCapsOverviewEdges(t *testing.T) {
 	for i := 0; i < moduleGraphOverviewLimit; i++ {
 		relations := make([]facts.Relation, 0, moduleGraphOverviewLimit-1)
 		for j := 0; j < moduleGraphOverviewLimit; j++ {
-			if i != j {
+			if i < j {
 				relations = append(relations, facts.Relation{Kind: facts.RelImports, Target: fmt.Sprintf("m%02d", j)})
 			}
 		}

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -125,10 +125,12 @@
     .module-node text { fill: #cbd3eb; font: 10px ui-monospace, SFMono-Regular, Menlo, monospace; pointer-events: none; }
     .module-node:hover rect, .module-node.active rect { fill: #172657; stroke: #7d92e4; }
     .module-node[data-role="selected"] rect { fill: #23336b; stroke: #9b75e8; stroke-width: 2; }
+    .module-node[data-role="cluster"] rect { fill: #241c46; stroke: #8b6fe0; stroke-dasharray: 4 3; }
     .module-node.dim, .module-edge.dim { opacity: .12; }
     .module-edge.active { opacity: .9; stroke: #9b75e8; stroke-width: 1.8; }
     .module-detail { display: none; padding: .9rem 1rem; background: #0a1432; }
     .module-detail.open { display: block; }
+    .module-detail-members { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .6rem; }
     .module-detail b { display: block; font-size: .82rem; }
     .module-detail span { color: #8f9bbb; font-size: .7rem; }
     .module-stats { display: flex; flex-wrap: wrap; gap: .35rem .8rem; margin-top: .65rem; font: .65rem ui-monospace, SFMono-Regular, Menlo, monospace; color: #9bb4f5; }
@@ -204,6 +206,7 @@
     .insight-group .table-scroll { padding: .1rem .3rem .4rem; }
     td.title { white-space: normal; }
     .structural-chip { margin-left: .4rem; font-size: .72rem; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 0 .35rem; }
+    .finding-action { color: var(--muted); font-size: .78rem; margin-top: .15rem; }
     {{/* extra-styles: extension slot — see pkg/dashboard.Options.Overlay */}}
     {{block "extra-styles" $}}{{end}}
   </style>
@@ -242,10 +245,12 @@
   {{if .Insights}}<div class="data-section">
     <div class="section-kicker">Current snapshot</div><h2>Findings</h2>
     <p class="insight-summary">{{.InsightStructural}} structural · {{.InsightCandidate}} candidate{{if ne .InsightCandidate 1}}s{{end}}</p>
-    {{range .Insights}}<details class="insight-group" open>
-      <summary><span class="ig-label">{{.Label}}</span><span class="ig-count">{{.Count}}</span></summary>
+    {{range $i, $g := .Insights}}<details class="insight-group"{{if or (eq $i 0) $g.HasStructural}} open{{end}}>
+      <summary><span class="ig-label">{{$g.Label}}</span><span class="ig-count">{{$g.Count}}</span></summary>
       <div class="table-scroll"><table><thead><tr><th>Finding</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
-      <tbody>{{range .Items}}<tr><td class="title">{{.Title}}</td><td class="num">{{.Confidence}}%</td><td>{{.Evidence}}</td></tr>{{end}}</tbody></table></div>
+      <tbody>{{range $g.Shown}}<tr><td class="title">{{.Title}}{{if .Action}}<div class="finding-action">→ {{.Action}}</div>{{end}}</td><td class="num">{{.Confidence}}%</td><td>{{.Evidence}}</td></tr>{{end}}</tbody></table>
+      {{if $g.Hidden}}<button type="button" class="count-link" onclick="openModal('insights-modal')">+{{$g.Hidden}} more — review all</button>{{end}}
+      </div>
     </details>{{end}}
   </div>{{else if .HasReceipt}}<div class="data-section"><div class="section-kicker">Current snapshot</div><h2>No findings</h2><p class="note">Enola found no structural issues or review candidates in this snapshot.</p></div>{{end}}
 
@@ -302,8 +307,9 @@
     {{if $graph.Focused}}<span class="chip">Neighborhood of {{$graph.FocusName}}</span>{{else}}<span class="chip">Showing {{len $graph.Nodes}} of {{$graph.Total}} connected modules</span>{{end}}
     <span class="chip">{{len $graph.Edges}} visible module dependencies{{if $graph.OmittedEdges}} · {{$graph.OmittedEdges}} hidden for clarity{{end}}</span>
     {{if not $graph.Focused}}<span class="chip">Layered by dependency direction</span>{{end}}
+    {{if $graph.ClusterCount}}<span class="chip">{{$graph.ClusterCount}} cyclic cluster{{if ne $graph.ClusterCount 1}}s{{end}} collapsed</span>{{end}}
   </div>
-  <p class="note">Search covers {{if $graph.AllModulesTruncated}}the {{len $graph.AllModules}} most-connected of {{$graph.Total}}{{else}}all {{$graph.Total}}{{end}} connected modules. {{if $graph.Focused}}This view contains the selected module, its immediate incoming and outgoing dependencies, and the dependencies between them. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}</p>
+  <p class="note">Search covers {{if $graph.AllModulesTruncated}}the {{len $graph.AllModules}} most-connected of {{$graph.Total}}{{else}}all {{$graph.Total}}{{end}} connected modules. {{if $graph.Focused}}This view contains the selected module, its immediate incoming and outgoing dependencies, and the dependencies between them. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}{{if $graph.ClusterCount}} Dashed ⟲ nodes are modules that import each other in a cycle, folded into one box so the map stays readable — click one to see its members, then click a member to explore it on its own.{{end}}</p>
   <section class="explorer" aria-label="Architecture explorer">
     <div class="graph-pane">
       {{if $graph.Focused}}<div class="graph-columns"><span>Consumers</span><span>Selected module</span><span>Dependencies</span></div>{{end}}
@@ -311,7 +317,7 @@
         <svg class="module-graph" width="{{$graph.Width}}" height="{{$graph.Height}}" viewBox="0 0 {{$graph.Width}} {{$graph.Height}}" role="img" aria-label="Module dependency graph">
           <defs><marker id="module-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#536a9f"/></marker></defs>
           {{range $graph.Edges}}{{if .Curve}}<path class="module-edge-hit" data-source="{{.Source}}" data-target="{{.Target}}" data-source-name="{{.SourceName}}" data-target-name="{{.TargetName}}" data-source-file="{{.SourceFile}}" data-target-file="{{.TargetFile}}" data-kind="{{.Kind}}" d="M{{.X1}},{{.Y1}} Q{{.CX}},{{.CY}} {{.X2}},{{.Y2}}" onclick="selectDependency(this)"/><path class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" d="M{{.X1}},{{.Y1}} Q{{.CX}},{{.CY}} {{.X2}},{{.Y2}}" marker-end="url(#module-arrow)"/>{{else}}<line class="module-edge-hit" data-source="{{.Source}}" data-target="{{.Target}}" data-source-name="{{.SourceName}}" data-target-name="{{.TargetName}}" data-source-file="{{.SourceFile}}" data-target-file="{{.TargetFile}}" data-kind="{{.Kind}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" onclick="selectDependency(this)"/><line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}{{end}}
-          {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-role="{{.Role}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" onclick="selectModule(this)"><title>{{.Name}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
+          {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-role="{{.Role}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" data-members="{{.MembersAttr}}" onclick="selectModule(this)"><title>{{.Tooltip}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
         </svg>
       </div>
       {{if $graph.Limited}}<div class="graph-note">{{if $graph.Focused}}This neighborhood is bounded to keep individual relationships inspectable.{{else}}This overview shows the most-connected modules and a representative dependency backbone. Search for any module to inspect its complete immediate neighborhood.{{end}}</div>{{end}}
@@ -319,7 +325,7 @@
     <aside class="inspector-pane" aria-label="Architecture inspector">
       <div class="inspector-head"><h3>Inspector</h3><p>Select a module, dependency, or finding to inspect it.</p></div>
       <div id="inspector-empty" class="inspector-empty">Nothing selected. Choose a node or edge on the map.</div>
-      <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div></div>
+      <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div><div id="module-detail-members" class="module-detail-members" hidden></div></div>
       {{if .Insights}}<div class="findings-pane">
       <h3>Findings <span class="note">({{.InsightTotal}})</span> <button type="button" class="count-link" onclick="openModal('insights-modal')">review all</button></h3>
       <div class="findings-groups">{{range .Insights}}
@@ -602,7 +608,7 @@
       <div class="table-scroll"><table>
         <thead><tr><th>Title</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
         <tbody>
-          {{range .Items}}<tr data-conf="{{.Confidence}}"><td class="title">{{.Title}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip">structural</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
+          {{range .Items}}<tr data-conf="{{.Confidence}}"><td class="title">{{.Title}}{{if .Action}}<div class="finding-action">→ {{.Action}}</div>{{end}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip">structural</span>{{else if .Informational}}<span class="structural-chip">context</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
         </tbody>
       </table></div>
     </details>
@@ -838,6 +844,28 @@
       document.getElementById('module-detail-file').textContent = node.getAttribute('data-file') || '';
       document.getElementById('module-detail-in').textContent = node.getAttribute('data-in') + ' consumer modules';
       document.getElementById('module-detail-out').textContent = node.getAttribute('data-out') + ' dependency modules';
+    }
+    var membersBox = document.getElementById('module-detail-members');
+    if (membersBox) {
+      var membersAttr = node.getAttribute('data-members');
+      membersBox.innerHTML = '';
+      membersBox.hidden = !membersAttr;
+      if (membersAttr) {
+        var hint = document.createElement('p');
+        hint.className = 'note';
+        hint.style.width = '100%';
+        hint.style.margin = '0 0 .1rem';
+        hint.textContent = 'These modules import each other in a cycle. Click one to explore just that module:';
+        membersBox.appendChild(hint);
+        membersAttr.split('|').forEach(function(name) {
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'count-link';
+          btn.textContent = name;
+          btn.onclick = function() { window.location.assign('/?module=' + encodeURIComponent(name) + '#architecture'); };
+          membersBox.appendChild(btn);
+        });
+      }
     }
   }
   function selectDependency(hit) {

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -99,6 +99,7 @@
     .explorer { display: grid; grid-template-columns: minmax(0, 1fr) 300px; min-height: 500px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: #07112d; }
     .inspector-pane { min-width: 0; border-left: 1px solid var(--border); background: #08112b; }
     .inspector-head { padding: .85rem 1rem; border-bottom: 1px solid var(--border); }
+    .inspector-head-row { display: flex; align-items: center; justify-content: space-between; gap: .5rem; }
     .inspector-head h3 { margin: 0; font-size: .88rem; }
     .inspector-head p { margin: .2rem 0 0; color: #7180aa; font-size: .68rem; }
     .inspector-empty { padding: .9rem 1rem; color: var(--muted); font-size: .75rem; }
@@ -323,7 +324,7 @@
       {{if $graph.Limited}}<div class="graph-note">{{if $graph.Focused}}This neighborhood is bounded to keep individual relationships inspectable.{{else}}This overview shows the most-connected modules and a representative dependency backbone. Search for any module to inspect its complete immediate neighborhood.{{end}}</div>{{end}}
     </div>
     <aside class="inspector-pane" aria-label="Architecture inspector">
-      <div class="inspector-head"><h3>Inspector</h3><p>Select a module, dependency, or finding to inspect it.</p></div>
+      <div class="inspector-head"><div class="inspector-head-row"><h3>Inspector</h3><button type="button" id="inspector-clear" class="count-link" hidden onclick="clearInspector()">Clear selection</button></div><p>Select a module, dependency, or finding to inspect it.</p></div>
       <div id="inspector-empty" class="inspector-empty">Nothing selected. Choose a node or edge on the map.</div>
       <div id="module-detail" class="module-detail"><div><b id="module-detail-name"></b><span id="module-detail-file"></span></div><div class="module-stats"><span id="module-detail-in"></span><span id="module-detail-out"></span></div><div id="module-detail-members" class="module-detail-members" hidden></div></div>
       {{if .Insights}}<div class="findings-pane">
@@ -812,9 +813,21 @@
   function openInspector() {
     var empty = document.getElementById('inspector-empty');
     var detail = document.getElementById('module-detail');
+    var clearBtn = document.getElementById('inspector-clear');
     if (empty) empty.hidden = true;
     if (detail) detail.classList.add('open');
+    if (clearBtn) clearBtn.hidden = false;
     return detail;
+  }
+  function clearInspector() {
+    clearGraphFocus();
+    document.querySelectorAll('.finding-button').forEach(function(b) { b.classList.remove('active'); });
+    var detail = document.getElementById('module-detail');
+    var empty = document.getElementById('inspector-empty');
+    var clearBtn = document.getElementById('inspector-clear');
+    if (detail) detail.classList.remove('open');
+    if (empty) empty.hidden = false;
+    if (clearBtn) clearBtn.hidden = true;
   }
   function toggleGraphFit(button) {
     var canvas = document.querySelector('.graph-canvas');

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -217,6 +217,7 @@
   <div class="topbar">
     <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span>{{if .HasReceipt}} <span class="note">· {{.Snapshot.RepoName}}{{if .Snapshot.Age}} · updated {{.Snapshot.Age}}{{end}}</span>{{end}}</h1></div>
     <div class="top-actions">
+      <span class="note" id="refresh-status" title="Auto-checks for a new snapshot every 5s"></span>
       <button class="secondary-action" type="button" onclick="refreshSnapshot(true)" title="Reload the latest snapshot from disk">Refresh</button>
     </div>
   </div>
@@ -253,7 +254,7 @@
       {{if $g.Hidden}}<button type="button" class="count-link" onclick="openModal('insights-modal')">+{{$g.Hidden}} more — review all</button>{{end}}
       </div>
     </details>{{end}}
-  </div>{{else if .HasReceipt}}<div class="data-section"><div class="section-kicker">Current snapshot</div><h2>No findings</h2><p class="note">Enola found no structural issues or review candidates in this snapshot.</p></div>{{end}}
+  </div>{{else if .HasReceipt}}<div class="data-section"><div class="section-kicker">Current snapshot</div><h2>No findings</h2><p class="note">No structural issues or review candidates found.</p></div>{{end}}
 
   <div class="data-section">
     <div class="section-kicker">Development feedback</div><h2>What changed?</h2>
@@ -261,7 +262,7 @@
       {{if .Changes.Incomparable}}
       <div class="snapshot-alert"><b>Comparison unavailable.</b> The current and previous snapshots used different extraction inputs, so their raw deltas would describe rebuild noise rather than a trustworthy code change.</div>
       {{else if .Changes.Initial}}
-      <p class="note">This is the first recorded architecture snapshot. The next snapshot will provide a change comparison.</p>
+      <p class="note">First recorded snapshot. The next one will show a comparison.</p>
       {{else}}
       <p class="note">Compared with the {{.Changes.ComparedTo}} · {{.Changes.Headline}}</p>
       <div class="grid">
@@ -271,7 +272,7 @@
         <div class="card"><div class="k">Dependencies added / removed</div><div class="v">+{{.Changes.EdgesAdded}} / −{{.Changes.EdgesRemoved}}</div></div>
       </div>
       {{end}}
-    {{else}}<p class="note">No earlier architecture snapshot is available yet. Generate another snapshot after a change to start tracking deltas.</p>{{end}}
+    {{else}}<p class="note">No earlier snapshot yet. Generate one after a change to track deltas.</p>{{end}}
   </div>
 
   <div class="grid">
@@ -310,7 +311,7 @@
     {{if not $graph.Focused}}<span class="chip">Layered by dependency direction</span>{{end}}
     {{if $graph.ClusterCount}}<span class="chip">{{$graph.ClusterCount}} cyclic cluster{{if ne $graph.ClusterCount 1}}s{{end}} collapsed</span>{{end}}
   </div>
-  <p class="note">Search covers {{if $graph.AllModulesTruncated}}the {{len $graph.AllModules}} most-connected of {{$graph.Total}}{{else}}all {{$graph.Total}}{{end}} connected modules. {{if $graph.Focused}}This view contains the selected module, its immediate incoming and outgoing dependencies, and the dependencies between them. <a href="/#architecture">Clear focus</a>.{{else}}Choose a module to replace this overview with its immediate dependency neighborhood.{{end}}{{if $graph.ClusterCount}} Dashed ⟲ nodes are modules that import each other in a cycle, folded into one box so the map stays readable — click one to see its members, then click a member to explore it on its own.{{end}}</p>
+  <p class="note">Search covers {{if $graph.AllModulesTruncated}}the {{len $graph.AllModules}} most-connected of {{$graph.Total}}{{else}}all {{$graph.Total}}{{end}} connected modules. {{if $graph.Focused}}Shows the selected module and its direct dependencies. <a href="/#architecture">Clear focus</a>.{{else}}Select a module to see its dependency neighborhood.{{end}}{{if $graph.ClusterCount}} Dashed ⟲ nodes group a cycle of modules — click for members.{{end}}</p>
   <section class="explorer" aria-label="Architecture explorer">
     <div class="graph-pane">
       {{if $graph.Focused}}<div class="graph-columns"><span>Consumers</span><span>Selected module</span><span>Dependencies</span></div>{{end}}
@@ -340,7 +341,7 @@
   </section>
 
   <div class="data-section"><h2>Most-connected modules in this view</h2>
-  <p class="note">These counts describe module imports. Symbol-level finding counts may be larger because many call sites can live inside one module.</p>
+  <p class="note">These are module-import counts. Symbol-level finding counts may be higher — one module can hold many call sites.</p>
   <div class="table-scroll"><table class="module-table">
     <thead><tr><th>Module</th><th>File</th><th class="num">Consumer modules</th><th class="num">Dependency modules</th><th class="num">Connections</th></tr></thead>
     <tbody>{{range $graph.Nodes}}<tr><td><button type="button" class="count-link" onclick="focusModule('{{.ID}}')">{{.Name}}</button></td><td>{{.File}}</td><td class="num">{{.FanIn}}</td><td class="num">{{.FanOut}}</td><td class="num">{{.Degree}}</td></tr>{{end}}</tbody>
@@ -372,10 +373,10 @@
     <div class="card"><div class="k">Extraction schema</div><div class="v">{{if .ExtractorVersion}}{{.ExtractorVersion}}{{else}}not recorded{{end}}</div></div>
     <div class="card"><div class="k">Analysis duration</div><div class="v">{{.Duration}}</div></div>
   </div>
-  {{if and .Git .Git.Dirty}}<p class="snapshot-alert">This snapshot was generated while the working tree had local changes. It describes that exact working state, not only commit <code>{{$.Snapshot.ShortCommit}}</code>.</p>{{end}}
+  {{if and .Git .Git.Dirty}}<p class="snapshot-alert">Generated with local changes present — reflects that working state, not just commit <code>{{$.Snapshot.ShortCommit}}</code>.</p>{{end}}
 
   <div class="data-section"><h2>Analysis scope</h2>
-    <p class="note">These extractors contributed facts. Quality details explain ignored and unsupported files.</p>
+    <p class="note">Extractors that contributed facts. See Quality for ignored and unsupported files.</p>
     {{if .Extractors}}<div class="chips">{{range .Extractors}}<span class="chip">{{.}}</span>{{end}}</div>{{else}}<p class="note">No extractors recorded.</p>{{end}}
     <p style="margin:.8rem 0 0"><button type="button" class="count-link" onclick="selectTab('quality')">Review analysis completeness →</button></p>
   </div>
@@ -429,7 +430,7 @@
 
   <section class="tab-panel" id="panel-diagnostics" role="tabpanel" aria-labelledby="tab-diagnostics" hidden>
   <div class="panel-intro"><div class="section-kicker">Troubleshooting</div><h2>Diagnostics</h2><p>Processes, paths, ports, and the exact data source for this page.</p></div>
-  <div class="snapshot-head"><div><h2>Active sessions</h2><p>{{len .Instances}} Enola process(es) running now. The highlighted row serves this page.</p></div></div>
+  <div class="snapshot-head"><div><h2>Active sessions</h2><p>{{len .Instances}} process(es) running. Highlighted row serves this page.</p></div></div>
   {{if .Instances}}<div class="table-scroll"><table>
     <thead><tr><th>Session</th><th>Repositories</th><th>Uptime</th><th class="num">Calls</th><th>Dashboard</th></tr></thead>
     <tbody>{{range .Instances}}<tr{{if .Self}} class="self-row"{{end}}><td>{{.Binary}} · PID {{.PID}}{{if .Self}} <span class="chip">this page</span>{{end}}</td><td>{{.Repos}}</td><td>{{.Uptime}}</td><td class="num">{{.Calls}}</td><td>{{if .URL}}<a href="{{.URL}}">open{{if .FrontDoor}} · shared{{end}}</a>{{else}}—{{end}}</td></tr>{{end}}</tbody>
@@ -458,7 +459,7 @@
     <div><h2>{{$.Quality.Status}}</h2><p>{{$.Quality.Summary}}</p></div>
     <span class="badge {{$.Quality.StatusClass}}">{{if .Quality.ParseErrors}}{{.Quality.ParseErrors}} error(s){{else}}{{if $.Quality.CoverageLabel}}{{$.Quality.CoverageLabel}}{{else}}no parse errors{{end}}{{end}}</span>
   </div>
-  {{if $.Quality.Inactive}}<div class="snapshot-alert"><b>Extractor coverage detail:</b> {{range $i, $cause := $.Quality.Inactive}}{{if $i}} · {{end}}{{$cause.Count}} file(s) {{$cause.Cause}}{{end}}. This affects {{$.Quality.InactiveShare}} of the {{$.Quality.FilesWalked}} files walked and does not mean the rest of the snapshot failed.</div>{{end}}
+  {{if $.Quality.Inactive}}<div class="snapshot-alert"><b>Extractor coverage detail:</b> {{range $i, $cause := $.Quality.Inactive}}{{if $i}} · {{end}}{{$cause.Count}} file(s) {{$cause.Cause}}{{end}}. Affects {{$.Quality.InactiveShare}} of {{$.Quality.FilesWalked}} files walked; the rest of the snapshot is unaffected.</div>{{end}}
 
   {{if .Quality.Census}}{{with .Quality.Census}}
   <h2>File accounting</h2>
@@ -469,20 +470,20 @@
     <div class="quality-item"><span class="k">Non-source / unsupported</span><span class="v">{{.ExcludedByKind}}</span><span class="why">Assets, data, or file types without an extractor.</span></div>
     <div class="quality-item"><span class="k">No facts emitted</span><span class="v">{{.SkippedWithCause}}</span><span class="why">Recognized files that contained no indexable structure.</span></div>
   </div>
-  <p class="accounting-note ok">These categories account for every walked file. Ignored and non-source files are not parse failures.</p>
+  <p class="accounting-note ok">Accounts for every walked file. Ignored and non-source files aren't parse failures.</p>
 
   {{if $.Quality.Potential}}<div class="data-section"><h2>Potential architecture blind spots</h2><p class="note">These file types can carry behavior or architecture, but are outside the current graph. Review whether they matter for this repository.</p><div class="table-scroll"><table>
     <thead><tr><th>File kind</th><th class="num">Files</th><th>Why review it</th></tr></thead>
     <tbody>{{range $.Quality.Potential}}<tr><td>{{.Kind}}</td><td class="num">{{.Count}}</td><td class="title">{{.Reason}}</td></tr>{{end}}</tbody>
   </table></div></div>{{end}}
 
-  {{if $.Quality.NoFacts}}<div class="data-section"><h2>Recognized files with no facts</h2><p class="note">These were analyzed successfully but contained no indexable architecture.</p><div class="table-scroll"><table>
+  {{if $.Quality.NoFacts}}<div class="data-section"><h2>Recognized files with no facts</h2><p class="note">Analyzed successfully; no indexable architecture found.</p><div class="table-scroll"><table>
     <thead><tr><th>Reason</th><th class="num">Files</th></tr></thead>
     <tbody>{{range $.Quality.NoFacts}}<tr><td>{{.Cause}}</td><td class="num">{{.Count}}</td></tr>{{end}}</tbody>
   </table></div></div>{{end}}
 
   {{if $.Quality.ExpectedFiles}}<details class="technical-receipt"><summary>Expected non-source exclusions · {{$.Quality.ExpectedFiles}} files across {{$.Quality.ExpectedKinds}} kinds</summary>
-    <p class="note">Assets, fixtures, snapshots, certificates, and other file kinds that normally do not define application architecture.</p>
+    <p class="note">Assets, fixtures, certs, and other files that don't usually define architecture.</p>
     <div class="table-scroll"><table><thead><tr><th>File kind</th><th class="num">Files</th></tr></thead><tbody>
     {{range $.Quality.Expected}}<tr><td>{{.Kind}}</td><td class="num">{{.Count}}</td></tr>{{end}}
     </tbody></table></div>
@@ -506,7 +507,7 @@
   </div></div>
   {{if gt .Quality.ParseErrors 0}}
   <div class="snapshot-alert">
-    <b>Possible extractor gap.</b> Enola could not parse {{.Quality.ParseErrors}} source file(s). If the files contain valid source, this may be an extractor bug.
+    <b>Possible extractor gap.</b> Could not parse {{.Quality.ParseErrors}} source file(s) — may be an extractor bug if the source is valid.
     <a class="secondary-action" style="display:inline-block;margin-left:.55rem;text-decoration:none" target="_blank" rel="noopener noreferrer" href="https://github.com/enola-labs/enola/issues/new?title=Extraction%20gap%20in%20snapshot%20{{.SnapshotID}}&amp;body=Snapshot%3A%20{{.SnapshotID}}%0AEnola%20version%3A%20{{.EnolaVersion}}%0AParse%20errors%3A%20{{.Quality.ParseErrors}}%0A%0APlease%20describe%20the%20valid%20source%20Enola%20could%20not%20parse.">Report extraction issue</a>
   </div>
   {{end}}
@@ -703,13 +704,21 @@
 {{block "extra-modals" $}}{{end}}
 
 <script>
+  function setRefreshStatus(text) {
+    var status = document.getElementById('refresh-status');
+    if (status) status.textContent = text;
+  }
   function refreshSnapshot(manual) {
     fetch('/api/refresh', {cache: 'no-store'})
       .then(function(response) { return response.json(); })
       .then(function(result) {
-        if (result.changed || manual) location.reload();
+        if (result.changed || manual) { location.reload(); return; }
+        setRefreshStatus('Checked ' + new Date().toLocaleTimeString());
       })
-      .catch(function() { if (manual) location.reload(); });
+      .catch(function() {
+        if (manual) { location.reload(); return; }
+        setRefreshStatus('Check failed');
+      });
   }
   function selectTab(name, updateHash) {
     var panel = document.getElementById('panel-' + name);
@@ -1007,6 +1016,7 @@
   window.addEventListener('hashchange', initialTab);
   initialTab();
   restoreFindingInspector();
+  setRefreshStatus('Checked ' + new Date().toLocaleTimeString());
   window.setInterval(function() { refreshSnapshot(false); }, 5000);
 </script>
 </body>

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -211,32 +211,43 @@
 <body>
 <div class="wrap">
   <div class="topbar">
-    <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span></h1></div>
+    <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span>{{if .HasReceipt}} <span class="note">· {{.Snapshot.RepoName}}{{if .Snapshot.Age}} · updated {{.Snapshot.Age}}{{end}}</span>{{end}}</h1></div>
     <div class="top-actions">
-      {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">not running</span>{{end}}
-      <button class="secondary-action" type="button" onclick="location.reload()" title="Reload the dashboard from the currently loaded snapshot">Refresh data</button>
+      <button class="secondary-action" type="button" onclick="refreshSnapshot(true)" title="Reload the latest snapshot from disk">Refresh</button>
     </div>
   </div>
 
   <nav class="tabs" role="tablist" aria-label="Dashboard sections">
-    <button class="tab active" id="tab-overview" role="tab" aria-selected="true" aria-controls="panel-overview" data-tab="overview" onclick="selectTab('overview')">Overview</button>
+    <button class="tab active" id="tab-overview" role="tab" aria-selected="true" aria-controls="panel-overview" data-tab="overview" onclick="selectTab('overview')">Findings</button>
     <button class="tab" id="tab-architecture" role="tab" aria-selected="false" aria-controls="panel-architecture" data-tab="architecture" onclick="selectTab('architecture')">Architecture</button>
-    <button class="tab" id="tab-snapshots" role="tab" aria-selected="false" aria-controls="panel-snapshots" data-tab="snapshots" onclick="selectTab('snapshots')">Snapshots</button>
-    <button class="tab" id="tab-activity" role="tab" aria-selected="false" aria-controls="panel-activity" data-tab="activity" onclick="selectTab('activity')">Activity</button>
+    <button class="tab" id="tab-snapshots" role="tab" aria-selected="false" aria-controls="panel-snapshots" data-tab="snapshots" onclick="selectTab('snapshots')">Snapshot</button>
+    <button class="tab" id="tab-activity" role="tab" aria-selected="false" aria-controls="panel-activity" data-tab="activity" onclick="selectTab('activity')">Lifetime usage</button>
     <button class="tab" id="tab-quality" role="tab" aria-selected="false" aria-controls="panel-quality" data-tab="quality" onclick="selectTab('quality')">Quality</button>
+    <button class="tab" id="tab-diagnostics" role="tab" aria-selected="false" aria-controls="panel-diagnostics" data-tab="diagnostics" onclick="selectTab('diagnostics')">Diagnostics</button>
   </nav>
 
   <main>
   <section class="tab-panel active" id="panel-overview" role="tabpanel" aria-labelledby="tab-overview">
+  {{if .VersionNotice}}<div class="snapshot-alert"><b>Snapshot update recommended.</b> {{.VersionNotice}} <code>{{.GenerateCommand}}</code></div>{{end}}
   <section class="hero">
     <div class="section-kicker">Repository intelligence</div>
     <h1>{{if .HasGraph}}Your architecture is mapped.{{else}}Ready to map this repository.{{end}}</h1>
-    <p>{{if .HasGraph}}See what Enola found and whether the analysis is complete enough to trust.{{else}}Generate a snapshot from your coding agent to reveal dependencies, hotspots, routes, and structural findings.{{end}}</p>
+    {{if .HasGraph}}<p>Review findings, changes, and the architecture captured for this repository.</p>{{else}}<p>No snapshot exists for this repository yet. Generate one and this page will update automatically.</p>{{if .GenerateCommand}}<p><code>{{.GenerateCommand}}</code></p>{{end}}{{end}}
     <div class="hero-meta">
       {{if .HasReceipt}}{{with .Receipt}}<span class="chip">{{.FactCount}} facts</span><span class="chip">{{.InsightCount}} findings</span>{{end}}{{end}}
       {{if .Insights}}<button type="button" class="primary-action" onclick="openModal('insights-modal')">Review findings</button>{{end}}
     </div>
   </section>
+
+  {{if .Insights}}<div class="data-section">
+    <div class="section-kicker">Current snapshot</div><h2>Findings</h2>
+    <p class="insight-summary">{{.InsightStructural}} structural · {{.InsightCandidate}} candidate{{if ne .InsightCandidate 1}}s{{end}}</p>
+    {{range .Insights}}<details class="insight-group" open>
+      <summary><span class="ig-label">{{.Label}}</span><span class="ig-count">{{.Count}}</span></summary>
+      <div class="table-scroll"><table><thead><tr><th>Finding</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
+      <tbody>{{range .Items}}<tr><td class="title">{{.Title}}</td><td class="num">{{.Confidence}}%</td><td>{{.Evidence}}</td></tr>{{end}}</tbody></table></div>
+    </details>{{end}}
+  </div>{{else if .HasReceipt}}<div class="data-section"><div class="section-kicker">Current snapshot</div><h2>No findings</h2><p class="note">Enola found no structural issues or review candidates in this snapshot.</p></div>{{end}}
 
   <div class="data-section">
     <div class="section-kicker">Development feedback</div><h2>What changed?</h2>
@@ -395,30 +406,8 @@
   </section>
 
   <section class="tab-panel" id="panel-activity" role="tabpanel" aria-labelledby="tab-activity" hidden>
-  <div class="panel-intro"><div class="section-kicker">Usage</div><h2>Activity</h2><p>Every active Enola session, this page's session, and lifetime activity across completed and running sessions.</p></div>
-
-  <div class="snapshot-head">
-    <div><h2>Active sessions</h2><p>{{len .Instances}} Enola server(s) running now. The highlighted row is the session serving this page.</p></div>
-  </div>
-  {{if .Instances}}<div class="table-scroll"><table>
-    <thead><tr><th>Session</th><th>Repositories</th><th>Uptime</th><th class="num">Calls</th><th>Dashboard</th></tr></thead>
-    <tbody>{{range .Instances}}<tr{{if .Self}} class="self-row"{{end}}><td>{{.Binary}} · PID {{.PID}}{{if .Self}} <span class="chip">this page</span>{{end}}</td><td>{{.Repos}}</td><td>{{.Uptime}}</td><td class="num">{{.Calls}}</td><td>{{if .URL}}<a href="{{.URL}}">open{{if .FrontDoor}} · shared{{end}}</a>{{else}}—{{end}}</td></tr>{{end}}</tbody>
-  </table></div>{{else}}<p class="note">No registered Enola server sessions are currently available.</p>{{end}}
-
-  <div class="snapshot-head data-section">
-    <div><h2>This page's session</h2><p>{{if .ReposLoaded}}{{.ReposLoaded}}{{else}}No repository label available{{end}}{{if .Uptime}} · running for {{.Uptime}}{{end}}</p></div>
-    {{if .Running}}<span class="badge on">running</span>{{else}}<span class="badge off">stopped</span>{{end}}
-  </div>
-  <div class="grid">
-    <div class="card"><div class="k">Tool calls this session</div><div class="v">{{.SessionCalls}}</div></div>
-    {{if .StartedAt}}<div class="card"><div class="k">Session started</div><div class="v">{{.StartedAt}}</div></div>{{end}}
-  </div>
-  {{if .SessionCalls}}<div class="data-section"><h2>Tools used this session</h2><div class="table-scroll"><table>
-    <thead><tr><th>Tool</th><th class="num">Calls</th></tr></thead>
-    <tbody>{{range .Tools}}{{if .Session}}<tr><td>{{.Name}}</td><td class="num">{{.Session}}</td></tr>{{end}}{{end}}</tbody>
-  </table></div></div>{{else}}<p class="note">No MCP tool calls have reached this server session yet. Snapshot generation performed by a separate command is recorded in lifetime activity, not here.</p>{{end}}
-
-  <div class="data-section"><div class="snapshot-head"><div><h2>Lifetime activity</h2><p>Aggregated across completed and active sessions · {{.ReposTracked}} repositories{{if .TrackingSince}} · tracked since {{.TrackingSince}}{{end}}. Individual completed-session records are not retained.</p></div></div>
+  <div class="panel-intro"><div class="section-kicker">All-time value</div><h2>Lifetime usage</h2><p>Usage accumulated across repositories and completed Enola sessions. These totals do not affect the snapshot shown elsewhere.</p></div>
+  <div class="data-section"><div class="snapshot-head"><div><h2>Tool activity</h2><p>{{.ReposTracked}} repositories tracked{{if .TrackingSince}} since {{.TrackingSince}}{{end}}.</p></div></div>
   {{if .Tools}}<div class="table-scroll"><table>
     <thead><tr><th>Tool</th><th class="num">Total calls</th></tr></thead>
     <tbody>{{range .Tools}}<tr><td>{{.Name}}</td><td class="num">{{.Total}}</td></tr>{{end}}</tbody>
@@ -429,11 +418,25 @@
     <tbody>{{range .Values}}<tr><td>{{.Label}}</td><td class="num">{{.Calls}}</td><td class="num">{{.TimeSaved}}</td><td class="num">{{.TokensSaved}}</td></tr>{{end}}<tr class="total"><td>{{.ValueTotal.Label}}</td><td class="num">{{.ValueTotal.Calls}}</td><td class="num">{{.ValueTotal.TimeSaved}}</td><td class="num">{{.ValueTotal.TokensSaved}}{{if $.BeyondContext}}+{{end}}</td></tr></tbody>
   </table></div>{{else}}<p class="note">No value recorded yet.</p>{{end}}</div>
 
-  <details class="technical-receipt"><summary>Runtime details</summary>
-  <div class="grid">
-    <div class="card"><div class="k">Server process</div><div class="v">{{if .Running}}PID {{.PID}}{{else}}stopped{{end}}</div></div>
+  </section>
+
+  <section class="tab-panel" id="panel-diagnostics" role="tabpanel" aria-labelledby="tab-diagnostics" hidden>
+  <div class="panel-intro"><div class="section-kicker">Troubleshooting</div><h2>Diagnostics</h2><p>Processes, paths, ports, and the exact data source for this page.</p></div>
+  <div class="snapshot-head"><div><h2>Active sessions</h2><p>{{len .Instances}} Enola process(es) running now. The highlighted row serves this page.</p></div></div>
+  {{if .Instances}}<div class="table-scroll"><table>
+    <thead><tr><th>Session</th><th>Repositories</th><th>Uptime</th><th class="num">Calls</th><th>Dashboard</th></tr></thead>
+    <tbody>{{range .Instances}}<tr{{if .Self}} class="self-row"{{end}}><td>{{.Binary}} · PID {{.PID}}{{if .Self}} <span class="chip">this page</span>{{end}}</td><td>{{.Repos}}</td><td>{{.Uptime}}</td><td class="num">{{.Calls}}</td><td>{{if .URL}}<a href="{{.URL}}">open{{if .FrontDoor}} · shared{{end}}</a>{{else}}—{{end}}</td></tr>{{end}}</tbody>
+  </table></div>{{else}}<p class="note">No registered Enola processes are available.</p>{{end}}
+  <div class="grid data-section">
+    <div class="card"><div class="k">This process</div><div class="v">{{if .Running}}PID {{.PID}}{{else}}stopped{{end}}</div></div>
     {{if .Binary}}<div class="card"><div class="k">Binary</div><div class="v">{{.Binary}}</div></div>{{end}}
     <div class="card"><div class="k">Dashboard port</div><div class="v">{{.Port}}</div></div>
+    <div class="card"><div class="k">Calls this session</div><div class="v">{{.SessionCalls}}</div></div>
+  </div>
+  <details class="technical-receipt"><summary>Paths and runtime details</summary>
+  <div class="grid">
+    {{if .SnapshotPath}}<div class="card path-card"><div class="k">Snapshot directory</div><div class="v">{{.SnapshotPath}}</div></div>{{end}}
+    {{if .GenerateCommand}}<div class="card path-card"><div class="k">Regenerate command</div><div class="v">{{.GenerateCommand}}</div></div>{{end}}
   </div>
   {{if .WorkDir}}<div class="card path-card" style="margin-top:.75rem"><div class="k">Working directory</div><div class="v">{{.WorkDir}}</div></div>{{end}}
   {{if .ConfigPath}}<div class="card path-card" style="margin-top:.75rem"><div class="k">Config path</div><div class="v">{{.ConfigPath}}</div></div>{{end}}
@@ -693,6 +696,14 @@
 {{block "extra-modals" $}}{{end}}
 
 <script>
+  function refreshSnapshot(manual) {
+    fetch('/api/refresh', {cache: 'no-store'})
+      .then(function(response) { return response.json(); })
+      .then(function(result) {
+        if (result.changed || manual) location.reload();
+      })
+      .catch(function() { if (manual) location.reload(); });
+  }
   function selectTab(name, updateHash) {
     var panel = document.getElementById('panel-' + name);
     var tab = document.getElementById('tab-' + name);
@@ -955,6 +966,7 @@
   window.addEventListener('hashchange', initialTab);
   initialTab();
   restoreFindingInspector();
+  window.setInterval(function() { refreshSnapshot(false); }, 5000);
 </script>
 </body>
 </html>

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -117,8 +117,8 @@
     .graph-canvas { flex: 1; min-height: 420px; overflow: auto; padding: .5rem; background-image: radial-gradient(rgba(139,165,255,.13) .7px, transparent .7px); background-size: 18px 18px; }
     .module-graph { display: block; width: auto; min-width: 100%; height: auto; }
     .graph-canvas.fit .module-graph { width: 100%; min-width: 100%; }
-    .module-edge { stroke: #536a9f; stroke-width: 1.2; opacity: .34; transition: opacity .18s, stroke .18s; pointer-events: none; }
-    .module-edge-hit { stroke: transparent; stroke-width: 12; cursor: pointer; }
+    .module-edge { fill: none; stroke: #536a9f; stroke-width: 1.2; opacity: .34; transition: opacity .18s, stroke .18s; pointer-events: none; }
+    .module-edge-hit { fill: none; stroke: transparent; stroke-width: 12; cursor: pointer; }
     .module-edge-hit:hover + .module-edge { opacity: 1; stroke: #9b75e8; stroke-width: 2; }
     .module-node { cursor: pointer; transition: opacity .18s; }
     .module-node rect { fill: #0d193b; stroke: #33456f; rx: 7; transition: fill .18s, stroke .18s; }
@@ -310,7 +310,7 @@
       <div class="graph-canvas">
         <svg class="module-graph" width="{{$graph.Width}}" height="{{$graph.Height}}" viewBox="0 0 {{$graph.Width}} {{$graph.Height}}" role="img" aria-label="Module dependency graph">
           <defs><marker id="module-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#536a9f"/></marker></defs>
-          {{range $graph.Edges}}<line class="module-edge-hit" data-source="{{.Source}}" data-target="{{.Target}}" data-source-name="{{.SourceName}}" data-target-name="{{.TargetName}}" data-source-file="{{.SourceFile}}" data-target-file="{{.TargetFile}}" data-kind="{{.Kind}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" onclick="selectDependency(this)"/><line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}
+          {{range $graph.Edges}}{{if .Curve}}<path class="module-edge-hit" data-source="{{.Source}}" data-target="{{.Target}}" data-source-name="{{.SourceName}}" data-target-name="{{.TargetName}}" data-source-file="{{.SourceFile}}" data-target-file="{{.TargetFile}}" data-kind="{{.Kind}}" d="M{{.X1}},{{.Y1}} Q{{.CX}},{{.CY}} {{.X2}},{{.Y2}}" onclick="selectDependency(this)"/><path class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" d="M{{.X1}},{{.Y1}} Q{{.CX}},{{.CY}} {{.X2}},{{.Y2}}" marker-end="url(#module-arrow)"/>{{else}}<line class="module-edge-hit" data-source="{{.Source}}" data-target="{{.Target}}" data-source-name="{{.SourceName}}" data-target-name="{{.TargetName}}" data-source-file="{{.SourceFile}}" data-target-file="{{.TargetFile}}" data-kind="{{.Kind}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" onclick="selectDependency(this)"/><line class="module-edge" data-source="{{.Source}}" data-target="{{.Target}}" x1="{{.X1}}" y1="{{.Y1}}" x2="{{.X2}}" y2="{{.Y2}}" marker-end="url(#module-arrow)"/>{{end}}{{end}}
           {{range $graph.Nodes}}<g class="module-node" data-id="{{.ID}}" data-role="{{.Role}}" data-name="{{.Name}}" data-file="{{.File}}" data-in="{{.FanIn}}" data-out="{{.FanOut}}" onclick="selectModule(this)"><title>{{.Name}}</title><rect x="{{.X}}" y="{{.Y}}" width="154" height="36"/><text x="{{.X}}" y="{{.Y}}" dx="9" dy="22">{{.Display}}</text></g>{{end}}
         </svg>
       </div>

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -246,7 +246,7 @@
 
   {{if .Insights}}<div class="data-section">
     <div class="section-kicker">Current snapshot</div><h2>Findings</h2>
-    <p class="insight-summary">{{.InsightStructural}} structural · {{.InsightCandidate}} candidate{{if ne .InsightCandidate 1}}s{{end}}</p>
+    <p class="insight-summary">{{.InsightStructural}} <span title="Confidence 100% — a proven, code-verified finding">structural</span> · {{.InsightCandidate}} <span title="Confidence below 100% — a heuristic suggestion worth reviewing">candidate{{if ne .InsightCandidate 1}}s{{end}}</span></p>
     {{range $i, $g := .Insights}}<details class="insight-group"{{if or (eq $i 0) $g.HasStructural}} open{{end}}>
       <summary><span class="ig-label">{{$g.Label}}</span><span class="ig-count">{{$g.Count}}</span></summary>
       <div class="table-scroll"><table><thead><tr><th>Finding</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
@@ -472,7 +472,7 @@
   </div>
   <p class="accounting-note ok">Accounts for every walked file. Ignored and non-source files aren't parse failures.</p>
 
-  {{if $.Quality.Potential}}<div class="data-section"><h2>Potential architecture blind spots</h2><p class="note">These file types can carry behavior or architecture, but are outside the current graph. Review whether they matter for this repository.</p><div class="table-scroll"><table>
+  {{if $.Quality.Potential}}<div class="data-section"><h2 title="File types that could carry architecture but aren't parsed">Potential architecture blind spots</h2><p class="note">These file types can carry behavior or architecture, but are outside the current graph. Review whether they matter for this repository.</p><div class="table-scroll"><table>
     <thead><tr><th>File kind</th><th class="num">Files</th><th>Why review it</th></tr></thead>
     <tbody>{{range $.Quality.Potential}}<tr><td>{{.Kind}}</td><td class="num">{{.Count}}</td><td class="title">{{.Reason}}</td></tr>{{end}}</tbody>
   </table></div></div>{{end}}
@@ -588,7 +588,7 @@
       <h3>Insights</h3>
       <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
     </div>
-    <div class="insight-summary">{{.InsightStructural}} structural &middot; {{.InsightCandidate}} candidate{{if ne .InsightCandidate 1}}s{{end}} &mdash; grouped by explainer, click a row to expand</div>
+    <div class="insight-summary">{{.InsightStructural}} <span title="Confidence 100% — a proven, code-verified finding">structural</span> &middot; {{.InsightCandidate}} <span title="Confidence below 100% — a heuristic suggestion worth reviewing">candidate{{if ne .InsightCandidate 1}}s{{end}}</span> &mdash; grouped by explainer, click a row to expand</div>
     <div class="insight-filter">
       <label for="insight-band">Confidence</label>
       <select id="insight-band" onchange="filterInsights(this.value)">
@@ -610,7 +610,7 @@
       <div class="table-scroll"><table>
         <thead><tr><th>Title</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
         <tbody>
-          {{range .Items}}<tr data-conf="{{.Confidence}}"><td class="title">{{.Title}}{{if .Action}}<div class="finding-action">→ {{.Action}}</div>{{end}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip">structural</span>{{else if .Informational}}<span class="structural-chip">context</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
+          {{range .Items}}<tr data-conf="{{.Confidence}}"><td class="title">{{.Title}}{{if .Action}}<div class="finding-action">→ {{.Action}}</div>{{end}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip" title="Confidence 100% — a proven, code-verified finding">structural</span>{{else if .Informational}}<span class="structural-chip" title="Describes the architecture — not a problem to fix">context</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
         </tbody>
       </table></div>
     </details>

--- a/pkg/dashboard/page.html.tmpl
+++ b/pkg/dashboard/page.html.tmpl
@@ -217,10 +217,11 @@
   <div class="topbar">
     <div class="brand"><h1>{{.Title}}<span class="brand-dot">.</span>{{if .HasReceipt}} <span class="note">· {{.Snapshot.RepoName}}{{if .Snapshot.Age}} · updated {{.Snapshot.Age}}{{end}}</span>{{end}}</h1></div>
     <div class="top-actions">
-      <span class="note" id="refresh-status" title="Auto-checks for a new snapshot every 5s"></span>
-      <button class="secondary-action" type="button" onclick="refreshSnapshot(true)" title="Reload the latest snapshot from disk">Refresh</button>
+      <button class="secondary-action" type="button" onclick="location.reload()" title="Reload the latest snapshot from disk">Refresh</button>
     </div>
   </div>
+
+  {{if .RefreshError}}<div class="snapshot-alert" role="alert">{{.RefreshError}}</div>{{end}}
 
   <nav class="tabs" role="tablist" aria-label="Dashboard sections">
     <button class="tab active" id="tab-overview" role="tab" aria-selected="true" aria-controls="panel-overview" data-tab="overview" onclick="selectTab('overview')">Findings</button>
@@ -237,7 +238,7 @@
   <section class="hero">
     <div class="section-kicker">Repository intelligence</div>
     <h1>{{if .HasGraph}}Your architecture is mapped.{{else}}Ready to map this repository.{{end}}</h1>
-    {{if .HasGraph}}<p>Review findings, changes, and the architecture captured for this repository.</p>{{else}}<p>No snapshot exists for this repository yet. Generate one and this page will update automatically.</p>{{if .GenerateCommand}}<p><code>{{.GenerateCommand}}</code></p>{{end}}{{end}}
+    {{if .HasGraph}}<p>Review findings, changes, and the architecture captured for this repository.</p>{{else}}<p>No snapshot exists for this repository yet. Generate one, then use Refresh to load it here.</p>{{if .GenerateCommand}}<p><code>{{.GenerateCommand}}</code></p>{{end}}{{end}}
     <div class="hero-meta">
       {{if .HasReceipt}}{{with .Receipt}}<span class="chip">{{.FactCount}} facts</span><span class="chip">{{.InsightCount}} findings</span>{{end}}{{end}}
       {{if .Insights}}<button type="button" class="primary-action" onclick="openModal('insights-modal')">Review findings</button>{{end}}
@@ -588,7 +589,7 @@
       <h3>Insights</h3>
       <button type="button" class="modal-close" aria-label="Close" onclick="closeModal(this)">&times;</button>
     </div>
-    <div class="insight-summary">{{.InsightStructural}} <span title="Confidence 100% — a proven, code-verified finding">structural</span> &middot; {{.InsightCandidate}} <span title="Confidence below 100% — a heuristic suggestion worth reviewing">candidate{{if ne .InsightCandidate 1}}s{{end}}</span> &mdash; grouped by explainer, click a row to expand</div>
+    <div class="insight-summary">{{.InsightStructural}} <span title="Confidence 100% — a proven, code-verified finding">structural</span> &middot; {{.InsightCandidate}} <span title="Confidence below 100% — a heuristic suggestion worth reviewing">candidate{{if ne .InsightCandidate 1}}s{{end}}</span>{{if .InsightInformational}} &middot; {{.InsightInformational}} context{{end}} &mdash; grouped by explainer, click a row to expand</div>
     <div class="insight-filter">
       <label for="insight-band">Confidence</label>
       <select id="insight-band" onchange="filterInsights(this.value)">
@@ -597,6 +598,7 @@
         <option value="high">High (85&ndash;99%)</option>
         <option value="medium">Medium (65&ndash;84%)</option>
         <option value="low">Low (&lt;65%)</option>
+        <option value="informational">Context</option>
       </select>
       <span class="note"><span id="insight-shown">{{.InsightTotal}}</span> shown</span>
     </div>
@@ -610,7 +612,7 @@
       <div class="table-scroll"><table>
         <thead><tr><th>Title</th><th class="num">Confidence</th><th>Evidence</th></tr></thead>
         <tbody>
-          {{range .Items}}<tr data-conf="{{.Confidence}}"><td class="title">{{.Title}}{{if .Action}}<div class="finding-action">→ {{.Action}}</div>{{end}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip" title="Confidence 100% — a proven, code-verified finding">structural</span>{{else if .Informational}}<span class="structural-chip" title="Describes the architecture — not a problem to fix">context</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
+          {{range .Items}}<tr data-band="{{.Band}}"><td class="title">{{.Title}}{{if .Action}}<div class="finding-action">→ {{.Action}}</div>{{end}}</td><td class="num">{{.Confidence}}%{{if .Structural}}<span class="structural-chip" title="Confidence 100% — a proven, code-verified finding">structural</span>{{else if .Informational}}<span class="structural-chip" title="Describes the architecture — not a problem to fix">context</span>{{end}}</td><td>{{.Evidence}}</td></tr>{{end}}
         </tbody>
       </table></div>
     </details>
@@ -704,22 +706,6 @@
 {{block "extra-modals" $}}{{end}}
 
 <script>
-  function setRefreshStatus(text) {
-    var status = document.getElementById('refresh-status');
-    if (status) status.textContent = text;
-  }
-  function refreshSnapshot(manual) {
-    fetch('/api/refresh', {cache: 'no-store'})
-      .then(function(response) { return response.json(); })
-      .then(function(result) {
-        if (result.changed || manual) { location.reload(); return; }
-        setRefreshStatus('Checked ' + new Date().toLocaleTimeString());
-      })
-      .catch(function() {
-        if (manual) { location.reload(); return; }
-        setRefreshStatus('Check failed');
-      });
-  }
   function selectTab(name, updateHash) {
     var panel = document.getElementById('panel-' + name);
     var tab = document.getElementById('tab-' + name);
@@ -753,15 +739,8 @@
     }
   }
 
-  // insightBandMatch reports whether a row's confidence percent falls in the band.
-  function insightBandMatch(band, c) {
-    switch (band) {
-      case 'structural': return c >= 100;
-      case 'high':       return c >= 85 && c < 100;
-      case 'medium':     return c >= 65 && c < 85;
-      case 'low':        return c < 65;
-      default:           return true; // all
-    }
+  function insightBandMatch(selected, rowBand) {
+    return selected === 'all' || selected === rowBand;
   }
   // filterInsights shows only rows in the chosen confidence band, then rescales each
   // explainer group's count and bar to the visible rows and hides emptied groups.
@@ -774,7 +753,7 @@
     groups.forEach(function (g) {
       var n = 0;
       g.querySelectorAll('tbody tr').forEach(function (r) {
-        var show = insightBandMatch(band, parseInt(r.getAttribute('data-conf'), 10));
+        var show = insightBandMatch(band, r.getAttribute('data-band'));
         r.style.display = show ? '' : 'none';
         if (show) n++;
       });
@@ -819,7 +798,19 @@
     graphNodes().forEach(function(n) { n.classList.remove('active', 'dim'); });
     graphEdges().forEach(function(e) { e.classList.remove('active', 'dim'); });
   }
+  function resetInspectorContent() {
+    ['module-detail-name', 'module-detail-file', 'module-detail-in', 'module-detail-out'].forEach(function(id) {
+      var field = document.getElementById(id);
+      if (field) field.textContent = '';
+    });
+    var members = document.getElementById('module-detail-members');
+    if (members) {
+      members.innerHTML = '';
+      members.hidden = true;
+    }
+  }
   function openInspector() {
+    resetInspectorContent();
     var empty = document.getElementById('inspector-empty');
     var detail = document.getElementById('module-detail');
     var clearBtn = document.getElementById('inspector-clear');
@@ -830,6 +821,7 @@
   }
   function clearInspector() {
     clearGraphFocus();
+    resetInspectorContent();
     document.querySelectorAll('.finding-button').forEach(function(b) { b.classList.remove('active'); });
     var detail = document.getElementById('module-detail');
     var empty = document.getElementById('inspector-empty');
@@ -1016,8 +1008,6 @@
   window.addEventListener('hashchange', initialTab);
   initialTab();
   restoreFindingInspector();
-  setRefreshStatus('Checked ' + new Date().toLocaleTimeString());
-  window.setInterval(function() { refreshSnapshot(false); }, 5000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
The dashboard now opens even when no snapshot exists, showing the exact generation command. Users can load newer snapshots with Refresh, keeping the graph stable while inspecting it.
- Keep snapshot loading scoped to the selected repository unless an explicit cluster configuration is supplied.
- Read graph data, snapshot metadata, and receipts from one consistent publication; preserve the page when refresh fails.
- "Prioritize findings", separate lifetime usage from diagnostics, and clarify confidence labels and suggested actions.
- Graph: Condense dependency cycles into clusters, improve edge rendering, and add a clear-selection control.
- Fix browser launching on macOS and update dashboard and CLI documentation.