### PR TITLE
Python: bind calls to symbols defined in a package __init__.py

### DIFF
--- a/internal/extractors/pythonextractor/resolve.go
+++ b/internal/extractors/pythonextractor/resolve.go
@@ -295,6 +295,37 @@ func buildReexportIndex(allFacts []facts.Fact, pkgDirs map[string]bool) reexport
 		delete(byDir[dir], n)
 	}
 
+	// A package's __init__.py also DEFINES symbols, not only re-exports them, and
+	// those were invisible here. `from pkg import helper` emits the call target
+	// "pkg.helper", whose module prefix "pkg" names a directory rather than a
+	// module, so absolute resolution fails exactly as it does for a re-export. The
+	// difference is that the symbol lives in this file, so the defining module is
+	// the __init__ module itself and the fact is already named
+	// "pkg/__init__.helper".
+	//
+	// Registered after the re-export pass and unconditionally: a name a package
+	// both defines and imports is shadowed by the local definition at runtime, so
+	// the local one is the correct binding rather than an ambiguity to drop.
+	for i := range allFacts {
+		f := &allFacts[i]
+		if f.Kind != facts.KindSymbol || !isInitFile(f.File) {
+			continue
+		}
+		module := strings.TrimSuffix(f.File, ".py")
+		rest, ok := strings.CutPrefix(f.Name, module+".")
+		if !ok || rest == "" {
+			continue
+		}
+		// The call site looks up the FIRST dotted segment, so a method binds
+		// through the class name that owns it.
+		name := firstSeg(rest)
+		dir := fileDir(f.File)
+		if byDir[dir] == nil {
+			byDir[dir] = map[string]string{}
+		}
+		byDir[dir][name] = module
+	}
+
 	dirs := make(map[string]bool, len(byDir))
 	for d := range byDir {
 		if len(byDir[d]) > 0 {

--- a/internal/extractors/pythonextractor/resolve_test.go
+++ b/internal/extractors/pythonextractor/resolve_test.go
@@ -840,6 +840,54 @@ func TestResolveImports_ExternalStillExternal(t *testing.T) {
 // module path, so the composed "<module>.<symbol>" was already canonical and the
 // dotted resolver could never read it — the edge was dropped long before
 // same-package absolute imports resolved to slash paths too.
+// TestExtract_PythonBindsCallToSymbolDefinedInInit covers a symbol DEFINED in a
+// package's __init__.py rather than re-exported by it. `from pkg import helper`
+// emits the call target "pkg.helper", whose module prefix names a directory and
+// so resolves to no module; the re-export index handled the case where __init__
+// imports the name from elsewhere, but not the case where __init__ defines it,
+// and the edge was left dangling. Measured on Airflow, every sampled function
+// defined in an __init__.py returned no callers at all.
+func TestExtract_PythonBindsCallToSymbolDefinedInInit(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"pkg/__init__.py": "def helper_in_init():\n    return 1\n",
+		"pkg/mod.py":      "def helper_in_module():\n    return 2\n",
+		"caller.py": "from pkg import helper_in_init\n" +
+			"from pkg.mod import helper_in_module\n\n" +
+			"def use():\n    return helper_in_init() + helper_in_module()\n",
+	}
+	var rel []string
+	for name, content := range files {
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rel = append(rel, name)
+	}
+	all, err := New().Extract(context.Background(), dir, rel)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	for _, f := range all {
+		if f.Kind != facts.KindSymbol || f.Name != "caller.use" {
+			continue
+		}
+		// The sibling module is the control: it always bound correctly, so a
+		// failure on it means something other than this fix broke.
+		if !hasRel(f, facts.RelCalls, "pkg/mod.helper_in_module") {
+			t.Fatalf("control edge missing; call targets = %v", f.Relations)
+		}
+		if !hasRel(f, facts.RelCalls, "pkg/__init__.helper_in_init") {
+			t.Fatalf("call to __init__-defined symbol unresolved; targets = %v", f.Relations)
+		}
+		return
+	}
+	t.Fatal("missing caller.use symbol")
+}
+
 func TestExtract_PythonResolvesInheritanceViaRelativeImport(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]string{


### PR DESCRIPTION
The re-export index mapped a package directory to the names its __init__.py imports from elsewhere, but not the names it defines itself. Both produce the same dangling edge: `from pkg import helper` emits the target "pkg.helper", whose prefix names a directory rather than a module, so absolute resolution fails and the call binds to nothing.

Local definitions are registered after the re-export pass and unconditionally. A name a package both defines and imports is shadowed by the local definition at runtime, so that is the correct binding rather than an ambiguity to drop.