### PR TITLE
Install under dash and on Windows, count upgrades apart from installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,10 @@ jobs:
           # ignored by both and nothing lands in ~/.local/bin.
           tar czf "${BINARY}.tar.gz" "${BINARY}${EXT}" LICENSE NOTICE
           sha256sum "${BINARY}.tar.gz" > "${BINARY}.sha256"
+          # The same digest under a name only `enola upgrade` fetches. GitHub's
+          # per-asset download counter is the only usage signal a release has,
+          # and one shared checksum would count upgrades as fresh installs.
+          cp "${BINARY}.sha256" "${BINARY}.upgrade.sha256"
 
       # Packages the pip-stamped binary from the build step, not the one in the
       # tarball. Same source, same compiler, same container, one linker flag
@@ -237,6 +241,7 @@ jobs:
           files: |
             enola-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
             enola-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.sha256
+            enola-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.upgrade.sha256
 
   # Publishes the draft only if all platform assets are present. If a build leg
   # fails — or never gets scheduled, e.g. because its runner label was retired —
@@ -267,7 +272,9 @@ jobs:
 
           missing=0
           for platform in $PLATFORMS; do
-            for ext in tar.gz sha256; do
+            # upgrade.sha256 is what `enola upgrade` verifies against, so a
+            # release without it would be one no installed build can upgrade to.
+            for ext in tar.gz sha256 upgrade.sha256; do
               name="enola-${VERSION}-${platform}.${ext}"
               if ! grep -qxF "$name" <<<"$ASSETS"; then
                 echo "::error::missing release asset: $name"
@@ -324,7 +331,9 @@ jobs:
   # be one users can install and then cannot upgrade away from.
   pypi-publish:
     needs: publish
-    if: github.event_name == 'push'
+    # TEMPORARILY DISABLED while the install and upgrade changes are tested on a
+    # GitHub release. Re-enable by dropping `false &&`.
+    if: false && github.event_name == 'push'
     runs-on: ubuntu-latest
 
     # Named by the Trusted Publisher configuration on PyPI. Publishing uses no

--- a/docs/INTEGRATING.md
+++ b/docs/INTEGRATING.md
@@ -32,6 +32,10 @@ https://github.com/enola-labs/enola/releases/download/v{version}/enola-{version}
 https://github.com/enola-labs/enola/releases/download/v{version}/enola-{version}-{os}-{arch}.sha256
 ```
 
+Each release also carries `enola-{version}-{os}-{arch}.upgrade.sha256`, the same
+digest under a name only `enola upgrade` fetches, so upgrades can be counted
+apart from installs. Integrations should verify against `.sha256`.
+
 The release workflow currently publishes:
 
 | OS | Architectures |

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,21 @@
-#!/usr/bin/env bash
-# install.sh — Install the latest enola release.
+#!/bin/sh
+# install.sh: install the latest enola release.
 # Usage: curl -fsSL https://raw.githubusercontent.com/enola-labs/enola/main/install.sh | sh
+#
+# POSIX sh on purpose, with no `set -o pipefail`. A piped script never honours its
+# own shebang: the `sh` on the right of the pipe runs it, and on Debian and Ubuntu
+# that is dash, which rejects pipefail before the first line of real work.
 
-set -euo pipefail
+set -eu
 
 # --- Detect OS ---
 OS="$(uname -s)"
 case "$OS" in
   Linux)   OS=linux ;;
   Darwin)  OS=darwin ;;
+  # Git Bash, MSYS2 and Cygwin report a decorated name. WSL reports Linux and
+  # gets the linux build, which is the right one for it.
+  MINGW*|MSYS*|CYGWIN*) OS=windows ;;
   *)       echo "Unsupported OS: $OS" >&2; exit 1 ;;
 esac
 
@@ -58,16 +65,26 @@ tar xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
 
 # --- Install ---
 BIN_NAME="${BASE}"
+TARGET="enola"
 if [ "$OS" = "windows" ]; then
   BIN_NAME="${BIN_NAME}.exe"
+  TARGET="enola.exe"
 fi
 
 INSTALL_DIR="${ENOLA_INSTALL_DIR:-$HOME/.local/bin}"
 mkdir -p "$INSTALL_DIR"
 
-install -m 755 "$TMPDIR/$BIN_NAME" "$INSTALL_DIR/enola"
+# Windows refuses to overwrite a running executable, and a re-run to upgrade
+# usually finds the MCP server holding this one. Renaming it is allowed, so move
+# it aside first, as `enola upgrade` does.
+if [ "$OS" = "windows" ] && [ -e "$INSTALL_DIR/$TARGET" ]; then
+  rm -f "$INSTALL_DIR/$TARGET.old" 2>/dev/null || true
+  mv "$INSTALL_DIR/$TARGET" "$INSTALL_DIR/$TARGET.old"
+fi
 
-echo "==> enola v${VERSION} installed to $INSTALL_DIR/enola"
+install -m 755 "$TMPDIR/$BIN_NAME" "$INSTALL_DIR/$TARGET"
+
+echo "==> enola v${VERSION} installed to $INSTALL_DIR/$TARGET"
 echo ""
 echo "If \$HOME/.local/bin is not in your PATH, add it:"
 echo "  export PATH=\"$HOME/.local/bin:\$PATH\""

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -185,6 +185,12 @@ type assets struct {
 
 // assetNames derives the release artifact names for a version and platform,
 // matching the naming produced by .github/workflows/release.yml.
+//
+// The checksum is deliberately not the `.sha256` that install.sh fetches, though
+// it holds the same digest. GitHub counts downloads per asset and records nothing
+// else about a request, so two clients fetching the same file cannot be told
+// apart. A checksum of its own is what lets the release counters separate
+// upgrades from fresh scripted installs.
 func assetNames(version, goos, goarch string) (assets, error) {
 	if !supportedPlatforms[goos+"/"+goarch] {
 		return assets{}, fmt.Errorf("no prebuilt release for %s/%s; install manually from https://github.com/%s/releases", goos, goarch, repoSlug)
@@ -196,7 +202,7 @@ func assetNames(version, goos, goarch string) (assets, error) {
 	}
 	return assets{
 		tarball:     base + ".tar.gz",
-		checksum:    base + ".sha256",
+		checksum:    base + ".upgrade.sha256",
 		innerBinary: inner,
 	}, nil
 }

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -55,7 +55,9 @@ func TestAssetNames(t *testing.T) {
 		if got.tarball != c.wantTarball {
 			t.Errorf("%s/%s tarball = %q, want %q", c.goos, c.goarch, got.tarball, c.wantTarball)
 		}
-		if got.checksum != "enola-1.2.3-"+c.goos+"-"+c.goarch+".sha256" {
+		// Not install.sh's `.sha256`: a shared asset would make upgrades
+		// indistinguishable from installs in the download counters.
+		if got.checksum != "enola-1.2.3-"+c.goos+"-"+c.goarch+".upgrade.sha256" {
 			t.Errorf("%s/%s checksum = %q", c.goos, c.goarch, got.checksum)
 		}
 		if got.innerBinary != c.wantInner {


### PR DESCRIPTION
install.sh is now POSIX sh, so `curl | sh` no longer dies on dash rejecting pipefail, and Git Bash, MSYS2 and Cygwin install enola.exe instead of being refused. enola upgrade verifies against a new .upgrade.sha256, the same digest as .sha256 under a name only the updater fetches: GitHub's per-asset download count is the only usage signal a release has, and a shared checksum made upgrades indistinguishable from fresh installs. PyPI publishing is paused until this is tested on a release.